### PR TITLE
Title only returns first element value

### DIFF
--- a/packages/metascraper-title/index.js
+++ b/packages/metascraper-title/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { titleize } = require('@metascraper/helpers')
+const { getValue, titleize } = require('@metascraper/helpers')
 const { isString } = require('lodash')
 
 const wrap = rule => ({ htmlDom }) => {
@@ -20,6 +20,6 @@ module.exports = () => ({
     ),
     wrap($ => $('h1[class*="title"] a').text()),
     wrap($ => $('h1[class*="title"]').text()),
-    wrap($ => $('title').text())
+    wrap($ => $('title').getValue())
   ]
 })

--- a/packages/metascraper-title/index.js
+++ b/packages/metascraper-title/index.js
@@ -20,6 +20,6 @@ module.exports = () => ({
     ),
     wrap($ => $('h1[class*="title"] a').text()),
     wrap($ => $('h1[class*="title"]').text()),
-    wrap($ => $('title').getValue())
+    wrap($ => getValue($, $('title')))
   ]
 })


### PR DESCRIPTION
Some sites have multiple `<title>` elements. (Not sure why)

ie. https://twitter.com => `title: "Twitter. It’s what’s happening.bird"`
(this url also also breaks the [Microlink.io](https://microlink.io) UI)

This fix returns the primary (first) `title` element on the page.