### PR TITLE
Add pseudo dom selectors support

### DIFF
--- a/packages/metascraper/package.json
+++ b/packages/metascraper/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@metascraper/helpers": "^3.11.5",
     "cheerio": "~1.0.0-rc.2",
+    "cheerio-advanced-selectors": "~2.0.1",
     "cosmiconfig": "~5.0.2",
     "lodash": "~4.17.10",
     "metascraper-author": "^3.11.5",

--- a/packages/metascraper/src/load-html.js
+++ b/packages/metascraper/src/load-html.js
@@ -1,7 +1,7 @@
 'use strict'
 const { forEach, flow, isEmpty, toLower } = require('lodash')
 const sanitizeHtml = require('sanitize-html')
-const cheerio = require('cheerio')
+const cheerio = require('cheerio-advanced-selectors').wrap(require('cheerio'))
 
 const normalizeAttributes = props => (tagName, attribs) => {
   forEach(props, propName => {


### PR DESCRIPTION
cheerio by default doesn't support pseudo selector.

This PR enable it!

Ideally, I want to add a more complete package for add this functionality, but it needs to be adapted in order to don't break the current interface: 

https://github.com/mrcoles/pseudo-cheerio/issues/3