### PR TITLE
Add greyscale option to Clearbit logo API

### DIFF
--- a/packages/metascraper-clearbit-logo/README.md
+++ b/packages/metascraper-clearbit-logo/README.md
@@ -31,6 +31,13 @@ Default: `png`
 
 Image format, either "png" or "jpg".
 
+##### greyscale
+
+Type: `boolean`<br>
+Default: `false`
+
+Desaturates image if set to `true`.
+
 ## License
 
 **metascraper-clearbit-logo** © [microlink.io](https://microlink.io), Released under the [MIT](https://github.com/microlinkhq/metascraper-clearbit-logo/blob/master/LICENSE.md) License.<br>

--- a/packages/metascraper-clearbit-logo/index.js
+++ b/packages/metascraper-clearbit-logo/index.js
@@ -5,18 +5,21 @@ const got = require('got')
 
 const DEFAULTS = {
   size: '128',
-  format: 'png'
+  format: 'png',
+  greyscale: false
 }
 
 const ENDPOINT = 'https://logo.clearbit.com'
 
 module.exports = opts => {
   opts = Object.assign({}, DEFAULTS, opts)
-  const { size, format } = opts
+  const { size, format, greyscale } = opts
 
   const clearbitLogo = async ({ url }) => {
     const { hostname } = new URL(url)
-    const logoUrl = `${ENDPOINT}/${hostname}?size=${size}&format=${format}`
+    const logoUrl = `${ENDPOINT}/${hostname}?size=${size}&format=${format}${
+      greyscale ? '&greyscale=true' : ''
+    }`
 
     try {
       await got.head(logoUrl)


### PR DESCRIPTION
Clearbit offers a `greyscale` option as seen [here](https://clearbit.com/docs?javascript#name-to-domain-api-http-response-http-get-params). Would be cool to have it in metascraper 🎬!