### PR TITLE
Add escape parameter to escape html data by default

### DIFF
--- a/packages/metascraper/package.json
+++ b/packages/metascraper/package.json
@@ -56,7 +56,8 @@
     "cheerio-advanced-selectors": "~2.0.1",
     "lodash": "~4.17.11",
     "p-reduce": "~1.0.0",
-    "whoops": "~4.0.1"
+    "whoops": "~4.0.1",
+    "xss": "~1.0.3"
   },
   "devDependencies": {
     "clear-module": "latest",

--- a/packages/metascraper/src/get-data.js
+++ b/packages/metascraper/src/get-data.js
@@ -2,6 +2,7 @@
 
 const { isEmpty } = require('lodash')
 const pReduce = require('p-reduce')
+const xss = require('xss')
 
 const getValue = async ({ htmlDom, url, conditions, meta }) => {
   const size = conditions.length
@@ -15,12 +16,12 @@ const getValue = async ({ htmlDom, url, conditions, meta }) => {
   return value
 }
 
-const getData = ({ rules, htmlDom, url }) =>
+const getData = ({ rules, htmlDom, url, escape }) =>
   pReduce(
     rules,
     async (acc, [propName, conditions]) => {
       const value = await getValue({ htmlDom, url, conditions, meta: acc })
-      acc[propName] = !isEmpty(value) ? value : null
+      acc[propName] = !isEmpty(value) ? (escape ? xss(value) : value) : null
       return acc
     },
     {}

--- a/packages/metascraper/src/index.js
+++ b/packages/metascraper/src/index.js
@@ -12,7 +12,7 @@ const MetascraperError = whoops('MetascraperError')
 
 module.exports = rules => {
   const loadedRules = loadRules(rules)
-  return async ({ url, html, rules: inlineRules, escape } = {}) => {
+  return async ({ url, html, rules: inlineRules, escape = true } = {}) => {
     if (!isUrl(url)) {
       throw new MetascraperError({
         message: 'Need to provide a valid URL.',

--- a/packages/metascraper/src/index.js
+++ b/packages/metascraper/src/index.js
@@ -12,18 +12,18 @@ const MetascraperError = whoops('MetascraperError')
 
 module.exports = rules => {
   const loadedRules = loadRules(rules)
-  return async ({ url, html, rules: inlineRules } = {}) => {
+  return async ({ url, html, rules: inlineRules, escape } = {}) => {
     if (!isUrl(url)) {
       throw new MetascraperError({
         message: 'Need to provide a valid URL.',
         code: 'INVALID_URL'
       })
     }
-
     return getData({
       url,
       htmlDom: loadHTML(html),
-      rules: mergeRules(inlineRules, loadedRules)
+      rules: mergeRules(inlineRules, loadedRules),
+      escape: ((typeof (escape) === 'undefined') || escape)
     })
   }
 }

--- a/packages/metascraper/test/unit/xss/files/issue-96.html
+++ b/packages/metascraper/test/unit/xss/files/issue-96.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html xmlns:og="http://ogp.me/ns#" lang="en">
+
+<head>
+    <meta charset="utf8">
+    <title>metascraper</title>
+    <meta property="og:description" content="The HR startups go to war.">
+    <meta property="og:image" content="image">
+    <meta property="og:title" content="<script src='http://127.0.0.1:8080/malware.js'></script>">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="http://127.0.0.1:8080">
+</head>
+
+<body>
+</body>
+</html>

--- a/packages/metascraper/test/unit/xss/xss.js
+++ b/packages/metascraper/test/unit/xss/xss.js
@@ -1,0 +1,33 @@
+'use strict'
+const fs = require('fs')
+const path = require('path')
+const metascraper = require(path.join(__dirname, '..', '..', '..'))([
+  require(path.join(__dirname, '..', '..', '..', '..', 'metascraper-title'))()
+])
+const assert = require('assert')
+
+describe('xss', () => {
+  // https://github.com/microlinkhq/metascraper/issues/96
+  // https://www.npmjs.com/advisories/603
+  it('escape attribute value', done => {
+    fs.readFile(
+      path.join(__dirname, 'files', 'issue-96.html'),
+      'utf8',
+      (error, html) => {
+        if (error) {
+          throw error
+        }
+        metascraper({
+          url: 'http://127.0.0.1:8080',
+          html: html
+        }).then(metadata => {
+          assert.equal(
+            metadata.title,
+            '&lt;script src=‘http://127.0.0.1:8080/malware.js’&gt;&lt;/script&gt;'
+          )
+          done()
+        })
+      }
+    )
+  })
+})


### PR DESCRIPTION
Related to #96 this simply add a noEscape parameter to metascraper. By default all extracted data are escaped using https://www.npmjs.com/package/xss

It can be disabled using :
```
metascraper({url,html,noEscape:true}
```