### PR TITLE
Fix metascraper-date's incorrect parsing of dates

### DIFF
--- a/packages/metascraper-date/index.js
+++ b/packages/metascraper-date/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { date } = require('@metascraper/helpers')
+const { date, $filter } = require('@metascraper/helpers')
 
 /**
  * Wrap a rule with validation and formatting logic.
@@ -15,19 +15,12 @@ const wrap = rule => ({ htmlDom }) => {
 }
 
 /**
- * Wrap a rule with validation and formatting logic when multiple elements may be matched by the
- * selector.
+ * extract the date for a given element
  *
- * @param {Function} rule
- * @return {Function} wrapped
+ * @param {CheerioElement} element
+ * @return {String | Boolean} false if no date, otherwise a string representing the date
  */
-
-const wrapMultiple = rule => ({ htmlDom }) => {
-  const elems = rule(htmlDom)
-  return elems.toArray().reduce((memo, elem) => (
-    memo || date(htmlDom(elem).text())
-  ), false)
-}
+const textDate = el => date(el.text())
 
 /**
  * Rules.
@@ -52,19 +45,19 @@ module.exports = () => ({
     wrap($ => $('meta[name*="dcterms.date" i]').attr('content')),
     wrap($ => $('[property*="dc:date" i]').attr('content')),
     wrap($ => $('[property*="dc:created" i]').attr('content')),
-    wrapMultiple($ => $('[class*="byline" i]')),
-    wrapMultiple($ => $('[class*="dateline" i]')),
-    wrapMultiple($ => $('[id*="metadata" i]')),
-    wrapMultiple($ => $('[class*="metadata" i]')), // twitter, move into a bundle of rules
-    wrapMultiple($ => $('[id*="date" i]')),
-    wrapMultiple($ => $('[class*="date" i]')),
-    wrapMultiple($ => $('[id*="publish" i]')),
-    wrapMultiple($ => $('[class*="publish" i]')),
-    wrapMultiple($ => $('[id*="post-timestamp" i]')),
-    wrapMultiple($ => $('[class*="post-timestamp" i]')),
-    wrapMultiple($ => $('[id*="post-meta" i]')),
-    wrapMultiple($ => $('[class*="post-meta" i]')),
-    wrapMultiple($ => $('[id*="time" i]')),
-    wrapMultiple($ => $('[class*="time" i]'))
+    wrap($ => $filter($, $('[class*="byline" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="dateline" i]'), textDate)),
+    wrap($ => $filter($, $('[id*="metadata" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="metadata" i]'), textDate)), // twitter, move into a bundle of rules
+    wrap($ => $filter($, $('[id*="date" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="date" i]'), textDate)),
+    wrap($ => $filter($, $('[id*="publish" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="publish" i]'), textDate)),
+    wrap($ => $filter($, $('[id*="post-timestamp" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="post-timestamp" i]'), textDate)),
+    wrap($ => $filter($, $('[id*="post-meta" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="post-meta" i]'), textDate)),
+    wrap($ => $filter($, $('[id*="time" i]'), textDate)),
+    wrap($ => $filter($, $('[class*="time" i]'), textDate))
   ]
 })

--- a/packages/metascraper-date/index.js
+++ b/packages/metascraper-date/index.js
@@ -15,6 +15,21 @@ const wrap = rule => ({ htmlDom }) => {
 }
 
 /**
+ * Wrap a rule with validation and formatting logic when multiple elements may be matched by the
+ * selector.
+ *
+ * @param {Function} rule
+ * @return {Function} wrapped
+ */
+
+const wrapMultiple = rule => ({ htmlDom }) => {
+  const elems = rule(htmlDom)
+  return elems.toArray().reduce((memo, elem) => (
+    memo || date(htmlDom(elem).text())
+  ), false)
+}
+
+/**
  * Rules.
  */
 
@@ -37,19 +52,19 @@ module.exports = () => ({
     wrap($ => $('meta[name*="dcterms.date" i]').attr('content')),
     wrap($ => $('[property*="dc:date" i]').attr('content')),
     wrap($ => $('[property*="dc:created" i]').attr('content')),
-    wrap($ => $('[class*="byline" i]').text()),
-    wrap($ => $('[class*="dateline" i]').text()),
-    wrap($ => $('[id*="metadata" i]').text()),
-    wrap($ => $('[class*="metadata" i]').text()), // twitter, move into a bundle of rules
-    wrap($ => $('[id*="date" i]').text()),
-    wrap($ => $('[class*="date" i]').text()),
-    wrap($ => $('[id*="publish" i]').text()),
-    wrap($ => $('[class*="publish" i]').text()),
-    wrap($ => $('[id*="post-timestamp" i]').text()),
-    wrap($ => $('[class*="post-timestamp" i]').text()),
-    wrap($ => $('[id*="post-meta" i]').text()),
-    wrap($ => $('[class*="post-meta" i]').text()),
-    wrap($ => $('[id*="time" i]').text()),
-    wrap($ => $('[class*="time" i]').text())
+    wrapMultiple($ => $('[class*="byline" i]')),
+    wrapMultiple($ => $('[class*="dateline" i]')),
+    wrapMultiple($ => $('[id*="metadata" i]')),
+    wrapMultiple($ => $('[class*="metadata" i]')), // twitter, move into a bundle of rules
+    wrapMultiple($ => $('[id*="date" i]')),
+    wrapMultiple($ => $('[class*="date" i]')),
+    wrapMultiple($ => $('[id*="publish" i]')),
+    wrapMultiple($ => $('[class*="publish" i]')),
+    wrapMultiple($ => $('[id*="post-timestamp" i]')),
+    wrapMultiple($ => $('[class*="post-timestamp" i]')),
+    wrapMultiple($ => $('[id*="post-meta" i]')),
+    wrapMultiple($ => $('[class*="post-meta" i]')),
+    wrapMultiple($ => $('[id*="time" i]')),
+    wrapMultiple($ => $('[class*="time" i]'))
   ]
 })

--- a/packages/metascraper-date/index.js
+++ b/packages/metascraper-date/index.js
@@ -15,14 +15,6 @@ const wrap = rule => ({ htmlDom }) => {
 }
 
 /**
- * extract the date for a given element
- *
- * @param {CheerioElement} element
- * @return {String | Boolean} false if no date, otherwise a string representing the date
- */
-const textDate = el => date(el.text())
-
-/**
  * Rules.
  */
 
@@ -45,19 +37,19 @@ module.exports = () => ({
     wrap($ => $('meta[name*="dcterms.date" i]').attr('content')),
     wrap($ => $('[property*="dc:date" i]').attr('content')),
     wrap($ => $('[property*="dc:created" i]').attr('content')),
-    wrap($ => $filter($, $('[class*="byline" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="dateline" i]'), textDate)),
-    wrap($ => $filter($, $('[id*="metadata" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="metadata" i]'), textDate)), // twitter, move into a bundle of rules
-    wrap($ => $filter($, $('[id*="date" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="date" i]'), textDate)),
-    wrap($ => $filter($, $('[id*="publish" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="publish" i]'), textDate)),
-    wrap($ => $filter($, $('[id*="post-timestamp" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="post-timestamp" i]'), textDate)),
-    wrap($ => $filter($, $('[id*="post-meta" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="post-meta" i]'), textDate)),
-    wrap($ => $filter($, $('[id*="time" i]'), textDate)),
-    wrap($ => $filter($, $('[class*="time" i]'), textDate))
+    wrap($ => $filter($, $('[class*="byline" i]'))),
+    wrap($ => $filter($, $('[class*="dateline" i]'))),
+    wrap($ => $filter($, $('[id*="metadata" i]'))),
+    wrap($ => $filter($, $('[class*="metadata" i]'))), // twitter, move into a bundle of rules
+    wrap($ => $filter($, $('[id*="date" i]'))),
+    wrap($ => $filter($, $('[class*="date" i]'))),
+    wrap($ => $filter($, $('[id*="publish" i]'))),
+    wrap($ => $filter($, $('[class*="publish" i]'))),
+    wrap($ => $filter($, $('[id*="post-timestamp" i]'))),
+    wrap($ => $filter($, $('[class*="post-timestamp" i]'))),
+    wrap($ => $filter($, $('[id*="post-meta" i]'))),
+    wrap($ => $filter($, $('[class*="post-meta" i]'))),
+    wrap($ => $filter($, $('[id*="time" i]'))),
+    wrap($ => $filter($, $('[class*="time" i]')))
   ]
 })

--- a/packages/metascraper/__snapshots__/index.js.snap-shot
+++ b/packages/metascraper/__snapshots__/index.js.snap-shot
@@ -65,7 +65,7 @@ exports['audiense 1'] = {
 
 exports['bbc 1'] = {
   "author": "Will Smale Business reporter, BBC News",
-  "date": "1711-07-20T12:00:00.000Z",
+  "date": "2017-07-10T00:00:00.000Z",
   "description": "How an IT worker quit his day job, and despite having no ideas to begin with, launched a firm from home that made him a multi-millionaire.",
   "image": "https://ichef-1.bbci.co.uk/news/1024/cpsprodpb/D20B/production/_96817735_carl4.jpg",
   "video": null,
@@ -182,7 +182,7 @@ exports['crn 1'] = {
 
 exports['economic-times 1'] = {
   "author": "J Vignesh",
-  "date": "2016-01-12T22:34:00.000Z",
+  "date": "2016-01-12T17:04:00.000Z",
   "description": "HackerRank, a tech recruiting company, has launched HackerRank Jobs, to bridge the gap between the applicant and recruiter.",
   "image": "http://economictimes.indiatimes.com/thumb/msid-50551911,width-600,resizemode-4/hackerrank-launches-job-search-platform-hackerrank-jobs.jpg",
   "video": null,
@@ -845,7 +845,7 @@ exports['washington-post 1'] = {
 
 exports['wired 1'] = {
   "author": "Adam Rogers",
-  "date": "1707-07-13T12:00:00.000Z",
+  "date": "2017-07-13T00:00:00.000Z",
   "description": "Even if climate change didn’t send Larsen C packing, the air and oceans on Earth are incontrovertibly warmer than they used to be. Could an event like this move a policy needle?",
   "image": "https://media.wired.com/photos/5966648eb07d437d51477a87/191:100/pass/LarsenC-FeatureArt.jpg",
   "video": null,
@@ -957,7 +957,7 @@ exports['youtube channel 1'] = {
 
 exports['wikipedia 1'] = {
   "author": null,
-  "date": "2016-10-13T12:00:00.000Z",
+  "date": "2016-10-13T00:00:00.000Z",
   "description": "Bob Dylan (/ˈdɪlən/; born Robert Allen Zimmerman, May 24, 1941) is an American singer-songwriter, author, and painter, who has been an influential figure in popular music and culture for more than five decades. Much of his most celebrated work dates from the 1960s, when he became a reluctant “voice …",
   "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Bob_Dylan_-_Azkena_Rock_Festival_2010_2.jpg/1200px-Bob_Dylan_-_Azkena_Rock_Festival_2010_2.jpg",
   "video": null,

--- a/packages/metascraper/__snapshots__/index.js.snap-shot
+++ b/packages/metascraper/__snapshots__/index.js.snap-shot
@@ -994,3 +994,16 @@ exports['learnnode 1'] = {
   "url": "https://learnnode.com"
 }
 
+exports['health.govt.nz 1'] = {
+  "author": null,
+  "date": "2011-04-07T00:00:00.000Z",
+  "description": "In December 2009 Cabinet agreed to strengthen the health sector’s focus on quality and safety by creating a Health Quality and Safety Commission. This regulatory impact statement considers what additional functions, powers, and funding mechanisms the Commission might need to achieve sustained qualit…",
+  "image": "https://html-microservice.herokuapp.com/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg",
+  "video": null,
+  "lang": "en",
+  "logo": "https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico",
+  "publisher": "Ministry of Health NZ",
+  "title": "Quality Improvement Agency: Health Quality and Safety Commission: Functions, Powers and Funding",
+  "url": "https://www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding"
+}
+

--- a/packages/metascraper/test/integration/health/index.js
+++ b/packages/metascraper/test/integration/health/index.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const snapshot = require('snap-shot')
+const { promisify } = require('util')
+const { resolve } = require('path')
+
+const fs = require('fs')
+
+const metascraper = require('../../..')([
+  require('metascraper-author')(),
+  require('metascraper-date')(),
+  require('metascraper-description')(),
+  require('metascraper-video')(),
+  require('metascraper-image')(),
+  require('metascraper-lang')(),
+  require('metascraper-logo')(),
+  require('metascraper-logo-favicon')(),
+  require('metascraper-publisher')(),
+  require('metascraper-title')(),
+  require('metascraper-url')(),
+  require('metascraper-readability')()
+])
+
+const readFile = promisify(fs.readFile)
+
+const url =
+  'https://html-microservice.herokuapp.com/https://www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding'
+
+it('health.govt.nz', async () => {
+  const html = await readFile(resolve(__dirname, 'input.html'))
+  const metadata = await metascraper({ html, url })
+  snapshot(metadata)
+})

--- a/packages/metascraper/test/integration/health/input.html
+++ b/packages/metascraper/test/integration/health/input.html
@@ -1,0 +1,960 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article# book: http://ogp.me/ns/book# profile: http://ogp.me/ns/profile# video: http://ogp.me/ns/video# product: http://ogp.me/ns/product# content: http://purl.org/rss/1.0/modules/content/ dc: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ rdfs: http://www.w3.org/2000/01/rdf-schema# sioc: http://rdfs.org/sioc/ns# sioct: http://rdfs.org/sioc/types# skos: http://www.w3.org/2004/02/skos/core# xsd: http://www.w3.org/2001/XMLSchema# " class="no-js">
+<head>
+  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="format-detection" content="telephone=no" />
+  <link rel="profile" href="http://www.w3.org/1999/xhtml/vocab" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<link rel="shortcut icon" href="https://www.health.govt.nz/sites/all/themes/mohpub_bootstrap/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="description" content="In December 2009 Cabinet agreed to strengthen the health sector’s focus on quality and safety by creating a Health Quality and Safety Commission. This regulatory impact statement considers what additional functions, powers, and funding mechanisms the Commission might need to achieve sustained quality and safety improvement." />
+<meta name="generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="canonical" href="https://www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding" />
+<link rel="shortlink" href="https://www.health.govt.nz/node/522" />
+<meta property="og:site_name" content="Ministry of Health NZ" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="https://www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding" />
+<meta property="og:title" content="Quality Improvement Agency: Health Quality and Safety Commission: Functions, Powers and Funding" />
+<meta property="og:description" content="In December 2009 Cabinet agreed to strengthen the health sector’s focus on quality and safety by creating a Health Quality and Safety Commission. This regulatory impact statement considers what additional functions, powers, and funding mechanisms the Commission might need to achieve sustained quality and safety improvement." />
+  <title>Quality Improvement Agency: Health Quality and Safety Commission: Functions, Powers and Funding | Ministry of Health NZ</title>
+  <link type="text/css" rel="stylesheet" href="https://www.health.govt.nz/sites/default/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://www.health.govt.nz/sites/default/files/css/css_fG21muFND2PGcaFxWhw-28-Ao8sOD7MBga8E4CJlB5o.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://www.health.govt.nz/sites/default/files/css/css_w5UPUg3F7vTao0qmlQiTdoTFX7wHpNekMWSey1Yw3Y8.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://www.health.govt.nz/sites/default/files/css/css_iiJoi8D_bFUG1V5rVlNuUgxDT-VP89ZRN11HYCnEoVc.css" media="all" />
+<link type="text/css" rel="stylesheet" href="https://www.health.govt.nz/sites/default/files/css/css_r7NPyvpdYfAyZmk9zkK8OaFKEFj6er5ZJnam2H644DM.css" media="print" />
+  <link rel="alternate stylesheet" type="text/css" href="/sites/all/themes/mohpub_bootstrap/css/high-contrast.css" media="screen" title="High Contrast" />
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0];var j=d.createElement(s);var dl=l!='dataLayer'?'&l='+l:'';j.type='text/javascript';j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'';j.async=true;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PFGG7W');</script>
+<script src="https://www.health.govt.nz/sites/default/files/js/js_v7z_ueNi9EIrZXPI8So7AkuzyXuKekr2jbdDptsM5Oc.js"></script>
+<script src="https://www.health.govt.nz/sites/default/files/js/js_Tik8PIaz_eQ5I4FMzmjkWoPEs9jKBgTSauo1jgsNa6g.js"></script>
+<script src="https://www.health.govt.nz/sites/default/files/js/js_fP8q6bTkC9KjqJ80V0y23uSPYfejvGhDYI2j6E3c4W4.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");ga("create", "UA-3573389-24", {"cookieDomain":".www.health.govt.nz","siteSpeedSampleRate":15});ga("send", "pageview");</script>
+<script src="https://www.health.govt.nz/sites/default/files/js/js_LwntcVO2M6XEr6RJV11Rmtn7JWx8h8iUb1tg4Jshuyc.js"></script>
+<script src="https://www.health.govt.nz/sites/default/files/js/js_phvmXRwbrloEX2rG_I8WYxzP3gVATincqryQ-UJgo7Y.js"></script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"mohpub_bootstrap","theme_token":"pSRpWSzWsdexlY94rzGb8rOWea1oTX0OK5tkY9nq7zk","js":{"sites\/all\/modules\/custom\/table_d3chart\/js\/table_d3chart.js":1,"sites\/all\/modules\/custom\/moh_d3\/moh_d3.js":1,"0":1,"sites\/all\/modules\/contrib\/jquery_update\/replace\/jquery\/1.7\/jquery.min.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/modules\/contrib\/extlink\/extlink.js":1,"modules\/field\/modules\/text\/text.js":1,"sites\/all\/modules\/contrib\/field_group\/field_group.js":1,"sites\/all\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"1":1,"sites\/all\/libraries\/c3\/c3.js":1,"sites\/all\/libraries\/d3\/d3.js":1,"sites\/all\/modules\/contrib\/d3\/js\/d3.js":1,"sites\/all\/libraries\/d3.helpers\/d3.helpers.js":1,"sites\/all\/libraries\/d3.c3\/d3-c3.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/assets\/ios-fix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/affix.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/alert.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/button.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/carousel.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/collapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/dropdown.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/modal.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tooltip.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/popover.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/scrollspy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/tab.js":1,"sites\/all\/themes\/mohpub_bootstrap\/bootstrap\/js\/transition.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.cookie.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.moh.announcement.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/svgeezy.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/fitvids.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-tabcollapse.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.scrollTo.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/script.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/jquery.google_analytics.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/bootstrap-accessibility.min.js":1,"sites\/all\/themes\/mohpub_bootstrap\/js\/style-switcher.js":1},"css":{"modules\/system\/system.base.css":1,"sites\/all\/modules\/contrib\/calendar\/css\/calendar_multiday.css":1,"sites\/all\/modules\/contrib\/date\/date_api\/date.css":1,"sites\/all\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"modules\/field\/theme\/field.css":1,"sites\/all\/modules\/contrib\/extlink\/extlink.css":1,"sites\/all\/modules\/contrib\/views\/css\/views.css":1,"sites\/all\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"sites\/all\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/contrib\/panels\/css\/panels.css":1,"sites\/all\/libraries\/c3\/c3.css":1,"sites\/all\/libraries\/d3.c3\/d3-c3.css":1,"sites\/all\/themes\/mohpub_bootstrap\/fontawesome\/css\/font-awesome.min.css":1,"sites\/all\/modules\/features\/site_profile\/css\/fix-rubik-multiselect-height.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/style.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/responsive-tables.css":1,"sites\/all\/themes\/mohpub_bootstrap\/css\/print.css":1}},"extlink":{"extTarget":0,"extClass":"ext","extLabel":"(link is external)","extImgClass":0,"extIconPlacement":"append","extSubdomains":0,"extExclude":"","extInclude":"","extCssExclude":"","extCssExplicit":"","extAlert":0,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","mailtoClass":"mailto","mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls|xml|z|zip|docx|xlsx|pptx|pptm|ppsx|ppsm|epub"},"mohD3":{"C3Types":["line","spline","step","area","area-spline","area-step","bar","scatter","pie","donut","gauge"],"graphRender":"line","graphLegend":true,"graphDefaultColors":"#2b8cbe, #abdda4, #7f7f7f, #92cddc, #dc8b0c","graphDefaultGroupedTooltip":0,"graphDefaultGridX":0,"graphDefaultGridY":0,"graphDefaultLegendPosition":"top-right","graphDefaultTooltip":1,"graphDefaultDataLabel":0,"graphLegendStep":"5","graphInteraction":true,"graphTypes":"","graphXaxisShow":true,"graphXaxisLabel":"","graphYaxisLabel":"","graphXaxisType":"category","graphXaxisCentered":false,"graphXaxisRotation":"","graphXaxisHeight":"","graphYaxisShow":true,"graphYaxisMax":"","graphYaxisMin":"","graphYaxisInverted":false,"graphYaxisCenter":"","graphYaxisPrefix":"","graphYaxisSuffix":"","graphYaxisPosition":"","graphY2axisShow":false,"graphY2axisSource":"","graphY2axisMax":"","graphY2axisMin":"","graphGroups":"","graphRotated":false,"graphIgnoreEmpty":false,"graphLineDot":true,"graphBarRatio":"0.9","graphDot":true,"graphDotR":"2.5","graphFocus":false},"tableD3":{"show":"View table data source","hide":"Hide table data source"},"urlIsAjaxTrusted":{"\/about-ministry\/legislation-and-regulation\/regulatory-impact-statements\/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding":true},"bootstrap":{"anchorsFix":1,"anchorsSmoothScrolling":1,"popoverEnabled":1,"popoverOptions":{"animation":1,"html":0,"placement":"right","selector":"","trigger":"click","triggerAutoclose":1,"title":"","content":"","delay":0,"container":"body"},"tooltipEnabled":1,"tooltipOptions":{"animation":1,"html":0,"placement":"auto left","selector":"","trigger":"hover focus","delay":0,"container":"body"}}});</script>
+  <!-- HTML5 element support for IE6-8 -->
+  <!--[if lt IE 9]>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/html5shiv.js"></script>
+    <script src="/sites/all/themes/mohpub_bootstrap/js/assets/respond.min.js"></script>
+  <![endif]-->
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-522 node-type-page node-has-intro" >
+<!--googleoff: all-->
+  <div id="skip-link">
+    <a href="#skip-content" id="skipper" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <div class="region region-page-top">
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PFGG7W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>  </div>
+  <div id="page">
+  <header id="navbar" role="banner" class="navbar container navbar-default">
+          <ul class="menu nav navbar-nav secondary"><li class="first leaf jobs depth-1"><a href="https://careers.health.govt.nz" title="">Jobs</a></li>
+<li class="leaf news depth-1"><a href="/news-media" data-is-top-level="0" title="">News</a></li>
+<li class="leaf contact-us depth-1"><a href="/about-ministry/contact-us" title="">Contact us</a></li>
+<li class="leaf twitter depth-1"><a href="https://twitter.com/minhealthnz" data-is-top-level="0" title="">Twitter</a></li>
+<li class="last leaf youtube depth-1"><a href="https://www.youtube.com/user/minhealthnz" data-is-top-level="0" title="">Youtube</a></li>
+</ul>        <div class="container">
+      <div class="navbar-header">
+                <a class="logo navbar-btn pull-left" href="/" title="Home">
+          <img src="/sites/all/themes/mohpub_bootstrap/images/mohlogo.svg" alt="Ministry of Health" />
+        </a>
+                  <div class="region region-header-top">
+    <section id="block-apachesolr-panels-search-form" class="block block-apachesolr-panels clearfix">
+
+      
+  <form action="/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding" method="post" id="apachesolr-panels-search-block" accept-charset="UTF-8"><div><div class="form-type-textfield form-item-apachesolr-panels-search-form form-item form-group">
+  <label class="element-invisible" for="edit-apachesolr-panels-search-form">Search </label>
+ <input title="Enter the terms you wish to search for." class="form-control form-text" data-toggle="tooltip" type="text" id="edit-apachesolr-panels-search-form" name="apachesolr_panels_search_form" value="" size="15" maxlength="128" />
+</div>
+<input type="hidden" name="form_build_id" value="form--78dENY24k9dxXrfUOqaCX5zpvcKg7QI7-Nxnj2skoQ" />
+<input type="hidden" name="form_id" value="apachesolr_panels_search_block" />
+<div class="form-actions form-wrapper form-group" id="edit-actions"><button id="edit-submit" name="op" value="Search" type="submit" class="btn btn-primary form-submit">Search</button>
+</div></div></form>
+</section> <!-- /.block -->
+  </div>
+        <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+        <button aria-expanded="false" aria-controls="megamenu" type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="menu-text">Menu</span><span class="sr-only">Toggle navigation</span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+
+        </button>
+      </div>
+
+              <div class="navbar-collapse collapse">
+          <nav id="megamenu" role="navigation">
+                          <h2 class="element-invisible">Main menu</h2><ul id="main-menu" class="menu nav navbar-nav yamm navbar"><li class="first dropdown"><a href="/your-health" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-780">Your health <b class="caret"></b></a>
+    <div id="megamenu-dropdown-780" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/your-health/conditions-and-treatments?mega=Your%20health&title=Conditions%20%26%20treatments" class="menu-header">Conditions & treatments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/your-health/conditions-and-treatments/mental-health/depression?mega=Your%20health&title=Depression">Depression</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/diabetes?mega=Your%20health&title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/influenza?mega=Your%20health&title=Influenza">Influenza</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/measles?mega=Your%20health&title=Measles">Measles</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/meningococcal-disease-including-meningitis?mega=Your%20health&title=Meningococcal%20disease">Meningococcal disease</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/mumps?mega=Your%20health&title=Mumps">Mumps</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/sore-throat?mega=Your%20health&title=Sore%20throat">Sore throat</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments/diseases-and-illnesses/whooping-cough?mega=Your%20health&title=Whooping%20cough">Whooping cough</a></li>
+                                  <li><a href="/your-health/conditions-and-treatments?mega=Your%20health&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/your-health/healthy-living?mega=Your%20health&title=Healthy%20living" class="menu-header">Healthy living</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/your-health/healthy-living/drinking-water?mega=Your%20health&title=Drinking-water">Drinking-water</a></li>
+                                  <li><a href="/your-health/healthy-living/food-activity-and-sleep/green-prescriptions?mega=Your%20health&title=Green%20Prescriptions">Green Prescriptions</a></li>
+                                  <li><a href="/your-health/healthy-living/food-activity-and-sleep/healthy-eating?mega=Your%20health&title=Healthy%20eating">Healthy eating</a></li>
+                                  <li><a href="/your-health/healthy-living/immunisation?mega=Your%20health&title=Immunisation">Immunisation</a></li>
+                                  <li><a href="/your-health/healthy-living/food-activity-and-sleep/physical-activity?mega=Your%20health&title=Physical%20activity">Physical activity</a></li>
+                                  <li><a href="/your-health/healthy-living/addictions/smoking?mega=Your%20health&title=Smoking">Smoking</a></li>
+                                  <li><a href="/your-health/healthy-living/teeth-and-gums?mega=Your%20health&title=Teeth%20and%20gums">Teeth and gums</a></li>
+                                  <li><a href="/your-health/healthy-living?mega=Your%20health&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/your-health/pregnancy-and-kids?mega=Your%20health&title=Pregnancy%20and%20kids" class="menu-header">Pregnancy and kids</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/your-health/pregnancy-and-kids/birth-and-afterwards?mega=Your%20health&title=Birth%20and%20afterwards">Birth and afterwards</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids/first-year/helpful-advice-during-first-year/breastfeeding-perfect-you-and-your-baby?mega=Your%20health&title=Breastfeeding">Breastfeeding</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids/pregnancy?mega=Your%20health&title=Pregnancy">Pregnancy</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids/services-and-support-during-pregnancy?mega=Your%20health&title=Services%20and%20support%20during%20pregnancy">Services and support during pregnancy</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids/services-and-support-you-and-your-child?mega=Your%20health&title=Services%20and%20support%20for%20you%20and%20your%20child">Services and support for you and your child</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids/first-year?mega=Your%20health&title=The%20first%20year">The first year</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids/under-fives?mega=Your%20health&title=Under%20fives">Under fives</a></li>
+                                  <li><a href="/your-health/pregnancy-and-kids?mega=Your%20health&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/your-health/services-and-support?mega=Your%20health&title=Services%20and%20support" class="menu-header">Services & support</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/your-health/services-and-support/health-care-services/help-alcohol-and-drug-problems?mega=Your%20health&title=Alcohol%20and%20drugs">Alcohol and drugs</a></li>
+                                  <li><a href="/your-health/services-and-support/disability-services?mega=Your%20health&title=Disability%20services">Disability services</a></li>
+                                  <li><a href="/your-health/services-and-support/health-care-services/earthquake-support-line?mega=Your%20health&title=Earthquake%20Support%20Line">Earthquake Support Line</a></li>
+                                  <li><a href="/your-health/services-and-support/health-care-services/healthline?mega=Your%20health&title=Healthline">Healthline</a></li>
+                                  <li><a href="/your-health/services-and-support/health-care-services/mental-health-services?mega=Your%20health&title=Mental%20health%20services">Mental health services</a></li>
+                                  <li><a href="/your-health/services-and-support/health-care-services/maori-health-provider-directory?mega=Your%20health&title=M%C4%81ori%20health%20providers">Māori health providers</a></li>
+                                  <li><a href="/your-health/services-and-support/health-care-services/services-older-people/rest-home-certification-and-audits?mega=Your%20health&title=Rest%20home%20certification">Rest home certification</a></li>
+                                  <li><a href="/your-health/services-and-support/health-care-services/hospitals-and-specialist-services/travel-assistance?mega=Your%20health&title=Travel%20assistance">Travel assistance</a></li>
+                                  <li><a href="/your-health/services-and-support?mega=Your%20health&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/your-health/full-a-z?mega=Your%20health&title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/new-zealand-health-system" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-6076">NZ health system <b class="caret"></b></a>
+    <div id="megamenu-dropdown-6076" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&title=Key%20organisations" class="menu-header">Key organisations</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/new-zealand-health-system/key-health-sector-organisations-and-people/crown-entities-and-agencies?mega=NZ%20health%20system&title=Crown%20entities%20%26%20agencies">Crown entities & agencies</a></li>
+                                  <li><a href="/new-zealand-health-system/key-health-sector-organisations-and-people/district-health-boards?mega=NZ%20health%20system&title=District%20health%20boards">District health boards</a></li>
+                                  <li><a href="/new-zealand-health-system/key-health-sector-organisations-and-people/non-governmental-organisations?mega=NZ%20health%20system&title=Non-governmental%20organisations">Non-governmental organisations</a></li>
+                                  <li><a href="/new-zealand-health-system/key-health-sector-organisations-and-people/primary-health-organisations?mega=NZ%20health%20system&title=Primary%20health%20organisations">Primary health organisations</a></li>
+                                  <li><a href="/new-zealand-health-system/key-health-sector-organisations-and-people/public-health-units?mega=NZ%20health%20system&title=Public%20health%20units">Public health units</a></li>
+                                  <li><a href="/new-zealand-health-system/key-health-sector-organisations-and-people?mega=NZ%20health%20system&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/new-zealand-health-system/health-targets?mega=NZ%20health%20system&title=Health%20targets" class="menu-header">Health targets</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/new-zealand-health-system/health-targets/about-health-targets?mega=NZ%20health%20system&title=2016/17%20health%20targets">2016/17 health targets</a></li>
+                                  <li><a href="/new-zealand-health-system/health-targets/how-my-dhb-performing-2017-18?mega=NZ%20health%20system&title=How%20is%20my%20DHB%20performing%3F">How is my DHB performing?</a></li>
+                                  <li><a href="/new-zealand-health-system/health-targets/how-my-pho-performing?mega=NZ%20health%20system&title=How%20is%20my%20PHO%20performing%3F">How is my PHO performing?</a></li>
+                                  <li><a href="/new-zealand-health-system/health-targets/how-my-dhb-performing-2017-18/how-my-dhb-performing-2016-17/health-targets-2016-17-quarter-4-results-summary?mega=NZ%20health%20system&title=Last%20results%20summary">Last results summary</a></li>
+                                  <li><a href="/new-zealand-health-system/health-targets?mega=NZ%20health%20system&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&title=Eligibility%20for%20public%20health%20services" class="menu-header">Eligibility for public health services</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/new-zealand-health-system/eligibility-publicly-funded-health-services/guide-eligibility-publicly-funded-health-services?mega=NZ%20health%20system&title=Guide%20to%20eligibility">Guide to eligibility</a></li>
+                                  <li><a href="/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-consumers?mega=NZ%20health%20system&title=Q%26A%20for%20consumers">Q&A for consumers</a></li>
+                                  <li><a href="/new-zealand-health-system/eligibility-publicly-funded-health-services/eligibility-questions-and-answers-service-providers?mega=NZ%20health%20system&title=Q%26A%20for%20service%20providers">Q&A for service providers</a></li>
+                                  <li><a href="/new-zealand-health-system/eligibility-publicly-funded-health-services/reciprocal-health-agreements?mega=NZ%20health%20system&title=Reciprocal%20health%20agreements">Reciprocal health agreements</a></li>
+                                  <li><a href="/new-zealand-health-system/eligibility-publicly-funded-health-services?mega=NZ%20health%20system&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&title=Claims%2C%20provider%20payments%20and%20entitlements" class="menu-header">Claims & provider payments</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements/carer-support-claims?mega=NZ%20health%20system&title=Carer%20Support">Carer Support</a></li>
+                                  <li><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements/high-use-health-card-payments?mega=NZ%20health%20system&title=High%20Use%20Health%20Card%20payments">High Use Health Card payments</a></li>
+                                  <li><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements/between-travel-settlement?mega=NZ%20health%20system&title=In-Between%20Travel%20Settlement">In-Between Travel Settlement</a></li>
+                                  <li><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements/maternity-claim-forms?mega=NZ%20health%20system&title=Maternity%20claim%20forms">Maternity claim forms</a></li>
+                                  <li><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements/national-travel-assistance?mega=NZ%20health%20system&title=National%20travel%20assistance%20claims">National travel assistance claims</a></li>
+                                  <li><a href="/new-zealand-health-system/claims-provider-payments-and-entitlements?mega=NZ%20health%20system&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/new-zealand-health-system/overview-health-system?mega=NZ%20health%20system&title=Overview">Overview of the health system</a>  <a href="/new-zealand-health-system/my-dhb?mega=NZ%20health%20system&title=Mydhb">My DHB</a> <a href="/new-zealand-health-system/system-level-measures-framework?mega=NZ%20health%20system&title=SLM">System level measures</a>  <a href="/publication/new-zealand-health-strategy-2016?mega=NZ%20health%20system&title=HealthStrategy">NZ Health Strategy</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/our-work" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-776">Our work <b class="caret"></b></a>
+  <div id="megamenu-dropdown-776" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/our-work/diseases-and-conditions/antimicrobial-resistance?mega=Our%20work&title=Antimicrobial%20resistance" class="menu-header">Antimicrobial resistance</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/populations/asian-and-migrant-health?mega=Our%20work&title=Asian%20and%20migrant%20health" class="menu-header">Asian and migrant health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/border-health?mega=Our%20work&title=Border%20health" class="menu-header">Border health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/life-stages/breastfeeding?mega=Our%20work&title=Breastfeeding" class="menu-header">Breastfeeding</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/diseases-and-conditions/national-cancer-programme?mega=Our%20work&title=Cancer%20programme" class="menu-header">Cancer programme</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/regulation-health-and-disability-system/certification-health-care-services?mega=Our%20work&title=Certification%20of%20health%20care%20services" class="menu-header">Certification of health care services</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/life-stages/child-health?mega=Our%20work&title=Child%20health" class="menu-header">Child health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/diseases-and-conditions/diabetes?mega=Our%20work&title=Diabetes" class="menu-header">Diabetes</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/disability-services?mega=Our%20work&title=Disability%20services" class="menu-header">Disability services</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/diseases-and-conditions?mega=Our%20work&title=Diseases%20and%20conditions" class="menu-header">Diseases and conditions</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/ehealth?mega=Our%20work&title=eHealth" class="menu-header">eHealth</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/our-work/hospitals-and-specialist-care/elective-services?mega=Our%20work&title=Elective%20services" class="menu-header">Elective services</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/hospitals-and-specialist-care/emergency-departments?mega=Our%20work&title=Emergency%20departments" class="menu-header">Emergency departments</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/emergency-management?mega=Our%20work&title=Emergency%20management" class="menu-header">Emergency management</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/environmental-health?mega=Our%20work&title=Environmental%20health" class="menu-header">Environmental health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/family-violence?mega=Our%20work&title=Family%20violence" class="menu-header">Family violence</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/fluoride-and-oral-health?mega=Our%20work&title=Fluoride%20and%20oral%20health" class="menu-header">Fluoride and oral health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/health-identity?mega=Our%20work&title=Health%20identity" class="menu-header">Health identity</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/life-stages/health-older-people?mega=Our%20work&title=Health%20of%20older%20people" class="menu-header">Health of older people</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/health-workforce?mega=Our%20work&title=Health%20workforce" class="menu-header">Health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/hospital-redevelopment-projects?mega=Our%20work&title=Hospital%20redevelopment%20projects" class="menu-header">Hospital redevelopment projects</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/our-work/hospitals-and-specialist-care?mega=Our%20work&title=Hospitals%20and%20specialist%20care" class="menu-header">Hospitals and specialist care</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/immunisation?mega=Our%20work&title=Immunisation" class="menu-header">Immunisation</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/populations/maori-health?mega=Our%20work&title=M%C4%81ori%20health" class="menu-header">Māori health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/life-stages/maternity-services?mega=Our%20work&title=Maternity" class="menu-header">Maternity</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/regulation-health-and-disability-system/medicines-control?mega=Our%20work&title=Medicines%20control" class="menu-header">Medicines control</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/mental-health-and-addictions?mega=Our%20work&title=Mental%20health%20and%20addictions" class="menu-header">Mental health and addictions</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/nursing?mega=Our%20work&title=Nursing" class="menu-header">Nursing</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/nutrition?mega=Our%20work&title=Nutrition" class="menu-header">Nutrition</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/oral-health?mega=Our%20work&title=Oral%20health" class="menu-header">Oral health</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/hospitals-and-specialist-care/organ-donation-and-transplantation?mega=Our%20work&title=Organ%20donation%20and%20transplantation" class="menu-header">Organ donation and transplantation</a>                              </li>
+                                                                </ul>
+                            <ul class="col list-unstyled no-menu-header">
+                                                                                <li>
+                <a href="/our-work/populations/pacific-health?mega=Our%20work&title=Pacific%20health" class="menu-header">Pacific health</a>                              </li>
+                                                                    <li>
+                <a href="/new-zealand-health-system/pay-equity-settlements?mega=Our%20work&title=Pay%20equity%20settlements" class="menu-header">Pay equity</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/physical-activity?mega=Our%20work&title=Physical%20activity" class="menu-header">Physical activity</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness?mega=Our%20work&title=Preventative%20health/wellness" class="menu-header">Preventative health/wellness</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/primary-health-care?mega=Our%20work&title=Primary%20health%20care" class="menu-header">Primary health care</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/public-health-workforce-development?mega=Our%20work&title=Public%20health%20workforce%20development" class="menu-header">Public health workforce</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/radiation-safety?mega=Our%20work&title=Radiation%20safety" class="menu-header">Radiation safety</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/regulation-health-and-disability-system?mega=Our%20work&title=Regulation" class="menu-header">Regulation</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/preventative-health-wellness/tobacco-control?mega=Our%20work&title=Tobacco%20control" class="menu-header">Tobacco control</a>                              </li>
+                                                                    <li>
+                <a href="/our-work/who-code-nz?mega=Our%20work&title=WHO%20Code%20in%20NZ" class="menu-header">WHO Code in NZ</a>                              </li>
+                      </ul>
+              </div>
+    </div>
+    <div class="feature-links">
+      <a href="/our-work?mega=Our%20work&title=A-Z">View the full A-Z</a>    </div>
+  </div>
+</li>
+<li class="dropdown"><a href="/nz-health-statistics" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="megamenu-dropdown-778">Health statistics <b class="caret"></b></a>
+    <div id="megamenu-dropdown-778" class="dropdown-menu">
+    <div class="yamm-content">
+      <div class="row">
+                            <div class="col">
+            <h3><a href="/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&title=Health%20statistics%20and%20data%20sets" class="menu-header">Statistics by topic</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/nz-health-statistics/health-statistics-and-data-sets/cancer-data-and-stats?mega=Health%20statistics&title=Cancer">Cancer</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets/diabetes-data-and-stats?mega=Health%20statistics&title=Diabetes">Diabetes</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets/mental-health-data-and-stats?mega=Health%20statistics&title=Mental%20health">Mental health</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets/maori-health-data-and-stats?mega=Health%20statistics&title=M%C4%81ori%20health">Māori health</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets/obesity-statistics?mega=Health%20statistics&title=Obesity">Obesity</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets/suicide-data-and-stats?mega=Health%20statistics&title=Suicide">Suicide</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets/tobacco-data-and-stats?mega=Health%20statistics&title=Tobacco">Tobacco</a></li>
+                                  <li><a href="/nz-health-statistics/health-statistics-and-data-sets?mega=Health%20statistics&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&title=National%20collections%20and%20surveys" class="menu-header">About our surveys & data collections</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/alcohol-and-drug-use-survey?mega=Health%20statistics&title=Alcohol%20%26%20Drug%20Use%20Survey">Alcohol & Drug Use Survey</a></li>
+                                  <li><a href="/nz-health-statistics/national-collections-and-surveys/national-collections-annual-maintenance-project/ncamp-2018?mega=Health%20statistics&title=NCAMP">NCAMP</a></li>
+                                  <li><a href="/nz-health-statistics/national-collections-and-surveys/collections/new-zealand-cancer-registry-nzcr?mega=Health%20statistics&title=NZ%20Cancer%20Registry">NZ Cancer Registry</a></li>
+                                  <li><a href="/nz-health-statistics/national-collections-and-surveys/surveys/new-zealand-health-survey?mega=Health%20statistics&title=NZ%20Health%20Survey">NZ Health Survey</a></li>
+                                  <li><a href="/nz-health-statistics/national-collections-and-surveys/surveys/past-surveys/nutrition-survey?mega=Health%20statistics&title=Nutrition%20Survey">Nutrition Survey</a></li>
+                                  <li><a href="/nz-health-statistics/national-collections-and-surveys/collections/primhd-mental-health-data?mega=Health%20statistics&title=PRIMHD">PRIMHD</a></li>
+                                  <li><a href="/nz-health-statistics/national-collections-and-surveys?mega=Health%20statistics&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&title=Classification%20and%20Terminology" class="menu-header">Classification & terminology</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/coding-queries/coding-query-database?mega=Health%20statistics&title=Coding%20query%20database">Coding query database</a></li>
+                                  <li><a href="/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs/courses-clinical-coding?mega=Health%20statistics&title=Courses%20on%20clinical%20coding">Courses on clinical coding</a></li>
+                                  <li><a href="/nz-health-statistics/classification-and-terminology/using-icd-10-am-achi-acs?mega=Health%20statistics&title=Using%20ICD-10-AM%2C%20ACHI%2C%20ACS">Using ICD-10-AM, ACHI, ACS</a></li>
+                                  <li><a href="/nz-health-statistics/classification-and-terminology?mega=Health%20statistics&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                                      <div class="col">
+            <h3><a href="/nz-health-statistics/data-references?mega=Health%20statistics&title=Data%20references" class="menu-header">Data references</a></h3>
+            <ul class="list-unstyled">
+                                                <li><a href="/nz-health-statistics/data-references/code-tables?mega=Health%20statistics&title=Code%20tables">Code tables</a></li>
+                                  <li><a href="/nz-health-statistics/data-references/data-dictionaries?mega=Health%20statistics&title=Data%20dictionaries">Data dictionaries</a></li>
+                                  <li><a href="/nz-health-statistics/data-references/diagnosis-related-groups?mega=Health%20statistics&title=Diagnosis-related%20groups">Diagnosis-related groups</a></li>
+                                  <li><a href="/nz-health-statistics/data-references/code-tables/common-code-tables/domicile-code-table?mega=Health%20statistics&title=Domicile%20code%20table">Domicile code table</a></li>
+                                  <li><a href="/nz-health-statistics/data-references/mapping-tools?mega=Health%20statistics&title=ICD%20mapping%20tools">ICD mapping tools</a></li>
+                                  <li><a href="/nz-health-statistics/data-references/weighted-inlier-equivalent-separations?mega=Health%20statistics&title=Weighted%20Inlier%20Equivalent%20Separations">Weighted Inlier Equivalent Separations</a></li>
+                                  <li><a href="/nz-health-statistics/data-references?mega=Health%20statistics&title=See%20all" class="view-more"><span>See all</span></a></li>
+                                          </ul>
+          </div>
+                        </div>
+    </div>
+    <div class="feature-links">
+      <h3 class="sr-only">Other related resources</h3>
+      <a href="/nz-health-statistics/health-statistics-and-data-sets/tier-1-health-statistics-release-calendar?mega=Health%20statistics&title=Tier%201%20calendar">Release calendar for our Tier 1 statistics</a> <a href="/nz-health-statistics/about-data-collection?mega=Health%20statistics&title=Enquiries">Data and survey enquiries</a>    </div>
+  </div>
+</li>
+<li class=""><a href="/publications" aria-haspopup="false">Publications</a></li>
+<li class=""><a href="/about-ministry" aria-haspopup="false" class="active-trail">About us</a></li>
+<li class="visible-xs"><a href="/contactus" aria-haspopup="false">Contact us</a></li>
+</ul>
+                                  </nav>
+        </div>
+          </div>
+  </header>
+
+  <div class="main-container container">
+    <!-- announcement -->
+        <!-- /announcement -->
+
+    <header role="banner" id="page-header">
+      
+          </header> <!-- /#page-header -->
+
+    <div class="row">
+      
+      <section class="col-sm-12">
+                        <a id="main-content"></a>
+                                                                            <div class="breadcrumbs">
+            <ul><li><a href="/">Home</a></li><li><a href="/about-ministry">About us</a></li><li><a href="/about-ministry/legislation-and-regulation">Legislation and regulation</a></li><li><a href="/about-ministry/legislation-and-regulation/regulatory-impact-statements">Regulatory impact statements</a></li><li><span class="current-breadcrumb">Quality Improvement Agency: Health Quality and Safety Commission: Functions, Powers and Funding</span></li></ul>          </div>
+        
+        
+        
+          <div class="region region-content">
+    <section id="block-system-main" class="block block-system clearfix">
+
+      
+  <div class="bootstrap-threecol-stacked" >
+  
+      <div class="row"> <!-- @TODO: Add extra classes -->
+      <div class='panel-panel left col-xs-12 col-md-3 col-lg-3'><div class="panel-pane pane-block pane-menu-block-1 odd" >
+  
+        <h2 class="pane-title h3"><a href="/about-ministry" class="active-trail">About us</a></h2>
+    
+  
+  <div class="pane-content">
+        <div class="menu-block-wrapper menu-block-1 menu-name-main-menu parent-mlid-0 menu-level-2">
+  <ul class="menu nav"><li class="first collapsed menu-mlid-1205 what-we-do depth-2"><a href="/about-ministry/what-we-do">What we do</a></li>
+<li class="expanded active-trail menu-mlid-1094 legislation-and-regulation depth-2"><a href="/about-ministry/legislation-and-regulation" class="active-trail">Legislation and regulation</a><ul class="menu nav"><li class="first leaf menu-mlid-8404 changes-to-health-practitioner-status depth-3"><a href="/about-ministry/legislation-and-regulation/changes-health-practitioner-status" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Changes to health practitioner status</a></li>
+<li class="collapsed menu-mlid-1097 legislation-the-ministry-administers depth-3"><a href="/about-ministry/legislation-and-regulation/legislation-ministry-administers">Legislation the Ministry administers</a></li>
+<li class="last leaf active-trail menu-mlid-1344 regulatory-impact-statements depth-3"><a href="/about-ministry/legislation-and-regulation/regulatory-impact-statements" class="active-trail">Regulatory impact statements</a></li>
+</ul></li>
+<li class="leaf menu-mlid-1116 ministry-directorates depth-2"><a href="/about-ministry/ministry-directorates" data-is-top-level="0" title="">Ministry directorates</a></li>
+<li class="collapsed menu-mlid-1171 leadership depth-2"><a href="/about-ministry/leadership-ministry" data-is-top-level="0" title="">Leadership</a></li>
+<li class="collapsed menu-mlid-2043 careers depth-2 section-overview "><a href="/about-ministry/careers">Careers</a></li>
+<li class="collapsed menu-mlid-7684 newsletters depth-2"><a href="/about-ministry/ministry-health-newsletters" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Newsletters</a></li>
+<li class="collapsed menu-mlid-1834 corporate-publications depth-2 section-overview "><a href="/about-ministry/corporate-publications">Corporate publications</a></li>
+<li class="collapsed menu-mlid-1921 consultations depth-2 section-overview "><a href="/about-ministry/consultations">Consultations</a></li>
+<li class="collapsed menu-mlid-8330 information-releases depth-2 section-overview "><a href="/about-ministry/information-releases" class="menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished menu-node-unpublished">Information releases</a></li>
+<li class="collapsed menu-mlid-1190 contact-us depth-2"><a href="/about-ministry/contact-us" data-is-top-level="1">Contact us</a></li>
+<li class="collapsed menu-mlid-2835 ministry-websites depth-2"><a href="/about-ministry/ministry-health-websites">Ministry websites</a></li>
+<li class="collapsed menu-mlid-4325 ministry-of-health-library depth-2"><a href="/about-ministry/ministry-health-library">Ministry of Health Library</a></li>
+<li class="last collapsed menu-mlid-6061 emergency-information-for-staff depth-2"><a href="/about-ministry/emergency-information-staff">Emergency information for staff</a></li>
+</ul></div>
+  </div>
+
+  
+  </div>
+</div>      <div class='panel-panel middle col-xs-12 col-md-9 col-lg-9'><div class="panel-pane pane-page-title even" >
+  
+      
+  
+  <div class="pane-content">
+    <span id="skip-content" tabindex="-1"></span>    <h1>Quality Improvement Agency: Health Quality and Safety Commission: Functions, Powers and Funding</h1>
+  </div>
+
+  
+  </div>
+<div class="panel-pane pane-node-content odd" >
+  
+      
+  
+  <div class="pane-content">
+        <article id="node-522" class="node node-page view-mode-full clearfix" about="/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding" typeof="sioc:Item foaf:Document">
+    <header>
+            <span property="dc:title" content="Quality Improvement Agency: Health Quality and Safety Commission: Functions, Powers and Funding" class="rdf-meta element-hidden"></span>      </header>
+    <div class="field field-name-field-intro-text field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="intro-text">Published: October 2010</p></div></div></div><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><p>In December 2009 Cabinet agreed to strengthen the health sector’s focus on quality and safety by replacing the Quality Improvement Committee (QIC) with a stand alone Crown Agent, the Health Quality and Safety Commission. This regulatory impact statement considers what additional functions, powers, and funding mechanisms the Commission might need to achieve sustained quality and safety improvement across the health and disability system.</p>
+<!--break-->
+<p>Specifically, this assessment considers options for guideline setting functions, mortality review functions, powers to require information, and funding models.</p>
+<p>The options and analysis in this assessment have been informed by a Sector Advisory Group (SAG), established for the life of this project, comprising of senior doctors, nurses and health managers with expertise in quality and safety improvement. Chief executives and board chairs of a number of international quality agencies were also interviewed as part of the analysis. The key assumption underpinning this analysis is that voluntary provider participation is integral to the success of the Commission. Indeed the key to leading significant improvements in quality and safety is through clinical engagement and the provision of collaborative support. Voluntary uptake of the Commission’s quality improvement initiatives will depend on its reputation with clinicians and its capacity to form positive working relationships with the sector.</p>
+<p>None of the proposals outlined in this assessment will impair private property rights, market competition, or the incentives on health care providers to innovate and invest, or over-ride fundamental common law principles. None of the options covered in this assessment, except one, will impose additional costs on health providers, as the Commission’s role is to promote the voluntary uptake of quality improvement activities. If the option is chosen to legally require providers to provide the Commission with information, this may result in some compliance costs. This may be partially mitigated by tightly specifying the purposes for which the Commission may request information. In the Ministry’s view, the benefits associated with coordinated, national safety and quality monitoring far out-weigh this cost. A comprehensive, well developed, national set of quality and safety indicators enables targeted quality improvement activities and assessment of their effectiveness. Effective quality and safety improvement initiatives have the potential to significantly reduce medical error, mortalities and wastage across the health and disability sector.</p>
+<p><strong>Ashley Bloomfield, Deputy Director-General (Acting)<br />
+	Sector Capability and Innovation<br />
+	Ministry of Health</strong></p>
+<p>16 June 2010</p>
+<h2>
+	Problem definition and status quo</h2>
+<p>New Zealand studies suggest that there are substantial human and financial costs associated with medical error. Davis et al found that 12.9 percent of people admitted to hospital suffered an unintended injury caused in the management of their conditions, rather than the underlying disease<sup>1</sup>. Subsequent estimates suggest that preventable adverse events in the health sector cost between $320 and $590 million in 2001<sup>2</sup>. These figures are likely to be conservative, given the age of the data and the growth in health expenditure over the last decade.</p>
+<p>A Clinical Reference Group<sup>3</sup> has indicated that an annual 1–2 percent reduction in the rate of adverse events is achievable with good quality improvement techniques and training, which could reduce wasted expenditure of around $8-20 million per annum. It is important to note that these savings may not be realised as actual dollar savings. Rather, effective quality and safety activities may improve the value of health expenditure by reducing wastage and freeing resources for increased service volumes and the provision of additional services.</p>
+<p>Although the New Zealand Public Health and Disability Act 2000 (NZPHD Act) recognises the importance of quality and safety<sup>4</sup>, to date only modest quality and safety improvements have been achieved at a national level. Implementing a culture of continuous quality and safety improvement across the health sector has proved difficult. The Ministerial Review Group (MRG)<sup>5</sup> identified the following barriers:</p>
+<ul>
+	<li>
+		a lack of national coordination in undertaking some quality activity, such as data collection</li>
+	<li>
+		a narrow focus on hospital care, rather than a whole of system view</li>
+	<li>
+		short-term financial incentives on DHBs lead them to under invest in safety and quality; and</li>
+	<li>
+		a perceived lack of independence from the regulatory, funding and performance functions of the Ministry of Health, leading to a lack of confidence and ownership by health professionals in supporting quality and safety improvement.</li>
+</ul>
+<p>Quality experts argue that a strong mandate to drive quality related activities, greater coordination of appropriate quality interventions at a national level and strong clinical engagement are pivotal to achieving sustained quality gains. Accordingly in December 2009, Cabinet agreed to strengthen the health sector’s focus on quality and safety by replacing the Quality Improvement Committee (QIC)<sup>6</sup> with a stand alone Crown Agent, the Health Quality and Safety Commission (the Commission). A stand alone Crown Agent was chosen by Cabinet in recognition of the need for a separate organisation, independent of the health system’s regulatory, funding and performance monitoring functions, to maintain the confidence and engagement of health professionals.</p>
+<p>Cabinet further agreed that the Commission shall have the following functions:</p>
+<ul>
+	<li>
+		public reporting of quality and safety indicators, including initially serious and sentinel events</li>
+	<li>
+		leading and coordinating work to improve quality and safety across the health and disability system</li>
+	<li>
+		any other functions it is authorised to perform by the Minister of Health (the Minister), including the collection, analysis and dissemination of information.</li>
+</ul>
+<p>Cabinet also directed the Ministry of Health, in conjunction with the Treasury and the State Services Commission, to report back on an appropriate funding model for the Commission as well as any powers it may require for successful performance of its functions. The following assessment reflects the work underpinning this Cabinet report back as well as additional functions that might further support the Commission in achieving sustained quality and safety improvements across the health and disability system. In particular, this assessment considers the Commission’s role in relation to options for guideline setting functions, mortality review functions, powers to require information and funding models.</p>
+<h2>
+	Objectives</h2>
+<p>The functions and powers considered in this assessment have the objective of supporting the Commission in its mandate to drive sustained quality improvement, including a decrease in adverse events across the wider health system (including primary care and the private sector). The goal of the Commission will be to improve quality and safety across the health system by reducing unwarranted variation, increasing adherence to evidence-based practice and reducing the incidence of adverse events. Effective change will be measured by a decrease in adverse events and increased patient satisfaction. It should also result in greater health sector productivity and efficiency.</p>
+<h2>
+	Regulatory impact analysis</h2>
+<h3>
+	Additional Commission functions</h3>
+<h4>
+	Guideline setting functions</h4>
+<p>Internationally, quality improvement agencies perform a variety of functions, including setting high level performance indicators (Public Health Wales) and the generation of voluntary, best practice guidelines (National Institute for Health and Clinical Excellence (NICE), England). In some jurisdictions quality improvement agencies play a role in mandatory standard setting and regulation (Queensland Health Quality and Complaints Commission, Australia). This can pose issues with regards to the difficulties of combining policing and improvement roles where trust is essential to influencing practice. Locally, it is feasible that the Commission could undertake a role in voluntary guideline or mandatory standard setting in addition to the public reporting of quality and safety indicators and improvement programme functions previously conferred on it by Cabinet. It is important to note that local experts, including the Sector Advisory Group (SAG), are opposed to the Commission taking a role in mandatory standard setting. Rather this function is viewed as more appropriately the responsibility of the regulator. For this reason, mandatory standard setting has been disregarded as a viable option.</p>
+<h4>
+	Option one, status quo, (preferred option): Selected indicators and quality improvement programmes only.</h4>
+<p>Benefits:</p>
+<ul>
+	<li>
+		allows the Commission to focus energy on building reciprocal relationships and providing support to the sector</li>
+	<li>
+		allows the Commission to focus on developing high level quality and safety indicators and to concentrate its efforts on programmes aimed at improving performance against these indicators.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		potential for lack of co-ordination and disjuncture between the Commission’s programmes and best practice guidelines produced elsewhere. Regardless of the Commission’s role in this regard, guidelines will continue to be produced by other entities, for example the professional colleges.</li>
+</ul>
+<h4>
+	Option two: In addition to the status quo, voluntary best practice guidelines.</h4>
+<p>Benefits:</p>
+<ul>
+	<li>
+		development of best practice guidelines may provide the sector with additional tools to support improvement against the Commission’s quality and safety indicators</li>
+	<li>
+		allows alignment and co-ordination between quality and safety indicators, quality programmes and best practice guidelines.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		resource intensive to develop. For example, NICE in England typically take 24 months to complete best practice guidelines</li>
+	<li>
+		development of guidelines may distract the Commission from its other functions</li>
+	<li>
+		there are multiple players already producing best practice guidelines, including the World Health Organisation, the New Zealand Guidelines Group, Standards New Zealand and a number of professional associations. There is a risk of duplication and overcrowding if the Commission were afforded this function</li>
+	<li>
+		best practice guidelines developed outside of broader funding considerations risk being expensive, extravagant and impractical for providers to implement.</li>
+</ul>
+<h4>
+	Transfer of mortality review committee functions</h4>
+<p>Under section 18 of the NZPHD Act the Minister may appoint one, or more, mortality review committees (the committees), which report directly to the Minister (section 11 of the NZPHD Act). The committees<sup>7</sup> are charged with, amongst other things:</p>
+<ul>
+	<li>
+		Reporting to the Minister on ‘specified classes of deaths with a view to reducing the number of deaths and to continuous quality improvement through the promotion of ongoing quality assurance programmes<sup>8’</sup></li>
+	<li>
+		‘Developing strategic plans and methodologies that are designed to reduce morbidity and mortality<sup>9</sup>.’</li>
+</ul>
+<p>Reports produced by the committees must currently also be considered and addressed, in the form of advice to the Minister, by QIC. Following amendment of the NZPHD Act, this responsibility will transfer to the Commission. The committee’s secretariat is currently located within the Ministry.</p>
+<p>There are significant synergies between the work of the Commission and the committees. With the amendment of the NZPHD Act, the Commission will have responsibility for public reporting of serious and sentinel events, a responsibility which has clear links with the mortality measurement and review functions of the committees. Both the Commission and the committees are also charged with providing advice on quality improvement and quality assurance programmes aimed at reducing morbidity and mortalities. These synergies mean that the committees and the Commission require similar expertise and are reliant on close communications. For these reasons, it is important to consider if there may be efficiencies in transferring the committees and their functions from the Ministry to the Commission.</p>
+<p>Consultation with the committee’s chairs revealed a range of views with regards to the transfer of mortality functions to the Commission. The Family Violence Death Mortality Review Committee expressed concern that transfer of its functions would hinder its ability to influence cross-sector change, whilst the Perinatal and Maternal Mortality Review Committee, and Perioperative Mortality Review Committee all saw considerable benefit and synergies in the transfer of their functions to the Commission. The Child and Youth Mortality Review Committee’s views sat in the middle of this continuum. Therefore, whilst the transfer of mortality review functions to the Commission may be of advantage to some of the committees, it is less advantageous to others. The interests of the full spectrum of committees and their functions will need to be carefully balanced. Whichever approach is taken, the Ministry stresses the importance of the committees’ shared secretariat remaining intact, so as to retain secretariat capacity.</p>
+<h4>
+	Option one, status quo:</h4>
+<p>Mortality review committees remain as section 11 Ministerial committees, reporting directly to the Minister with secretariat support remaining in the Ministry.</p>
+<p>Under this option, the Minister would need to refer the mortality review committees’ reports to the Commission to provide him/her with advice on the matters they raise.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		committees have direct report and influence with the Minister</li>
+	<li>
+		committees retain the gravitas and status associated with being a Ministerial committee</li>
+	<li>
+		committees considering mortalities with broader social determinants beyond the health sector may be better placed within the Ministry to influence at an inter-sectoral, cross government level (eg, Family Violence Death Mortality Review Committee or Child and Youth Mortality Review Committee).</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		loss of potential synergies and efficiencies that might be achieved by transferring functions of the mortality review committees to the Commission, particularly given the Commission’s role in developing quality and safety programmes, setting indicators, and reporting on serious and sentinel events.</li>
+</ul>
+<h4>
+	Option two:</h4>
+<p>The Commission’s governing board must re-establish, as statutory standing committees within the Commission, the existing mortality committees.</p>
+<p>Under this option secretariat capacity and expertise would transfer, with the mortality review committees, from the Ministry to the Commission.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		enables strengthened synergies between the quality and safety improvement functions of the committees and the quality and safety improvement focus of the Commission</li>
+	<li>
+		committees can leverage off the Commission’s clinical and sector relationships. Due to the supportive, non-regulatory role of the Commission these relationships are likely to be stronger than those of the Ministry</li>
+	<li>
+		committees are likely to have more direct input into the quality and safety improvement programmes developed by the Commission. This will be most valuable for committees seeking to influence determinants located within the health sector (eg, Perioperative Mortality Review Committee and Perinatal and Maternal Mortality Review Committee)</li>
+	<li>
+		ensures continuation of the committees and the functions they fulfil.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		loss of direct report and influence with the Minister</li>
+	<li>
+		committees considering mortalities with broader social determinants than the health sector are less well placed to influence at an inter-sectoral, cross government level (eg, family violence or child and youth)</li>
+	<li>
+		potential loss of momentum in transferring the committees and their functions.</li>
+</ul>
+<h4>
+	Option three:</h4>
+<p>The Commission undertakes section 18 functions as it sees fit.</p>
+<p>As an interim step, the Commission could be required to establish committees (reflecting the current committees and membership) to ensure continuity while the Commission establishes itself and determines how best to organise any mortality review functions. Under this option secretariat capacity and expertise would transfer from the Ministry to the Commission.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		gives Commission flexibility in the means by which it operationalises its mortality review functions</li>
+	<li>
+		enables strengthened synergies between the quality and safety improvement functions of the committees and the quality and safety improvement focus of the Commission.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		loss of direct report and influence with the Minister</li>
+	<li>
+		risks diluting the Commission’s emphasis on the mortality review functions that the committees currently fulfil</li>
+	<li>
+		potential loss of momentum in transferring committee functions.</li>
+</ul>
+<p>The mortality review committees have existing powers to require information. Under options two and three these powers would transfer to the Commission, but would apply only with respect to the Commission’s mortality review functions. As this is a transfer of existing requirements from the Ministry to the Commission, it will not place additional burden on DHBs or private providers. Options two and three are also cost neutral, with the operational cost of the mortality review functions transferring from Ministry baselines to the Commission. None of the options canvassed above will increase Vote Health baselines.</p>
+<h2>
+	Powers required by the Commission to enable performance of its functions</h2>
+<h3>
+	Power to require information</h3>
+<p>Effective improvement comes from good quality analysis that points to where the opportunities are, helps measure when those improvements have been made and sustains them by continuously identifying the next best opportunity. Clearly the collection of information is pivotal to the success of such analysis. What is not so clear is whether the provision of information should be voluntary, or whether providers should be compelled to provide information with respect to quality and safety indicators as set by the Commission. The trade-off here is between the Commission’s ability to measure against accurate and encompassing quality and safety indicators versus the importance of clinician engagement and goodwill which is best fostered through voluntary participation.</p>
+<h4>
+	Option one:</h4>
+<p>Voluntary provision of information by providers.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		both the MRG and SAG have emphasised the importance of voluntary participation. The key to leading significant improvements in quality and safety is through clinical engagement and supporting clinicians to make positive changes themselves. From this perspective, there is likely to be value in applying the principle of voluntary participation to the provision of information.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		voluntary provision of information is unlikely to allow development of truly national quality and safety indicators, compromising the Commission’s ability to monitor the performance of the health sector in its entirety. A lack of national coordination in undertaking quality activities, such as data collection, was one of the key barriers to sustained quality improvement identified by the MRG. (Note: the provision of information in relation to mortality review functions will remain mandatory, see above)</li>
+	<li>
+		there is a risk of self-selection bias for participating providers, ie, only high or, alternatively, poor performing providers may choose to participate, thereby compromising the relevance and accuracy of the Commission’s quality and safety indicators.</li>
+</ul>
+<h4>
+	Option two, (preferred option):</h4>
+<p>Compulsion on providers to provide information for specified purposes; eg, to require information with respect to quality and safety indicators as set by the Commission.</p>
+<p>Under this option the Commission would be expected to obtain information through a ‘partnership’ approach, relying on its legislative powers only as a last resort and with the approval of the Minister of Health.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		helps to ensure comprehensive information is available to support the development of quality and safety indicators across the health sector, ie, that indicators capture all providers</li>
+	<li>
+		allows comparative analysis of quality and safety performance and variation between providers and DHBs. Allows analysis of the reasons behind variations in outcomes and performance.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		compulsion may undermine clinical engagement and the goodwill needed to ensure quality and safety improvement programmes are implemented</li>
+	<li>
+		places compliance burden on DHBs and private providers who already face significant transaction costs associated with the existing regulatory and monitoring framework.</li>
+</ul>
+<h2>
+	Funding models</h2>
+<p>To ensure the relevance and sector focus of the Commission’s quality improvement activities, the MRG recommended its funding be via a mix of ‘fee-based quality programmes and financial subscriptions from public and private member organisations.’ In addition to the provision of quality improvement programmes, the Commission will also undertake a number of ‘public good’ functions, such as developing, measuring and reporting against indicators and advising the Minister. As a Crown entity, the Commission will also be required to meet statutory obligations associated with governance and accountability.</p>
+<p>Treasury’s Guidelines for Setting Charges in the Public Sector identifies three types of ‘goods’ that determine appropriate sources of funding: public goods, private goods and industry or club goods:</p>
+<ul>
+	<li>
+		Public Good: excluding people from the benefits of a public good is either difficult or costly and its use by one person does not prevent its use by another person. Public goods should be government (taxpayer) funded.</li>
+	<li>
+		Private Good: people can be excluded from the benefits of a private good if they do not pay for it, and its use by one person conflicts with its use by another (so there is an additional cost incurred in providing the service to another person). Private goods should be funded by the users or beneficiaries (or those whose actions create the risk if applicable).</li>
+	<li>
+		Club Good or Industry Good: a club good has some characteristics of a public good, in that its use by one person does not detract from its use by another, but either people can be excluded from the benefits of the good at low cost, or the beneficiaries are a narrow identifiable group. Industry/club goods should be funded by the identified groups of the users or beneficiaries (or risk makers).</li>
+</ul>
+<p>An analysis of the potential outputs of the Commission against Treasury’s guidelines, as summarised in the table below, suggests that the Commission might best be funded by a mix of Crown funding and charging for programmes and services.</p>
+<table border="1" cellpadding="1" cellspacing="1" class="table-style-two" summary="Analysis of the potential outputs of the Commission against Treasury’s guidelines suggests that the Commission might best be funded by a mix of Crown funding and charging for programmes and services.">
+	<caption>
+		Analysis of the potential outputs of the Commission against Treasury’s guidelines</caption>
+	<thead>
+		<tr>
+			<th scope="col">
+				<strong>Function</strong></th>
+			<th scope="col">
+				<strong>Type of good</strong></th>
+			<th scope="col">
+				<strong>Who pays</strong></th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>
+				Governance; leading and coordinating work to improve quality and safety<sup>10</sup>; s17 functions; mortality revew functions<sup>11</sup>; Health Information and Innovation Resource Centre</td>
+			<td>
+				Public</td>
+			<td>
+				Crown</td>
+		</tr>
+		<tr>
+			<td>
+				Public reporting of quality and safety indicators</td>
+			<td>
+				Public</td>
+			<td>
+				Crown</td>
+		</tr>
+		<tr>
+			<td>
+				National Quality Improvement Programmes and any other products</td>
+			<td>
+				Club or industry good</td>
+			<td>
+				Industry<br />
+				(providers/health professionals)</td>
+		</tr>
+		<tr>
+			<td>
+				Education and professional development</td>
+			<td>
+				Club or industry good</td>
+			<td>
+				Industry<br />
+				(providers/health professionals)</td>
+		</tr>
+	</tbody>
+</table>
+<p>Whilst the above table suggests a mixed funding model may be preferable, it is feasible that the Commission may be fully Crown funded or, alternatively, may be entirely self-funded through service charges and subscription fees.</p>
+<p>The voluntary nature of the Commission’s safety and quality improvement programmes places it as a provider of products and services that may be freely purchased, or not, by providers. Legislative change would only be required if provider participation in the Commission’s programmes were mandatory. Given that voluntary participation is considered integral to the success of the Commission, this approach is not seen as feasible. Rather, in the Ministry’s view, reputation concerns and the existing accountability and monitoring framework may more appropriately be used as levers to encourage provider participation in the Commission’s programmes.</p>
+<h4>
+	Option one:</h4>
+<p>Commission fully funded by the Crown, including quality improvement programmes and products.<br />
+	Crown funding will need to come from within Vote Health baselines.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		provides a greater degree of security of funding for the Commission, thereby ensuring stability</li>
+	<li>
+		in SAG’s view, the full scope of the Commission’s services are public goods reflecting the Government’s commitment to improving health safety and quality for the benefit of New Zealand citizens. From this perspective, the Crown’s investment will manifest itself in other parts of the sector, through reduced morbidity and mortality, increased throughput, reduced waiting times and reduced bed utilisation.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		may not encourage the Commission to seek efficiencies and could lead to ‘gold-plating’, though this could be managed via the accountability framework</li>
+	<li>
+		private providers would effectively free-ride.</li>
+</ul>
+<h4>
+	Option two:</h4>
+<p>Full cost recovery from providers through fee-based quality improvement programmes and financial subscriptions from member providers.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		the charge of improvement programmes and products falls on DHBs and private providers, who are in a good position to monitor standards, exert countervailing pressure on costs, and hold the agency to account by either raising concerns or by not purchasing certain services</li>
+	<li>
+		charging private providers is consistent with the safety and quality risks they can generate, the costs of which may fall on the public health system</li>
+	<li>
+		minimises costs to the taxpayer.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		DHBs and private providers may under-invest in quality due to short-term financial pressures, a lack of information about the benefits of quality improvement activity, or a lack of information about the Commission’s performance, particularly in its first few years</li>
+	<li>
+		consultation on the MRG recommendations showed concern that the Commission could become focused on revenue raising at the expense of independent analysis and supporting the sector</li>
+	<li>
+		there is a risk that the Commission may fail to generate enough revenue to function, particularly in its first few years</li>
+	<li>
+		SAG considered that cost recovery through a charging model would be inappropriate as the return on the Crown’s investment will occur in another part of the sector at a later time, eg, through reduced morbidity and mortality, increased throughput, reduced bed utilisation, and reduced waiting times</li>
+	<li>
+		sector providers bear costs for certain activities not directly related to quality and safety improvement programmes. eg, Commission providing advice to Minister and production of accountability documents.</li>
+</ul>
+<h4>
+	Option three (preferred option):</h4>
+<p>The Commission partially funded by the Crown and partially by charging providers for quality improvement programmes and products. Under this option a phased approach could be taken, with the Commission being fully Crown funded for the first two to three years of its operation while it establishes itself. After this period, the Commission would be expected to become partially self-funded through provider charges. As with Option One, Crown funding will need to come from within Vote Health baselines.</p>
+<p>Benefits:</p>
+<ul>
+	<li>
+		analysis of Treasury’s Guidelines for Setting Charges in the Public Sector suggests that a mixed funding model best reflects the Committees’ functions</li>
+	<li>
+		dual benefits of some stability from Crown funding, as well as incentives to remain relevant to DHBs and private providers.</li>
+</ul>
+<p>Costs:</p>
+<ul>
+	<li>
+		DHBs and private providers may still under-invest in quality, for the same reasons outlined under option two</li>
+	<li>
+		the Commission may become focused on revenue raising at the expense of independent analysis and best practice approaches to quality and safety improvement.</li>
+</ul>
+<h2>
+	Consultation</h2>
+<p>The options considered in this assessment have been informed by a Sector Advisory Group (SAG) established for the life of this project, comprising of senior doctors, nurses and health managers with expertise in quality and safety. It was the general view of SAG that the Commission must rely on winning hearts and minds and that this should be the basis of its ‘power’. SAG members were generally concerned that dependence on legislative powers could detract from the Commission’s ability to build a culture of continuous quality and safety improvement across the whole of the system.</p>
+<p>A later, more in-depth discussion with the Commission’s interim board showed a strong consensus that the power to require information from providers (both private and public) would be essential to ensuring the Commission’s success. The Commission’s interim board also agreed that the Commission’s power to require information should be for clearly specified purposes only.</p>
+<p>In terms of funding models, most SAG members held the view that the full scope of the Commission’s services are public goods, reflecting the government’s commitment to improving health safety and quality for the benefit of New Zealand citizens. Therefore, in SAG’s view, those services are appropriately funded by the Crown. There was a minority view that private sector providers should be charged for programmes, and that all providers could be charged for education and training.</p>
+<p>The mortality review committee chairs were also consulted on whether or not their functions should be transferred to the Commission. There was a continuum of views, with the Family Violence Death Mortality Review Committee expressing concern that transfer of its functions would hinder its ability to effect cross-sector change, through to the Perinatal and Maternal Mortality Review Committee, and Perioperative Mortality Review Committee which saw considerable benefit and synergies in the transfer of their functions to the Commission. The Child and Youth Mortality Review Committee’s views sat in the middle of this continuum. Each of the committees expressed some concern regarding the loss of direct influence with the Minister, which was seen as a key benefit of their current status as Ministerial committees.</p>
+<p>Extensive feedback was also received by the Minister on the original MRG report. This feedback has also informed the options covered in this assessment. Submissions showed broad support for an increased focus on clinician led, quality improvement initiatives. DHBs, clinician professional associations and primary care providers all supported a focus on community based services, in addition to hospital based services. A number of submissions showed concern that a self-funding quality agency could become preoccupied with revenue sources rather than independent analysis and reporting.</p>
+<p>A broad range of options for Commission functions, powers and the funding model for the Commission were discussed with an officials’ group comprising the Treasury, State Services Commission and the Department of Prime Minister and Cabinet. This discussion informed the options and analysis in this assessment. The officials’ group supported charging for programmes and education activities but recognise that some Commission functions are public good activities and should therefore be funded by the Crown. Treasury in particular raised the concern that providers, including DHBs, may fail to participate in quality improvement programmes, particularly if provided at a charge.</p>
+<p>The Health and Disability Commissioner, the Accident Compensation Corporation (ACC) and the Ministry of Justice were consulted and broadly supportive of the preferred options canvassed in this assessment. ACC noted some concern regarding a mixed funding approach and queried whether DHBs would willingly participate in fee-based quality improvement programmes. The Ministries of Social Development and Women’s Affairs were consulted specifically on the transfer of the family violence mortality review function to the Commission. These two agencies were of the view that the Family Violence Death Mortality Review Committee does not fit well within the ambit of the Commission, whose primary focus is improving quality and safety across the health and disability system. Rather, in their view, family violence is a cross-cutting social, criminal justice and public health issue, requiring a whole of system response.<br />
+	Back to top</p>
+<h2>
+	Conclusions and recommendations</h2>
+<p>The above regulatory impact analysis summarises the range of advantages and costs associated with options for guideline setting, the transfer of mortality review functions, powers to require information and funding models. From this analysis, the following conclusions can be drawn.</p>
+<h3>
+	Guideline setting functions</h3>
+<p>It is the Ministry’s view that mandatory standard setting would not support the objectives of the Commission. This view is clearly supported by SAG. Rather, it is important that regulatory functions remain outside the Commission, allowing it to focus on providing support to the sector in a spirit of partnership and trust. There could be benefits, however, in the Commission taking a role in voluntary guideline setting. Commission guidelines may provide the sector with additional tools to support quality and safety improvements, however there is a risk of overcrowding and duplication given that a number of entities, both internationally and locally, already provide this function. It is also possible that the development of resource intensive guidelines will detract the Commission from its other functions.</p>
+<h3>
+	Mortality review functions</h3>
+<p>As discussed above, there are significant synergies between the work of the Commission and the committees. Transfer of the committees, or the committees’ functions, may enable these synergies to be maximised to optimal advantage. Such an approach would, however, cost the committees direct influence with the Minister, a key benefit of the committees’ current status as Ministerial committees. Consultation also indicated that whilst transfer of the committees’ functions to the Commission may be of advantage to some of the committees, the Family Violence Death Mortality Review Committee felt that this approach would hinder its ability to effect cross-sector change. The interests of the full spectrum of committees and their functions will need to be carefully balanced when taking this decision. Whichever approach is taken, the Ministry stresses the importance of the committees’ shared secretariat remaining intact, so as to retain secretariat capacity and critical mass.</p>
+<p>If mortality review functions were transferred to the Commission, the committees could either be established as statutory standing committees or the Commission could undertake its mortality review functions as it sees fit. Whilst the former approach would ensure continuation of the committees as they are currently structured, the latter option would afford the Commission greater operational flexibility.</p>
+<h3>
+	Powers to require information</h3>
+<p>Good information and data is integral to an effective safety and quality improvement strategy. High quality information enables assessment of performance across the health sector as well as analysis of the drivers behind unwarranted variations in clinical outcomes. In the Ministry’s view, it is unlikely that the Commission could effectively monitor and address the safety and quality of the health and disability sector at a national level in the absence of a power to require information from providers. If the Commission were afforded the power to require information, it should be expected to do so through a ‘partnership’ approach, relying on its legislative powers only in instances of last resort. The Commission should not have an unbounded ability to require information from providers. Rather, legislation will need to clearly specify the purposes for which the Commission may require information.</p>
+<h3>
+	Funding models</h3>
+<p>There are several options for funding models to support the Commission, ranging from full Crown funding through to full self-funding/cost recovery via fee-based quality improvement programmes and financial subscriptions. The Ministry recommends a mixed funding model, i.e., that the Commission be partially funded by the Crown and partially self-funded by charging providers for quality improvement programmes and products. This approach would provide the dual benefits of stability from Crown funding, as well as incentives on the Commission to remain relevant to DHBs and private providers. If a mixed funding model were chosen, the Ministry recommends a phased approach. The Ministry recommends that the Commission be fully Crown funded for two to three years, thus allowing the Commission to establish itself in a stable funding environment. After this period, the Commission should be expected to partially self-fund via provider charges.</p>
+<h3>
+	Implementation</h3>
+<p>To support a smooth transition process to the new arrangements, the Quality Improvement Committee will be replaced with an interim board charged with overseeing the Commission’s establishment. The Ministry has also formed an establishment unit to support the interim board and undertake the preparatory work required for establishing the Commission. The interim board and establishment unit are responsible for transitioning the existing quality improvement work programme, of both QIC and the Ministry, to the interim entity.</p>
+<h4>
+	Interim steps</h4>
+<p>Appoint interim board to direct establishment of the Commission (see above).</p>
+<h4>
+	Medium term steps (from July 2010)</h4>
+<p>Recruitment of executive leader<br />
+	Minister’s letter of expectations<br />
+	Statement of Intent and work programme development<br />
+	Transfer contracts, funding and staff from Ministry to the Commission<br />
+	Formal Board appointment when NZPHD Act amendment passed<br />
+	Statement of Intent agreed with Minister</p>
+<h4>
+	Longer term steps (from 2011)</h4>
+<p>Transfer of mortality review committees, including funding, staff and assets<br />
+	In third year, 2012/13, introduction of expectation that the Commission begin charging for selected quality improvement programmes.</p>
+<h2>
+	Monitoring, evaluation and review</h2>
+<p>The Commission will be expected to collect information to measure the impact of its programmes, both qualitatively and quantitatively, on improving quality and safety and any resulting cost savings or productivity improvement. After five years of operation the Commission will be expected to undertake and provide the Minister with an evaluation of the impact of its activities.</p>
+<p>In addition to this the Ministry will be responsible for ongoing monitoring of the performance of the Commission, including financial performance, against agreed accountability documents on the Minister’s behalf. The Ministry, as the key policy and budget advisor to the Minister of Health, will also provide him / her with advice on any specific proposals that have funding implications for Vote Health.</p>
+<p>Beyond the standard monitoring processes, Cabinet has also agreed to a further review of the DHB model within the next three years. This review will assess whether more fundamental reform will be needed to create strong enough incentives for efficiency, and to enable the sector to lift its performance within a more sustainable growth track. This will include an assessment of the extent to which the Commission has been effective in improving quality and safety performance across the health sector.</p>
+<h2>
+	Footnotes</h2>
+<ol>
+	<li>
+		Davis P, Lay-Yee R, Briant R, Alim W, Scott A, and Schug S. Adverse events in New Zealand public hospitals 1: Occurrence and impact. New Zealand Medical Journal (2002) 115:1167.</li>
+	<li>
+		Brown P, McArthur C, Newby L, Lay-Yee R, Davis P, and Briant R. Cost of medical injury in New Zealand: a retrospective cohort study. Journal of Health Services Research and Policy (2002) 7:29–34.</li>
+	<li>
+		A Clinical Reference Group was established in November 2009, at the request of the Minister of Health, to provide advice on the Ministerial Review Group recommendation that an independent national quality agency be established to replace the Quality Improvement Committee.</li>
+	<li>
+		The NZPHD Act 2000, s9(1)(a) and (b), requires the Minister of Health to determine a strategy for the development and use of:
+		<ul>
+			<li>
+				nationally consistent standards and quality assurance programmes for health services and consumer safety; and</li>
+			<li>
+				nationally consistent performance monitoring of health services and consumer safety against those standards and programmes.</li>
+		</ul>
+	</li>
+	<li>
+		Ministerial Review Group Meeting the Challenge: Enhancing Sustainability and the Patient and Consumer Experience within the Current Legislative Framework for Health and Disability Services in New Zealand (2009).</li>
+	<li>
+		The Quality Improvement Committee was established as a section 11 Ministerial Committee to advise the Minister on health epidemiology and quality assurance matters (section 17 NZPHD Act).</li>
+	<li>
+		Currently the following mortality review committees have been established: Perinatial and Maternal Mortality Review Committee; Child and Youth Mortality Review Committee; Perioperative Mortality Review Committee; and Family Violence Death Review Committee. In addition, time-limited committees are occasionally established in response to specific issues, for example, the Pandemic Influenza Mortality Review Committee.</li>
+	<li>
+		Section 18 (1)(a) of the New Zealand Public Health and Disability Act 2000.</li>
+	<li>
+		Section 18 (2)(a) of the New Zealand Public Health and Disability Act 2000.</li>
+	<li>
+		Aspects of these functions will be overheads related to Quality Improvement Programmes and Education/Professional Development which could be cost-recovered through fees charged for those services.</li>
+	<li>
+		Advice to the Minister on any health epidemiology or quality assurance matter; ensuring, to the maximum extent practicable, national coordination in reporting relevant health epidemiology and quality assurance matters and that there is a capacity to improve health outcomes through quality assurance programmes directed to clinical providers; considering all reports from any mortality review committees and providing advice to the Minister on appropriate quality assurance programmes to institute and respond to those and other relevant reports. </li>
+</ol>
+</div></div></div>    <footer>
+          </footer>
+    </article>
+  </div>
+
+  
+  </div>
+<div class="panel-pane pane-node-links even" >
+  
+      
+  
+  <div class="pane-content">
+          </div>
+
+  
+  </div>
+</div>          </div>
+  
+  </div>
+
+</section> <!-- /.block -->
+  </div>
+      </section>
+
+      
+    </div>
+    <div id="content-footer-wrapper" class="clearfix">
+      <div id="content-footer" class="clearfix">
+                  <p class="page_updated">Page last updated: <span class="date">07 April 2011</span></p>                  <div class="region region-content-footer">
+    <section id="block-moh-tools-page-tools" class="block block-moh-tools clearfix">
+  <a href="#"
+        data-placement="top"
+        data-title="Share this content."
+        data-html="true"
+        data-content="<p>Share this page on some of the most popular social networking and content sites on the internet.</p><div class='service-links'><ul><li class='first'><a href='http://twitter.com/share?url=https%3A//www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding&text=Quality%20Improvement%20Agency%3A%20Health%20Quality%20and%20Safety%20Commission%3A%20Functions%2C%20Powers%20and%20Funding' title='Share this on Twitter' class='service-links-twitter' rel='nofollow'><img typeof='foaf:Image' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/twitter.png' alt='Twitter' /> Twitter</a></li>
+<li class='last'><a href='http://www.facebook.com/sharer.php?u=https%3A//www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding&t=Quality%20Improvement%20Agency%3A%20Health%20Quality%20and%20Safety%20Commission%3A%20Functions%2C%20Powers%20and%20Funding' title='Share on Facebook.' class='service-links-facebook' rel='nofollow'><img typeof='foaf:Image' src='https://www.health.govt.nz/sites/all/modules/contrib/service_links/images/facebook.png' alt='Facebook' /> Facebook</a></li>
+</ul></div>" class="share-this-content"><i class="fa fa-share"></i> Share</a><a href="#" title="print this page" class="print"><i class="fa fa-print"></i> Print</a><a href="https://www.health.govt.nz/forward?path=node/522" title="Email this page" class="email"><i class="fa fa-envelope"></i> Email</a><a href="/feedback?ref=https%3A//www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding" title="Feedback" class="rss"><i class="fa fa-comment"></i> Feedback</a></section>
+
+  </div>
+      </div>
+    </div>
+
+  </div>
+  <footer class="footer container">
+    <h2 class='hidden'>Site Footer</h2>
+    <div class="footer-default">
+      <div class="row">
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-first-column-links">
+            <ul class="field-items"><li class="field-item"><a
+                href="https://www.health.govt.nz/node/492"
+                class=""
+                >About this site</a
+              ></li><li class="field-item"><a
+                href="https://www.health.govt.nz/node/524"
+                class=""
+                >Contact us</a
+              ></li><li class="field-item"><a
+                href="https://www.health.govt.nz/node/488"
+                class=""
+                >Other Ministry of Health websites</a
+              ></li><li class="field-item"><a
+                href="https://www.health.govt.nz/node/7497"
+                class=""
+                >Official Information Act requests</a
+              ></li><li class="field-item"><a
+                href="https://www.health.govt.nz/about-ministry/information-releases"
+                class=""
+                >Information releases</a
+              ></li><li class="field-item"><a
+                href="https://consult.health.govt.nz/"
+                class=""
+                >Consultations</a
+              ></li></ul>
+          </div>
+        </div>
+        <div class="col-sm-6 col-md-6">
+          <div class="field field-name-field-tax-footer-body field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><h3>Where to go for help</h3>
+
+<table>
+	<tbody>
+		<tr>
+			<th scope="row">Emergencies</th>
+			<td><strong>Dial <a href="tel:111">111</a></strong> (for ambulance, fire or police)</td>
+		</tr>
+		<tr>
+			<th scope="row">Healthline</th>
+			<td><strong>Dial <a href="tel:0800611116">0800 611 116</a></strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Poisons</th>
+			<td><strong>Dial <a href="tel:0800764766">0800 POISON</a> </strong>(<a href="tel:0800764766">0800 764 766</a>)</td>
+		</tr>
+		<tr>
+			<th scope="row">Mental health crisis</th>
+			<td><strong><a href="/your-health/services-and-support/health-care-services/mental-health-services/crisis-assessment-teams">Emergency contact numbers</a></strong></td>
+		</tr>
+	</tbody>
+</table>
+</div></div></div>        </div>
+      </div>
+      <div class="row">
+        <div class="sub-footer">
+          <div class="column col-sm-12 col-md-3">
+            <a href="https://www.govt.nz/">
+              <img src="/sites/all/themes/mohpub_bootstrap/images/nzgovtlogo_white.png"
+                   width="152" height="16"
+                   alt="govt.nz - connecting you to New Zealand central & local government services"
+                   title="govt.nz - connecting you to New Zealand central & local government services" />
+            </a>
+          </div>
+          <div class="column col-sm-12 col-md-9">
+          <span class="bottom-menu-moh with-v-divider">© Ministry of Health – Manatū Hauora</span><ul class="bottom-menu-list"><li class="bottom-menu-list-item with-v-divider"><a href="https://www.health.govt.nz/sitemap"class="">Site map</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://www.health.govt.nz/about-site/privacy-and-security"class="">Privacy & security</a></li><li class="bottom-menu-list-item with-v-divider"><a href="https://www.health.govt.nz/about-site/copyright"class="">Copyright</a></li></ul>          </div>
+        </div>
+      </div>
+    </div>
+    <div class="footer-print">© Ministry of Health – Manatū Hauora</div>
+  </footer>
+  <a class="scrollToTop">Back to top <i class="fa fa-arrow-up"></i></a>
+</div>
+  <script src="https://www.health.govt.nz/sites/default/files/js/js_akZOsKtodu3PdnQzY3_ElOfujkLxJcowmaWgHTBBLOE.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Here is an example page which currently has an incorrectly parsed date:

https://www.health.govt.nz/about-ministry/legislation-and-regulation/regulatory-impact-statements/quality-improvement-agency-health-quality-and-safety-commission-functions-powers-and-funding

The HTML which is extracted to find the date string is

```html
<p class="page_updated">Page last updated: <span class="date">07 April 2011</span></p>
```

Currently the extracted date is `201107-04-07` because the selector matches multiple elements (`p.page_updated`, `span.date`) which overlap resulting in the extracted text being:

```
"Page last updated: 07 April 201107 April 2011"
```

This pull request fixes this bug by mapping over each matched element and attempting to parse it as a date, returning the first successful match from that selector. With the fix, the date on this page is
correctly parsed as `2017-04-07`.