### PR TITLE
fix: only use entry-title selector when only one entry-title exists

### DIFF
--- a/packages/metascraper-title/index.js
+++ b/packages/metascraper-title/index.js
@@ -13,7 +13,7 @@ module.exports = () => ({
     wrap($ => $('meta[property="og:title"]').attr('content')),
     wrap($ => $('meta[name="twitter:title"]').attr('content')),
     wrap($ => $('.post-title').text()),
-    wrap($ => ($('.entry-title').length === 1 ? $('.entry-title').text() : '')),
+    wrap($ => $filter($, $('.entry-title'))),
     wrap($ => $('h1[class*="title" i] a').text()),
     wrap($ => $('h1[class*="title" i]').text()),
     wrap($ => $filter($, $('title')))

--- a/packages/metascraper-title/index.js
+++ b/packages/metascraper-title/index.js
@@ -13,7 +13,7 @@ module.exports = () => ({
     wrap($ => $('meta[property="og:title"]').attr('content')),
     wrap($ => $('meta[name="twitter:title"]').attr('content')),
     wrap($ => $('.post-title').text()),
-    wrap($ => $('.entry-title').text()),
+    wrap($ => ($('.entry-title').length === 1 ? $('.entry-title').text() : '')),
     wrap($ => $('h1[class*="title" i] a').text()),
     wrap($ => $('h1[class*="title" i]').text()),
     wrap($ => $filter($, $('title')))


### PR DESCRIPTION
Hi,

I came across [this website](https://ministryofstartups.com/), which doesn't have any of the social meta tags (`'og:title'`, `'twitter:title'`), but has multiple `.entry-title` classes. This caused the package to create a really long, somewhat nonsensical title for this page.

I think it only really makes sense to use a `.entry-title` selector when there is only one present on the page.

Let me know what you think of this change.

Cheers.