### PR TITLE
Add AMP url package

### DIFF
--- a/packages/metascraper-amphtml/.npmrc
+++ b/packages/metascraper-amphtml/.npmrc
@@ -1,0 +1,4 @@
+unsafe-perm=true
+save-prefix=~
+shrinkwrap=false
+save=false

--- a/packages/metascraper-amphtml/README.md
+++ b/packages/metascraper-amphtml/README.md
@@ -1,0 +1,19 @@
+# metascraper-url
+
+[![npm](https://img.shields.io/npm/v/metascraper-url.svg?style=flat-square)](https://www.npmjs.com/package/metascraper-url)
+[![Dependency Status](https://david-dm.org/microlinkhq/metascraper.svg?path=packages/metascraper-url&style=flat-square)](https://david-dm.org/microlinkhq/metascraper?path=packages/metascraper-url)
+
+> Get amphtml URL from HTML markup.
+
+## Install
+
+```bash
+$ npm install metascraper-amphtml --save
+```
+
+## License
+
+**metascraper-url** © [microlink.io](https://microlink.io), Released under the [MIT](https://github.com/microlinkhq/metascraper-url/blob/master/LICENSE.md) License.<br>
+Authored and maintained by microlink.io with help from [contributors](https://github.com/microlinkhq/metascraper-url/contributors).
+
+> [microlink.io](https://microlink.io) · GitHub [@microlink.io](https://github.com/microlinkhq) · Twitter [@microlinkhq](https://twitter.com/microlinkhq)

--- a/packages/metascraper-amphtml/README.md
+++ b/packages/metascraper-amphtml/README.md
@@ -1,7 +1,4 @@
-# metascraper-url
-
-[![npm](https://img.shields.io/npm/v/metascraper-url.svg?style=flat-square)](https://www.npmjs.com/package/metascraper-url)
-[![Dependency Status](https://david-dm.org/microlinkhq/metascraper.svg?path=packages/metascraper-url&style=flat-square)](https://david-dm.org/microlinkhq/metascraper?path=packages/metascraper-url)
+# metascraper-amphtml
 
 > Get amphtml URL from HTML markup.
 
@@ -13,7 +10,3 @@ $ npm install metascraper-amphtml --save
 
 ## License
 
-**metascraper-url** © [microlink.io](https://microlink.io), Released under the [MIT](https://github.com/microlinkhq/metascraper-url/blob/master/LICENSE.md) License.<br>
-Authored and maintained by microlink.io with help from [contributors](https://github.com/microlinkhq/metascraper-url/contributors).
-
-> [microlink.io](https://microlink.io) · GitHub [@microlink.io](https://github.com/microlinkhq) · Twitter [@microlinkhq](https://twitter.com/microlinkhq)

--- a/packages/metascraper-amphtml/index.js
+++ b/packages/metascraper-amphtml/index.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { url: isUrl } = require('@metascraper/helpers')
+
+/**
+ * Wrap a rule with validation and formatting logic.
+ *
+ * @param {Function} rule
+ * @return {Function} wrapped
+ */
+
+const wrapUrl = rule => ({ htmlDom, url }) => {
+  const value = rule(htmlDom)
+  return isUrl(value, { url })
+}
+
+/**
+ * Rules.
+ */
+
+module.exports = () => ({
+  amphtml: [
+    wrapUrl($ => $('link[rel="amphtml"]').attr('href'))
+  ]
+})

--- a/packages/metascraper-amphtml/package.json
+++ b/packages/metascraper-amphtml/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-url"
+    "url": "https://github.com/microlinkhq/metascraper/tree/master/packages/metascraper-amphtml"
   },
   "bugs": {
     "url": "https://github.com/microlinkhq/metascraper/issues"

--- a/packages/metascraper-amphtml/package.json
+++ b/packages/metascraper-amphtml/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "metascraper-amphtml",
+  "description": "Get the AMP url from HTML markup",
+  "homepage": "https://metascraper.js.org",
+  "version": "5.7.4",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-url"
+  },
+  "bugs": {
+    "url": "https://github.com/microlinkhq/metascraper/issues"
+  },
+  "keywords": [
+    "metascraper",
+    "url"
+  ],
+  "dependencies": {
+    "@metascraper/helpers": "^5.7.4"
+  },
+  "devDependencies": {
+    "standard": "latest"
+  },
+  "engines": {
+    "node": ">= 8"
+  },
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "test": "exit 0"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
This adds support to extract a publisher's Google AMP html tag from the header.