### PR TITLE
[metascraper-helpers] jsonld caching

### DIFF
--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -37,7 +37,7 @@ const isIso = require('isostring')
 const toTitle = require('title')
 const isUri = require('is-uri')
 const { URL } = require('url')
-const mem = require('mem')
+const memoizeOne = require('memoize-one')
 
 const VIDEO = 'video'
 const AUDIO = 'audio'
@@ -221,28 +221,25 @@ const isMime = (contentType, type) => {
   return eq(type, get(EXTENSIONS, ext))
 }
 
-const jsonld = mem(
-  (url, $) => {
-    const data = {}
-    try {
-      $('script[type="application/ld+json"]').map((i, e) =>
-        Object.assign(
-          data,
-          ...castArray(
-            JSON.parse(
-              $(e)
-                .contents()
-                .text()
-            )
+const jsonld = memoizeOne((url, $) => {
+  const data = {}
+  try {
+    $('script[type="application/ld+json"]').map((i, e) =>
+      Object.assign(
+        data,
+        ...castArray(
+          JSON.parse(
+            $(e)
+              .contents()
+              .text()
           )
         )
       )
-    } catch (err) {}
+    )
+  } catch (err) {}
 
-    return data
-  },
-  { cacheKey: url => url }
-)
+  return data
+})
 
 const $jsonld = propName => ($, url) => {
   const json = jsonld(url, $)

--- a/packages/metascraper-helpers/package.json
+++ b/packages/metascraper-helpers/package.json
@@ -28,7 +28,7 @@
     "iso-639-3": "~1.2.0",
     "isostring": "0.0.1",
     "lodash": "~4.17.15",
-    "mem": "~5.1.1",
+    "memoize-one": "~5.1.1",
     "mime-types": "~2.1.24",
     "normalize-url": "~4.5.0",
     "smartquotes": "~2.3.1",


### PR DESCRIPTION
The current implementation of the `$jsonld` uses `jsonld` which is wrapped by `mem`.

Unfortunately, because the use of `mem` does not actually specify any cache limitations, all cache entries are just persisted forever. This means that if at any point you scrape the same URL twice, updates to the `script[type="application/ld+json"]` on the page will never be parsed, forcing you to restart the server.

I don't think this was intentional behaviour, so this PR replaces use of `mem` with `memoize-one` which is used elsewhere in the codebase already. This will only cache the result for the last invoked call, which for the purposes of what caching the parse results of `jsonld` achieves, is the same, without the same drawbacks for subsequent calls with the same URL, but different content.