### PR TITLE
build: remove unnecessary options

### DIFF
--- a/packages/metascraper/src/load-html.js
+++ b/packages/metascraper/src/load-html.js
@@ -2,9 +2,4 @@
 
 const cheerio = require('cheerio-advanced-selectors').wrap(require('cheerio'))
 
-module.exports = (html = '') =>
-  cheerio.load(html, {
-    lowerCaseTags: true,
-    decodeEntities: true,
-    lowerCaseAttributeNames: true
-  })
+module.exports = (html = '') => cheerio.load(html)


### PR DESCRIPTION
these options are related to htmlparser2: https://github.com/fb55/htmlparser2/wiki/Parser-options
they are used only on XML mode, so they are not necessary in this case.