### PR TITLE
fix: Use url-regex-safe to fix url-regex vulnerability

### DIFF
--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -22,7 +22,7 @@ const {
 
 const memoizeOne = require('memoize-one').default || require('memoize-one')
 const condenseWhitespace = require('condense-whitespace')
-const urlRegex = require('url-regex')({ exact: true })
+const urlRegex = require('url-regex-safe')({ exact: true })
 const langs = Object.values(require('iso-639-3/to-1'))
 const isRelativeUrl = require('is-relative-url')
 const fileExtension = require('file-extension')

--- a/packages/metascraper-helpers/package.json
+++ b/packages/metascraper-helpers/package.json
@@ -34,7 +34,7 @@
     "smartquotes": "~2.3.1",
     "title": "~3.4.2",
     "truncate": "~2.1.0",
-    "url-regex-safe": "0.0.5",
+    "url-regex-safe": "~1.0.1",
     "video-extensions": "~1.1.0"
   },
   "devDependencies": {

--- a/packages/metascraper-helpers/package.json
+++ b/packages/metascraper-helpers/package.json
@@ -34,7 +34,7 @@
     "smartquotes": "~2.3.1",
     "title": "~3.4.2",
     "truncate": "~2.1.0",
-    "url-regex": "~5.0.0",
+    "url-regex-safe": "0.0.5",
     "video-extensions": "~1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The package [url-regex](https://www.npmjs.com/package/url-regex) has a [Regular Expression Denial of Service vulnerability](https://www.npmjs.com/advisories/1550) and it looks like it is [not maintained anymore](https://github.com/kevva/url-regex/issues/70).
This PR replaces url-regex with [url-regex-safe](https://www.npmjs.com/package/url-regex-safe) which solves the problem above while providing a drop-in replacement for url-regex.