### PR TITLE
Adds type declaration for TypeScript

### DIFF
--- a/packages/metascraper/index.d.ts
+++ b/packages/metascraper/index.d.ts
@@ -1,0 +1,32 @@
+declare module 'metascraper' {
+  export default function MetaParser(rules: Rule[]): Scraper;
+
+  type Scraper = (options: ScrapOptions) => Promise<Metadata>;
+  interface ScrapOptions {
+    url: string;
+    html?: string;
+    rules?: Rule[];
+  }
+  interface Metadata {
+    author: string;
+    date: string;
+    description: string;
+    image: string;
+    publisher: string;
+    title: string;
+    url: string;
+  }
+  type RuleSet = {
+    [C in keyof Metadata]?: Array<Check>;
+  };
+  type Check = (options: CheckOptions) => string | null | undefined;
+  interface CheckOptions {
+    htmlDom: typeof import('cheerio');
+    url: string
+  }
+  type Rule = () => RuleSet;
+}
+
+declare module 'metascraper-*' {
+  export default function rules(): import('metascraper').Rule;
+}

--- a/packages/metascraper/package.json
+++ b/packages/metascraper/package.json
@@ -64,7 +64,7 @@
     "whoops": "~4.1.0"
   },
   "devDependencies": {
-    "@types/cheerio": "~0.22.21",
+    "@types/cheerio": "latest",
     "clear-module": "latest",
     "coveralls": "latest",
     "metascraper-clearbit": "latest",

--- a/packages/metascraper/package.json
+++ b/packages/metascraper/package.json
@@ -64,6 +64,7 @@
     "whoops": "~4.1.0"
   },
   "devDependencies": {
+    "@types/cheerio": "~0.22.21",
     "clear-module": "latest",
     "coveralls": "latest",
     "metascraper-clearbit": "latest",


### PR DESCRIPTION
I was integrating your parser in a TypeScript so I figured I could give you the `.d.ts` I've created :smiley: 

What it does:
* Adds an index.d.ts for `metaparser` module
* Adds a global declaration for `metaparser-*` module
* Import Cheerio's typing

The module is use exactly as in Node.js.