### PR TITLE
feat(audio/video): add support for ld+json contentUrl property

### DIFF
--- a/packages/metascraper-audio/index.js
+++ b/packages/metascraper-audio/index.js
@@ -1,6 +1,12 @@
 'use strict'
 
-const { isMime, audio, toRule, $filter } = require('@metascraper/helpers')
+const {
+  isMime,
+  audio,
+  toRule,
+  $filter,
+  $jsonld
+} = require('@metascraper/helpers')
 
 const toAudio = toRule(audio)
 
@@ -20,6 +26,7 @@ module.exports = () => ({
       )
       return contentType ? withContentType(streamUrl, contentType) : streamUrl
     }),
+    toAudio($jsonld('contentUrl')),
     toAudio($ => $('audio').attr('src')),
     toAudio($ => $('audio > source').attr('src')),
     ({ htmlDom: $ }) => $filter($, $('a'), el => audio(el.attr('href')))

--- a/packages/metascraper-audio/test/index.js
+++ b/packages/metascraper-audio/test/index.js
@@ -52,4 +52,14 @@ describe('metascraper-audio', () => {
     const metadata = await metascraper({ html, url })
     snapshot(metadata)
   })
+
+  it('audio jsld:contentUrl', async () => {
+    const html = `<script type="application/ld+json">
+        {"@context":"http://schema.org","@type":"AudioObject","@id":"https://example.com/audio.mp3","contentUrl":"https://example.com/audio.mp3"}
+      </script>`
+    const url = 'https://browserless.js.org'
+
+    const metadata = await metascraper({ html, url })
+    snapshot(metadata)
+  })
 })

--- a/packages/metascraper-video/index.js
+++ b/packages/metascraper-video/index.js
@@ -24,6 +24,7 @@ module.exports = () => ({
     toVideo($ => $('meta[property="og:video:url"]').attr('content')),
     toVideo($ => $('meta[property="og:video"]').attr('content')),
     toVideo($ => $('meta[property="twitter:player:stream"]').attr('content')),
+    toVideo($jsonld('contentUrl')),
     toVideoFromDom($ => $('video').get()),
     toVideoFromDom($ => $('video > source').get())
   ]

--- a/packages/metascraper-video/test/index.js
+++ b/packages/metascraper-video/test/index.js
@@ -101,4 +101,15 @@ describe('metascraper-video', () => {
       snapshot(metadata)
     })
   })
+  describe('jsonld', () => {
+    it('contentUrl', async () => {
+      const html = `<script type="application/ld+json">
+        {"@context":"http://schema.org","@type":"VideoObject","@id":"https://example.com/video.mp4","contentUrl":"https://example.com/video.mp4"}
+      </script>`
+      const url = 'https://browserless.js.org'
+
+      const metadata = await metascraper({ html, url })
+      snapshot(metadata)
+    })
+  })
 })


### PR DESCRIPTION
closes #353 

Adds support for extracting audio/video URLs from the [contentUrl](https://schema.org/contentUrl) property in `ld+json`.

I have not come across a page that uses this for video urls (perhaps because I haven't been looking) but I decided to go ahead and add support for video too since the schema.org docs call out:

>`contentUrl`: Actual bytes of the media object, for example the image file or video file.


I should probably figure out how to write my own integration tests at some point huh @Kikobeats.  Feel free to add them yourself or point me in the right direction and I can do it myself.

Here are the URLs I was using to test:

```
"https://www.nytimes.com/2021/01/26/opinion/ezra-klein-podcast-vivek-murthy.html",
"https://www.nytimes.com/2020/11/19/opinion/sway-kara-swisher-raj-chetty.html",
```