### PR TITLE
feat: add support for meta name & twitter:player video urls

### DIFF
--- a/packages/metascraper-video/index.js
+++ b/packages/metascraper-video/index.js
@@ -30,8 +30,8 @@ module.exports = () => ({
     toVideo($ => $('meta[property="og:video:secure_url"]').attr('content')),
     toVideo($ => $('meta[property="og:video:url"]').attr('content')),
     toVideo($ => $('meta[property="og:video"]').attr('content')),
-    toVideo($ => $('meta[property="twitter:player:stream"]').attr('content')),
-    toVideo($ => $('meta[property="twitter:player"]').attr('content')),
+    toVideo($ => $('meta[name="twitter:player:stream"]').attr('content')),
+    toVideo($ => $('meta[name="twitter:player"]').attr('content')),
     toVideo($jsonld('contentUrl')),
     toVideoFromDom($ => $('video').get()),
     toVideoFromDom($ => $('video > source').get())

--- a/packages/metascraper-video/index.js
+++ b/packages/metascraper-video/index.js
@@ -32,11 +32,6 @@ module.exports = () => ({
     toVideo($ => $('meta[property="og:video"]').attr('content')),
     toVideo($ => $('meta[property="twitter:player:stream"]').attr('content')),
     toVideo($ => $('meta[property="twitter:player"]').attr('content')),
-    toVideo($ => $('meta[name="og:video:secure_url"]').attr('content')),
-    toVideo($ => $('meta[name="og:video:url"]').attr('content')),
-    toVideo($ => $('meta[name="og:video"]').attr('content')),
-    toVideo($ => $('meta[name="twitter:player:stream"]').attr('content')),
-    toVideo($ => $('meta[name="twitter:player"]').attr('content')),
     toVideo($jsonld('contentUrl')),
     toVideoFromDom($ => $('video').get()),
     toVideoFromDom($ => $('video > source').get())

--- a/packages/metascraper-video/index.js
+++ b/packages/metascraper-video/index.js
@@ -31,6 +31,12 @@ module.exports = () => ({
     toVideo($ => $('meta[property="og:video:url"]').attr('content')),
     toVideo($ => $('meta[property="og:video"]').attr('content')),
     toVideo($ => $('meta[property="twitter:player:stream"]').attr('content')),
+    toVideo($ => $('meta[property="twitter:player"]').attr('content')),
+    toVideo($ => $('meta[name="og:video:secure_url"]').attr('content')),
+    toVideo($ => $('meta[name="og:video:url"]').attr('content')),
+    toVideo($ => $('meta[name="og:video"]').attr('content')),
+    toVideo($ => $('meta[name="twitter:player:stream"]').attr('content')),
+    toVideo($ => $('meta[name="twitter:player"]').attr('content')),
     toVideo($jsonld('contentUrl')),
     toVideoFromDom($ => $('video').get()),
     toVideoFromDom($ => $('video > source').get())

--- a/packages/metascraper-video/test/index.js
+++ b/packages/metascraper-video/test/index.js
@@ -111,5 +111,14 @@ describe('metascraper-video', () => {
       const metadata = await metascraper({ html, url })
       snapshot(metadata)
     })
-  })
+  }),
+    describe('twitter', () => {
+      it('name twitter:player', async () => {
+        const html = `<meta name="twitter:player" content="https://browserless.js.org/videos/JPJAu6qU-UpFyHQ41.mp4">`
+        const url = 'https://browserless.js.org'
+
+        const metadata = await metascraper({ html, url })
+        snapshot(metadata)
+      })
+    })
 })

--- a/packages/metascraper/__snapshots__/index.js.snap-shot
+++ b/packages/metascraper/__snapshots__/index.js.snap-shot
@@ -1104,7 +1104,7 @@ exports['indiehackers 1'] = {
   "publisher": "Indie Hackers",
   "title": "Before and After Product-Market Fit with Peter and Calvin from Segment",
   "url": "https://www.indiehackers.com/podcast/032-peter-and-calvin-of-segment",
-  "audio": "https://chtbl.com/track/EB7BD2/media.transistor.fm/70c487ed/f3249e4a.mp3?download=true"
+  "audio": "https://chtbl.com/track/EB7BD2/media.transistor.fm/70c487ed/f3249e4a.mp3?download=true&src=player"
 }
 
 exports['transistor.fm 1'] = {


### PR DESCRIPTION
I noticed metascraper was not returning videos for this page despite having a video url provided in a twitter meta tag

https://www.outsideonline.com/2403038/elyse-saugstad-cody-townsend-couples-therapy

There are two things going on in this PR:

- Duplicated existing rules to a variant which enables pulling from meta tags with `name` attribute instead of just `property` attribute. The [twitter card validator ](https://cards-dev.twitter.com/validator) verifies the tags at the url above, so even though this format isn't called out it appears to be valid.
- adds a new rules for the tag `twitter:player` which is exhibited at the url above.