### PR TITLE
metascraper-author: remove invalid markup support

### DIFF
--- a/packages/metascraper-author/index.js
+++ b/packages/metascraper-author/index.js
@@ -23,7 +23,6 @@ module.exports = () => ({
     toAuthor($jsonld('author.name')),
     toAuthor($jsonld('brand.name')),
     toAuthor($ => $('meta[name="author"]').attr('content')),
-    toAuthor($ => $('meta[property="author"]').attr('content')),
     toAuthor($ => $('meta[property="article:author"]').attr('content')),
     toAuthor($ => $filter($, $('[itemprop*="author" i] [itemprop="name"]'))),
     toAuthor($ => $filter($, $('[itemprop*="author" i]'))),

--- a/packages/metascraper-video/test/fixtures/video-src.html
+++ b/packages/metascraper-video/test/fixtures/video-src.html
@@ -1,2383 +1,2808 @@
-
-
-
-
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>You can visit the Pentagon’s secret nuclear bunker inside Minecraft - The Verge</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="apple-mobile-web-app-title" content="Verge" />
-    
-    <script type="text/javascript" src="https://optimize-stats.voxmedia.com/loader.min.js?key=efd28c71b5699c36"></script>
-      <meta property="article:publisher" content="http://www.facebook.com/verge" />
-  <meta property="author" content="Rachel Becker" />
-  <meta property="article:published_time" content="2018-01-22T18:38:17-05:00" />
+<html lang="en" class=" fonts-loaded">
+<div id="005c0ad5-9268-46b7-85ba-348ecfa44fc2" style="display: none;">
+  {"method":"get","path":"self.screen.width","level":"info","category":"screen","jsContextId":"1e23f426-9fb1-4cbb-b2d0-e10089fbd1f4","url":"https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model","stack":[{"functionName":"Object.breakpoint","fileName":"https://cdn.vox-cdn.com/packs/js/chorus-45a5379b6bb9fb7c7e01.js","lineNumber":"2","columnNumber":"127731"},{"fileName":"https://cdn.vox-cdn.com/packs/js/chorus-45a5379b6bb9fb7c7e01.js","lineNumber":"2","columnNumber":"152945"},{"functionName":"u","fileName":"https://cdn.vox-cdn.com/packs/js/chorus-45a5379b6bb9fb7c7e01.js","lineNumber":"2","columnNumber":"34858"},{"functionName":"d","fileName":"https://cdn.vox-cdn.com/packs/js/chorus-45a5379b6bb9fb7c7e01.js","lineNumber":"2","columnNumber":"35158"}]}
+</div>
 
-    
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/unison_base/nittigrotesk/nittigrotesk-normal.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Italic.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Semibold.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md-obq.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-bd-obq.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2" as="font" type="font/woff2" crossorigin>
-  
-
-  
-    <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/pathways-display.woff2" as="font" type="font/woff2" crossorigin>
-  
+<head>
+  <title>You can visit the Pentagon’s secret nuclear bunker inside Minecraft - The Verge</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="apple-mobile-web-app-title" content="Verge">
 
 
-<meta id="chorus-fonts" data-cid="site/font_loader-1516303765_3739_9609" data-cdata='{"version":"ae9b6b8d70a06cb8231ba7728cfa6e99","fonts_catalog":[{"slug":"unison-nitti","family":"nitti-grotesk","weight":"400","style":"normal","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/unison_base/nittigrotesk/nittigrotesk-normal.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/unison_base/nittigrotesk/nittigrotesk-normal.woff"},{"slug":"verge-adelle-sans","family":"adelle-sans","weight":"400","style":"italic","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Italic.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Italic.woff"},{"slug":"verge-adelle-sans","family":"adelle-sans","weight":"600","style":"normal","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Semibold.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Semibold.woff"},{"slug":"verge-heroic","family":"Heroic","weight":"500","style":"italic","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md-obq.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md-obq.woff"},{"slug":"verge-heroic","family":"Heroic","weight":"500","style":"normal","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md.woff"},{"slug":"verge-heroic","family":"Heroic","weight":"600","style":"italic","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-bd-obq.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-bd-obq.woff"},{"slug":"verge-heroic","family":"Heroic","weight":"600","style":"normal","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff"},{"slug":"verge-heroic","family":"Heroic","weight":"700","style":"normal","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff"},{"slug":"verge-pathways","family":"Pathways","weight":"400","style":"normal","woff2_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/pathways-display.woff2","woff_url":"https://cdn.vox-cdn.com/shared_fonts/unison/verge/pathways-display.woff"}],"font_stylesheets":["https://fonts.voxmedia.com/unison/stylesheets/verge.1d37918fdeeb1febc4d68217382a1e72.css"],"font_tracker_stylesheets":[],"typekit_ids":[],"headline_balance_div_classes":"","headline_balance_fraction":1.0}'>
+  <script async="" src="https://auth.voxmedia.com/sso/unison_request?community_id=372&amp;t=1615220568608"></script>
+  <script type="text/javascript" src="https://static.narrativ.com/tags/verge.js" async=""></script>
+  <script async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-W8JKW6"></script>
+  <script async="" src="https://www.google-analytics.com/analytics.js"></script>
+  <script type="text/javascript" src="https://optimize-stats.voxmedia.com/loader.min.js?key=efd28c71b5699c36"></script>
+  <meta property="article:publisher" content="http://www.facebook.com/verge">
+  <meta name="author" content="Rachel Becker">
+  <meta property="article:published_time" content="2018-01-22T18:38:17-05:00">
+  <meta property="article:modified_time" content="2018-01-22T18:38:17-05:00">
 
-    <script>var chorusInitQueue=[],volume_embed_host="https://volume.vox-cdn.com";var Chorus=Chorus||{};Chorus.windowLoaded=!1,Chorus.AddScript=function(t,e){var o=document.createElement("script");o.async=!0,o.type="text/javascript",o.src=t,"function"==typeof e&&(o.onload=e);var a=document.getElementsByTagName("script")[0];return a.parentNode.insertBefore(o,a),o},Chorus.ready=function(t){"loading"!=document.readyState?t():document.addEventListener?document.addEventListener("DOMContentLoaded",t):document.attachEvent("onreadystatechange",function(){"loading"!=document.readyState&&t()})},Chorus.OnLoad=function(t){if(Chorus.windowLoaded=!0)return void t();var e=window.onload;"function"!=typeof window.onload?window.onload=t:window.onload=function(){e(),t()}},Chorus.OnLoad(function(){Chorus.windowLoaded=!0});var dataLayer=dataLayer||[];Chorus.OnLoad(function(){var t;void 0!==navigator.doNotTrack?t=navigator.doNotTrack:void 0!==window.doNotTrack?t=window.doNotTrack:void 0!==navigator.msDoNotTrack&&(t=navigator.msDoNotTrack),t=void 0!==t?/1|yes|true/.test(String(t).toLowerCase())?"true":"false":"undefined";var e={DNT:t};"object"==typeof ChorusAds&&(e["Ads Blocked"]=ChorusAds.adsBlocked),dataLayer.push(e)}),function(t){function e(t,e){var o=window.performance;if(o&&o.mark&&o.measure){var a=t.toLocaleLowerCase().replace(/\W+/g,"_")+(e?"_"+e:"");o.mark(a),o.measure(a+"_time","navigationStart",a)}}function o(){s.classList.add(c),e("fonts_success")}function a(){s.classList.add(c),e("fonts_fail")}function n(t){var o=[t.family,t.style,t.weight,"loaded"].join(" ");e(o)}function r(t){var e=f.font_stylesheets||[];t&&(e=e.filter(function(e){return!e.match(t)})),e.forEach(d)}function d(e){var o=t.createElement("link");o.href=e,o.rel="stylesheet",o.media="all",u.parentNode.insertBefore(o,u)}function i(e){var o,a=t,n=a.documentElement,r=setTimeout(function(){n.className=n.className.replace(/\bwf-loading\b/g,"")+" wf-inactive"},e.scriptTimeout),d=a.createElement("script"),i=!1,c=a.getElementsByTagName("script")[0];n.className+=" wf-loading",d.src="https://use.typekit.net/"+e.kitId+".js",d.async=!0,d.onload=d.onreadystatechange=function(){if(o=this.readyState,!(i||o&&"complete"!=o&&"loaded"!=o)){i=!0,clearTimeout(r);try{Typekit.load(e)}catch(t){}}},c.parentNode.insertBefore(d,c)}var c="fonts-loaded",s=t.documentElement,u=t.getElementById("chorus-fonts");if(u){var f=JSON.parse(u.getAttribute("data-cdata"));t.fonts?(r("voxmedia.com"),f.fonts_catalog.forEach(function(e){if(e.woff2_url||e.woff_url){var o=[e.woff2_url,e.woff_url].filter(function(t){return t}).map(function(t){return"url("+t+")"}).join(", "),a=new FontFace(e.family,o,{weight:e.weight,style:e.style});t.fonts.add(a),a.load().then(n)}}),t.fonts.ready.then(o,a)):r(),f.typekit_ids.forEach(function(t){i({kitId:t,scriptTimeout:3e3,async:!0})}),f.font_tracker_stylesheets.forEach(d)}}(document);</script>
-  <script class="kxint" type="text/javascript">
-    window.Krux||((Krux=function(){Krux.q.push(arguments);}).q=[]);
-    (function(){
-      function retrieve(e){var r,o="kxvoxmedia_"+e;return window.localStorage?window.localStorage[o]||"":navigator.cookieEnabled?(r=document.cookie.match(o+"=([^;]*)"),r&&unescape(r[1])||""):""}Krux.user=retrieve("user"),Krux.segments=retrieve("segs")&&retrieve("segs").split(",")||[];
-    })();
+
+
+
+  <link rel="preload"
+    href="https://cdn.vox-cdn.com/shared_fonts/unison/unison_base/nittigrotesk/nittigrotesk-normal.woff2" as="font"
+    type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Italic.woff2" as="font"
+    type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Semibold.woff2" as="font"
+    type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md-obq.woff2"
+    as="font" type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md.woff2"
+    as="font" type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-bd-obq.woff2"
+    as="font" type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2"
+    as="font" type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2"
+    as="font" type="font/woff2" crossorigin="">
+
+
+
+  <link rel="preload" href="https://cdn.vox-cdn.com/shared_fonts/unison/verge/pathways-normal-webfont.woff2" as="font"
+    type="font/woff2" crossorigin="">
+
+
+
+  <meta id="chorus-fonts" data-cid="site/font_loader-1615216181_5187_51173"
+    data-cdata="{&quot;version&quot;:&quot;d3a15f142bcd041806ec9275c9672d13&quot;,&quot;fonts_catalog&quot;:[{&quot;slug&quot;:&quot;unison-nitti&quot;,&quot;family&quot;:&quot;nitti-grotesk&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/unison_base/nittigrotesk/nittigrotesk-normal.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/unison_base/nittigrotesk/nittigrotesk-normal.woff&quot;},{&quot;slug&quot;:&quot;verge-adelle-sans&quot;,&quot;family&quot;:&quot;adelle-sans&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Italic.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Italic.woff&quot;},{&quot;slug&quot;:&quot;verge-adelle-sans&quot;,&quot;family&quot;:&quot;adelle-sans&quot;,&quot;weight&quot;:&quot;600&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Semibold.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/AdelleSans-Semibold.woff&quot;},{&quot;slug&quot;:&quot;verge-heroic&quot;,&quot;family&quot;:&quot;Heroic&quot;,&quot;weight&quot;:&quot;500&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md-obq.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md-obq.woff&quot;},{&quot;slug&quot;:&quot;verge-heroic&quot;,&quot;family&quot;:&quot;Heroic&quot;,&quot;weight&quot;:&quot;500&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-md.woff&quot;},{&quot;slug&quot;:&quot;verge-heroic&quot;,&quot;family&quot;:&quot;Heroic&quot;,&quot;weight&quot;:&quot;600&quot;,&quot;style&quot;:&quot;italic&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-bd-obq.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-bd-obq.woff&quot;},{&quot;slug&quot;:&quot;verge-heroic&quot;,&quot;family&quot;:&quot;Heroic&quot;,&quot;weight&quot;:&quot;600&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff&quot;},{&quot;slug&quot;:&quot;verge-heroic&quot;,&quot;family&quot;:&quot;Heroic&quot;,&quot;weight&quot;:&quot;700&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/heroic-cond-vrg-web-ltd-hvy.woff&quot;},{&quot;slug&quot;:&quot;verge-pathways&quot;,&quot;family&quot;:&quot;Pathways&quot;,&quot;weight&quot;:&quot;400&quot;,&quot;style&quot;:&quot;normal&quot;,&quot;woff2_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/pathways-normal-webfont.woff2&quot;,&quot;woff_url&quot;:&quot;https://cdn.vox-cdn.com/shared_fonts/unison/verge/pathways-normal-webfont.woff&quot;}],&quot;font_stylesheets&quot;:[&quot;https://fonts.voxmedia.com/unison/stylesheets/verge.ccc871708379b713e3df3eb38e09e86b.css&quot;],&quot;font_tracker_stylesheets&quot;:[],&quot;typekit_ids&quot;:[],&quot;headline_balance_div_classes&quot;:&quot;.c-page-title,.c-entry-summary,.c-entry-box__title,.c-entry-box--compact__title,.c-entry-box--compact__dek,.c-rock-list__entry-title&quot;,&quot;headline_balance_fraction&quot;:0.5}">
+
+  <script
+    data-privacy-no-concern="">var chorusInitQueue = [], volume_embed_host = "https://volume.vox-cdn.com"; var Chorus = Chorus || {}; Chorus.windowLoaded = !1, Chorus.AddScript = function (t, e) { var o = document.createElement("script"); o.async = !0, o.type = "text/javascript", o.src = t, "function" == typeof e && (o.onload = e); var a = document.getElementsByTagName("script")[0]; return a.parentNode.insertBefore(o, a), o }, Chorus.ready = function (t) { "loading" != document.readyState ? t() : document.addEventListener ? document.addEventListener("DOMContentLoaded", t) : document.attachEvent("onreadystatechange", function () { "loading" != document.readyState && t() }) }, Chorus.OnLoad = function (t) { if (Chorus.windowLoaded = !0) return void t(); var e = window.onload; "function" != typeof window.onload ? window.onload = t : window.onload = function () { e(), t() } }, Chorus.OnLoad(function () { Chorus.windowLoaded = !0 }); var dataLayer = dataLayer || []; Chorus.OnLoad(function () { var t; void 0 !== navigator.doNotTrack ? t = navigator.doNotTrack : void 0 !== window.doNotTrack ? t = window.doNotTrack : void 0 !== navigator.msDoNotTrack && (t = navigator.msDoNotTrack), t = void 0 !== t ? /1|yes|true/.test(String(t).toLowerCase()) ? "true" : "false" : "undefined"; var e = { DNT: t }; dataLayer.push(e) }); var VoxMediaFontLoader = function (t) { function e(t, e) { var o = window.performance; if (o && o.mark && o.measure) { var a = t.toLocaleLowerCase().replace(/\W+/g, "_") + (e ? "_" + e : ""); o.mark(a), o.measure(a + "_time", "navigationStart", a) } } function o() { s.classList.add(c), e("fonts_success") } function a() { s.classList.add(c), e("fonts_fail") } function n(t) { var o = [t.family, t.style, t.weight, "loaded"].join(" "); e(o) } function r(t) { var e = u.font_stylesheets || []; t && (e = e.filter(function (e) { return !e.match(t) })), e.forEach(i) } function i(e) { var o = t.createElement("link"); o.href = e, o.rel = "stylesheet", o.media = "all", f.parentNode.insertBefore(o, f) } function d(e) { var o, a = t, n = a.documentElement, r = setTimeout(function () { n.className = n.className.replace(/\bwf-loading\b/g, "") + " wf-inactive" }, e.scriptTimeout), i = a.createElement("script"), d = !1, c = a.getElementsByTagName("script")[0]; n.className += " wf-loading", i.src = "https://use.typekit.net/" + e.kitId + ".js", i.async = !0, i.onload = i.onreadystatechange = function () { if (o = this.readyState, !(d || o && "complete" != o && "loaded" != o)) { d = !0, clearTimeout(r); try { Typekit.load(e) } catch (t) { } } }, c.parentNode.insertBefore(i, c) } var c = "fonts-loaded", s = t.documentElement, f = t.getElementById("chorus-fonts"); if (f) { var u = JSON.parse(f.getAttribute("data-cdata")); t.fonts ? (r("voxmedia.com"), u.fonts_catalog.forEach(function (e) { if (e.woff2_url || e.woff_url) { var o = [e.woff2_url, e.woff_url].filter(function (t) { return t }).map(function (t) { return "url(" + t + ")" }).join(", "), a = new FontFace(e.family, o, { weight: e.weight, style: e.style }); t.fonts.add(a), a.load().then(n) } }), t.fonts.ready.then(o, a)) : r(), u.typekit_ids.forEach(function (t) { d({ kitId: t, scriptTimeout: 3e3, async: !0 }) }), u.font_tracker_stylesheets.forEach(i) } }; VoxMediaFontLoader(document);</script>
+
+  <script>
+    dataLayer = [{ "Network": "theverge", "Community": "theverge", "root_domain": "theverge.com", "GA Primary ID": "UA-26533115-1", "GA CrossDomains": "theverge.com", "Content ID": "16685133", "Story Word Count": 589, "Entry Groups": "front-page:tldr:science:tech", "articleSection": "Front Page", "Author": "Rachel Becker", "Last Time Updated": "2018-01-22 18:43", "Hour of Update": "18", "Publish Date": "2018-01-22 18:38", "Hour of Publish": "18", "Evergreen URL": "no value set", "Demand Post": "no", "All Chorus Categories": "theverge:theverge:front-page:tldr:science:tech", "Content Type": "article", "chartbeat_domain": "theverge.com", "chartbeat_zone": "172968584/verge", "chartbeat_authors": "Rachel Becker", "Logged in Status": "Logged Out", "auth0_id": "No Auth0 ID", "enable_url_cleaning": true, "ScrollSubscription": "false" }];
   </script>
 
-     <script>
-   dataLayer = [{"Network":"theverge","Community":"theverge","GA Primary ID":"UA-26533115-1","GA CrossDomains":"theverge.com","Content ID":"16685133","Entry Groups":"front-page:tldr:science:tech","Author":"Rachel Becker","Last Time Updated":"2018-01-22 18:43","Hour of Update":"18","Publish Date":"2018-01-22 18:38","Hour of Publish":"18","Demand Post":"no","All Chorus Categories":"theverge:theverge:front-page:tldr:science:tech","Content Type":"article","chartbeat_domain":"theverge.com","chartbeat_zone":"172968584/verge","chartbeat_authors":"Rachel Becker","Logged in Status":"Logged Out"}];
- </script>
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-W8JKW6');</script>
-<!-- End Google Tag Manager -->
-    <script>
-  ChorusAds={ adsBlocked: true };
-  ChorusAds.cmd = ChorusAds.cmd || [];
-  ChorusAds.cmd.push(function() { ChorusAds.adsBlocked = false; });
-  ChorusAds.settings = {"production":true,"slug":"/172968584/verge","dfpVariables":{"network":["verge"],"affiliation":["general"],"unison":[true],"entry_id":[16685133],"entry_type":["article"],"entry_slug":["2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"],"entry_author":["Rachel Becker"],"entry_group":["front-page","tldr","science","tech"],"hub_page":["tldr","science","tech"],"page_type":["interior_page"],"keywords":"you can visit the pentagon s secret nuclear bunker inside minecraft the verge"},"isUnison":true,"is_unison":true,"prebid":{"enabled":true,"timeout":1000,"defaultConfig":{"openx":{"delDomain":"sbnationbidder-d.openx.net","unit":538623520},"rubicon":{"accountId":7470,"position":"btf","siteId":40684,"zoneId":185818}},"prelude":{"trustx":{"uid":2663}},"reskin":{"trustx":{"uid":2664}},"desktop_leaderboard_variable":{"trustx":{"uid":2665},"appnexus":{"placementId":9885469},"indexExchange":{"id":42,"siteID":185962},"rubicon":{"position":"atf"},"triplelift":{"inventoryCode":"theverge_leaderboard_desktop"}},"medium_rectangle_variable":{"trustx":{"uid":2666},"appnexus":{"placementId":9885470},"indexExchange":{"id":43,"siteID":185963},"rubicon":{"position":"atf"},"triplelift":{"inventoryCode":"theverge_300x250_desktop"}},"btf_medium_rectangle_variable":{"trustx":{"uid":2668},"appnexus":{"placementId":9885472},"indexExchange":{"id":46,"siteID":185966}},"desktop_article_medrec_dynamic":{"trustx":{"uid":2669},"appnexus":{"placementId":11807780},"indexExchange":{"id":244,"siteID":213003}},"btf_leaderboard_variable":{"trustx":{"uid":2670},"appnexus":{"placementId":9885490},"indexExchange":{"id":45,"siteID":185965}},"native_ad_latest":{"trustx":{"uid":2671}},"native_ad_ymal_link":{"trustx":{"uid":2672}},"mobile_leaderboard":{"trustx":{"uid":2673},"appnexus":{"placementId":9885473},"indexExchange":{"id":51,"siteID":185971},"rubicon":{"position":"atf"},"triplelift":{"inventoryCode":"theverge_300x250_leaderboard_mobile"}},"mobile_article_body":{"trustx":{"uid":2674},"appnexus":{"placementId":11807777},"indexExchange":{"id":241,"siteID":213000}},"native_ad_mobile":{"trustx":{"uid":2675}},"mobile_article_body_med_rec_dynamic":{"trustx":{"uid":2676},"appnexus":{"placementId":11807779},"indexExchange":{"id":243,"siteID":213002}},"mobile_footer":{"trustx":{"uid":2677},"appnexus":{"placementId":9885475},"indexExchange":{"id":52,"siteID":185972}},"tablet_leaderboard":{"trustx":{"uid":2678},"appnexus":{"placementId":9885477},"indexExchange":{"id":48,"siteID":185968},"rubicon":{"position":"atf"}},"tablet_medium_rectangle":{"trustx":{"uid":2679},"appnexus":{"placementId":9885478},"indexExchange":{"id":49,"siteID":185969},"rubicon":{"position":"atf"}},"tablet_btf_leaderboard":{"trustx":{"uid":2680},"appnexus":{"placementId":9885480},"indexExchange":{"id":50,"siteID":185970}},"native_ad_content_link":{"trustx":{"uid":2681}},"hub_river_leaderboard":{"trustx":{"uid":2682},"appnexus":{"placementId":11807782},"indexExchange":{"id":245,"siteID":213004}},"hub_river_med_rec":{"trustx":{"uid":2684},"appnexus":{"placementId":11807783},"indexExchange":{"id":246,"siteID":213005}},"mobile_med_rec_athena":{"trustx":{"uid":2685},"appnexus":{"placementId":9885474},"indexExchange":{"id":100,"siteID":186845},"rubicon":{"position":"atf"},"triplelift":{"inventoryCode":"theverge_300x250_mobile"}},"athena":{"appnexus":{"placementId":9885471},"indexExchange":{"id":47,"siteID":185967},"rubicon":{"position":"atf"}},"btf_tablet_medium_rectangle":{"appnexus":{"placementId":9885479},"indexExchange":{"id":99,"siteID":186844}},"desktop_article_body":{"appnexus":{"placementId":11807778},"indexExchange":{"id":242,"siteID":213001}},"in_map":{"appnexus":{"placementId":11807781},"indexExchange":{"disabled":true}},"athena_features":{"appnexus":{"placementId":11807784},"indexExchange":{"id":247,"siteID":213006}},"athena_features_dynamic":{"appnexus":{"placementId":11807785},"indexExchange":{"id":248,"siteID":213007}}},"dynamicSlotConfig":[{"name":"editorially_placed_athena","selector":".m-ad.m-ad__editorial-athena-placement","sizes":[[1030,590]],"holdSize":[300,500],"filters":{"viewportWidth":{"max":727}}},{"name":"editorially_placed_athena","selector":".m-ad.m-ad__editorial-athena-placement","sizes":[[1030,590]],"holdSize":[728,295],"filters":{"viewportWidth":{"min":728}}},{"name":"editorially_placed_leaderboard","selector":".m-ad.m-ad__editorial-leaderboard-placement","sizes":[[728,90]],"holdSize":[728,90],"filters":{"viewportWidth":{"min":728}}},{"name":"prelude","selector":".l-root","sizes":[[1400,600]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"allowSiblings":true,"filters":{"viewportWidth":{"min":881}}},{"name":"reskin","selector":".l-root","sizes":[[2,2]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"min":1280},"hideIfPresent":{"selector":".l-feature, .c-maps-hub"}}},{"name":"desktop_leaderboard_variable","selector":".l-header","sizes":[[728,90],[970,250],[970,90],[1020,90]],"holdSize":[728,90],"insertion":"after","filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-feature"}}},{"name":"tablet_leaderboard","selector":".l-header","sizes":[[728,90]],"holdSize":[728,90],"insertion":"after","filters":{"viewportWidth":{"min":729,"max":880}}},{"name":"mobile_leaderboard","selector":".l-hub-page .l-header","sizes":[[320,50],[300,250]],"holdSize":[300,250],"insertion":"after","maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"package_cover_ad","selector":".c-package-cover","sizes":[[728,90],[970,250],[970,90],[1020,90],[1030,590]],"holdSize":[728,90],"insertion":"after","filters":{"viewportWidth":{"min":729}}},{"name":"package_cover_ad_mobile","selector":".c-package-cover","sizes":[[320,50],[300,250],[1030,590],[1020,90],[1030,590]],"holdSize":[320,50],"insertion":"after","filters":{"viewportWidth":{"max":729}}},{"name":"btf_leaderboard_variable","selector":".c-footer","sizes":[[728,90],[1020,90]],"holdSize":[728,90],"filters":{"viewportWidth":{"min":881}}},{"name":"tablet_btf_leaderboard","selector":".c-footer","sizes":[[728,90]],"holdSize":[728,90],"filters":{"viewportWidth":{"min":729,"max":888}}},{"name":"mobile_footer","selector":"body:not(.entry_layout_unison_package_landing) .c-footer","sizes":[[320,50],[300,250]],"holdSize":[300,250],"filters":{"viewportWidth":{"min":0,"max":728}}},{"name":"package_mobile_footer","selector":".entry_layout_unison_package_landing .c-footer","sizes":[[320,50],[300,250],[1030,590]],"holdSize":[300,250],"filters":{"viewportWidth":{"min":0,"max":728}}},{"name":"athena_features","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[1030,590],[300,250],[300,265]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"avoidFloats":true,"paragraphHeight":{"above":200},"viewportWidth":{"max":779},"spacing":{"before":1500}}},{"name":"athena_features_dynamic","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[1030,590],[300,250],[300,265]],"previewHoldSize":[300,250],"maxSlots":2,"filters":{"avoidFloats":true,"paragraphHeight":{"above":200},"viewportWidth":{"max":779},"spacing":{"before":3000}}},{"name":"athena_features","selector":".l-feature .c-entry-content \u003e p + p","sizes":[[1030,590]],"previewHoldSize":[726,415],"maxSlots":3,"filters":{"paragraphHeight":{"above":200},"avoidFloats":true,"viewportWidth":{"min":779},"spacing":{"before":2000}}},{"name":"mobile_leaderboard","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[320,50],[300,250]],"holdSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728}}},{"name":"desktop_article_body","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[1030,590]],"previewHoldSize":[726,415],"maxSlots":1,"filters":{"avoidFloats":true,"spacing":{"before":750,"after":450},"viewportWidth":{"min":729}}},{"name":"mobile_article_body","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[1030,590],[300,250],[300,265]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728},"spacing":{"before":600}}},{"name":"native_ad_mobile","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[1030,590],[300,250],[300,265]],"previewHoldSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"max":728},"spacing":{"before":600}}},{"name":"mobile_article_body_med_rec_dynamic","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[300,250]],"customSizes":[{"placement":1,"sizes":[[300,250],[1030,590]]},{"placement":3,"sizes":[[300,250],[1030,590]]}],"previewHoldSize":[300,250],"filters":{"viewportWidth":{"max":728},"spacing":{"before":900}}},{"name":"desktop_article_medrec_dynamic","selector":".l-segment:not(.l-feature) .c-entry-content \u003e p + p","sizes":[[300,250]],"holdSize":[300,250],"filters":{"paragraphHeight":{"above":150,"below":250},"viewportWidth":{"min":729},"avoidFloats":true,"spacing":{"before":1500,"after":750}}},{"name":"medium_rectangle_variable","selector":".l-col__sidebar \u003e div:first-of-type","sizes":[[300,250],[300,600]],"holdSize":[300,250],"maxSlots":1,"filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-full-archives"}}},{"name":"btf_medium_rectangle_variable","selector":"body:not(.l-hub-page) .l-col__sidebar \u003e div:last-of-type, .l-hub-page .river-segment-1 .l-col__sidebar \u003e div:last-of-type","sizes":[[300,250]],"holdSize":[300,250],"insertion":"after","maxSlots":1,"filters":{"viewportWidth":{"min":881},"hideIfPresent":{"selector":".l-full-archives"}}},{"name":"tablet_medium_rectangle","selector":"body:not(.l-hub-page) .l-col__sidebar \u003e div:first-of-type","sizes":[[300,250]],"holdSize":[300,250],"filters":{"viewportWidth":{"min":729,"max":880}}},{"name":"in_map","selector":".c-mapstack__ad","sizes":[[300,250]],"previewHoldSize":[300,250]},{"name":"athena","selector":".l-hub-page .river-segment-0, .l-article-body-segment","sizes":[[1030,590]],"holdSize":[728,295],"maxSlots":1,"insertion":"after","filters":{"viewportWidth":{"min":728}}},{"name":"hub_river_leaderboard","selector":".l-hub-page .c-compact-river__entry, .l-hub-page .c-river__entry","sizes":[[728,90]],"holdSize":[728,90],"filters":{"spacing":{"before":700,"after":500},"containerWidth":{"min":728}}},{"name":"mobile_med_rec_athena","selector":".l-hub-page .river-segment-0","sizes":[[300,250],[1030,590],[300,265]],"holdSize":[300,250],"maxSlots":1,"insertion":"after","filters":{"viewportWidth":{"max":728}}},{"name":"hub_river_med_rec","selector":".l-hub-wrapper .c-compact-river__entry","sizes":[[300,250]],"holdSize":[300,250],"filters":{"spacing":{"before":600,"after":400},"viewportWidth":{"max":728}}},{"name":"site_sponsorship_logo_white","selector":".site_sponsorship_logo.site_sponsorship_logo-white","sizes":[[26,1]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"min":601}}},{"name":"site_sponsorship_logo_color","selector":".site_sponsorship_logo:not(.site_sponsorship_logo-white), .c-tab-bar__sponsorship","sizes":[[26,2]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"min":601}}},{"name":"site_sponsorship_logo_mobile_white","selector":".site_sponsorship_logo_mobile.site_sponsorship_logo-white","sizes":[[26,3]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"max":600}}},{"name":"site_sponsorship_logo_mobile_color","selector":".site_sponsorship_logo_mobile:not(.site_sponsorship_logo-white), .c-tab-bar__sponsorship","sizes":[[26,4]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"filters":{"viewportWidth":{"max":600}}},{"name":"native_ad_latest","selector":".dynamic-native-ad-native_ad_latest","sizes":[[300,100]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_video","selector":".dynamic-native-ad-native_ad_video","sizes":[[200,200]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_ymal_link","selector":".dynamic-native-ad-native_ad_ymal_link","sizes":[[1200,100]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_linkset_link","selector":".dynamic-native-ad-native_ad_linkset_link","sizes":[[1200,100]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"native_ad_content_link","selector":".dynamic-native-ad-native_ad_content_link","sizes":[[650,150]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false},{"name":"branded_content_feedback_form","selector":".branded_content_feedback_form","sizes":[[300,200]],"prebidEligible":false,"refreshEligible":false,"watcherEligible":false,"maxSlots":1}]};
-</script>
+  <!-- Google Optimize -->
+  <!-- Page hiding snippet -->
+  <script>(function (a, s, y, n, c, h, i, d, e) {
+      s.className += ' ' + y; h.start = 1 * new Date;
+      h.end = i = function () { s.className = s.className.replace(RegExp(' ?' + y), '') };
+      (a[n] = a[n] || []).hide = h; setTimeout(function () { i(); h.end = null }, c); h.timeout = c;
+    })(window, document.documentElement, 'async-hide', 'dataLayer', 4000,
+      { 'GTM-54FC4VZ': true });</script>
+
+  <script>
+    (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+    ga('create', 'UA-26533115-1', 'auto', { 'allowLinker': true, 'useAmpClientId': true });
+    ga('require', 'GTM-54FC4VZ');
+  </script>
+  <!-- End Google Optimize -->
+
+  <!-- Google Tag Manager -->
+  <script>(function (w, d, s, l, i) {
+      w[l] = w[l] || []; w[l].push({
+        'gtm.start':
+          new Date().getTime(), event: 'gtm.js'
+      }); var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+          'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-W8JKW6');</script>
+  <!-- End Google Tag Manager -->
+
+  <!-- Narrativ -->
+  <script type="text/javascript">
+    (function (window, document, account) {
+      window.NRTV_EVENT_DATA = { "exclusiveLinks": true };
+      var b = document.createElement("script");
+      b.type = "text/javascript";
+      b.src = `https://static.narrativ.com/tags/${account}.js`;
+      b.async = true;
+      var a = document.getElementsByTagName("script")[0];
+      a.parentNode.insertBefore(b, a);
+    })(window, document, "verge");
+  </script>
+
+  <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com">
+  <link rel="dns-prefetch" href="https://securepubads.g.doubleclick.net">
+  <link rel="dns-prefetch" href="https://stats.g.doubleclick.net">
+  <link rel="dns-prefetch" href="https://www.google-analytics.com">
+  <link rel="dns-prefetch" href="https://cdn.permutive.com">
+  <link rel="dns-prefetch" href="https://mb.moatads.com">
+
+  <script>
+    var concertAdsQueue = concertAdsQueue || [];
+
+    CONCERT_ADS_CONFIG = { "production": true, "slug": "/172968584/verge", "dfpVariables": { "network": ["verge"], "affiliation": ["general"], "unison": [true], "entry_id": [16685133], "entry_type": ["article"], "entry_slug": ["2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"], "entry_author": ["Rachel Becker"], "entry_blurb": ["The zombies are only released on the weekends, the developers promise"], "entry_title": ["You can visit the Pentagon’s secret nuclear bunker inside Minecraft"], "entry_published_date": ["2018-01-22T18:38:17.000-05:00"], "entry_group": ["front-page", "tldr", "science", "tech"], "hub_page": ["tldr", "science", "tech"], "page_type": ["interior_page"], "keywords": ["you", "can", "visit", "the", "pentagon", "s", "secret", "nuclear", "bunker", "inside", "minecraft", "the", "verge", "front-page", "tldr", "science", "tech"] }, "isUnison": true, "is_unison": true, "prebid": { "biddingEnabled": false, "prebidEnabled": false, "rubiconDemandManagerEnabled": false, "timeout": 1000, "amazonPubId": 3176, "priceGranularity": "dense", "defaultConfig": { "openx": { "delDomain": "sbnationbidder-d.openx.net" }, "rubicon": { "accountId": 7470, "position": "btf" }, "rubiconLite": { "accountId": 18288, "siteId": 193902, "sizes": [213, 270, 271, 272], "position": "btf" }, "consumable": { "networkId": 9969, "siteId": 1039096 }, "rubi__mm": { "accountId": 21670, "siteId": 294140, "zoneId": 1480258, "zoneName": "SBNation_MediaMath DC" }, "rubi__ttd": { "accountId": 21670, "siteId": 294142, "zoneName": "SBNation_TTD DC", "zoneId": 1480284 }, "usersync": { "userIds": [{ "name": "unifiedId", "params": { "url": "https://match.adsrvr.org/track/rid?ttd_pid=gs8reto\u0026fmt=json" }, "storage": { "type": "cookie", "name": "pbjs-unifiedid", "expires": 14 }, "syncDelay": 3000 }] } }, "prelude": { "trustx": { "uid": 2663 }, "consumable": { "unitId": 7423, "unitName": "cnsmbl-video-970x250" } }, "reskin": { "trustx": { "uid": 2664 } }, "desktop_leaderboard_variable": { "trustx": { "uid": 2665 } }, "medium_rectangle_variable": { "trustx": { "uid": 2666 } }, "btf_medium_rectangle_variable": { "trustx": { "uid": 2668 } }, "desktop_article_medrec_dynamic": { "trustx": { "uid": 2669 } }, "btf_leaderboard_variable": { "trustx": { "uid": 2670 } }, "native_ad_latest": { "trustx": { "uid": 2671 } }, "native_ad_ymal_link": { "trustx": { "uid": 2672 } }, "mobile_leaderboard": { "trustx": { "uid": 2673 } }, "mobile_article_body": { "trustx": { "uid": 2674 } }, "native_ad_mobile": { "trustx": { "uid": 2675 } }, "mobile_article_body_med_rec_dynamic": { "trustx": { "uid": 2676 } }, "mobile_footer": { "trustx": { "uid": 2677 } }, "tablet_leaderboard": { "trustx": { "uid": 2678 } }, "tablet_medium_rectangle": { "trustx": { "uid": 2679 } }, "tablet_btf_leaderboard": { "trustx": { "uid": 2680 } }, "native_ad_content_link": { "trustx": { "uid": 2681 } }, "hub_river_leaderboard": { "trustx": { "uid": 2682 } }, "hub_river_med_rec": { "trustx": { "uid": 2684 } }, "mobile_med_rec_athena": { "trustx": { "uid": 2685 } } }, "slots": [{ "name": "buy_button", "type": "buy_button", "selector": "[id^=\"buy-button-\"], .buy-button", "watcherEligible": false, "productElementStyle": "-15px 0 35px 0" }, { "name": "connatix-article", "type": "connatix", "selector": ".l-segment:not(.l-feature) .c-entry-content", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "hideIfPresent": { "selector": ".c-stream-list" } } }, { "name": "connatix-hub", "type": "connatix", "selector": ".l-hub-page .c-pagination", "insertion": "after", "maxSlots": 1, "watcherEligible": false }, { "name": "connatix-article-desktop", "type": "connatix", "selector": ".l-segment:not(.l-feature) .c-entry-content", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "viewportWidth": { "min": 728 }, "hideIfPresent": { "selector": ".c-stream-list" } } }, { "name": "connatix-article-mobile", "type": "connatix", "selector": ".l-segment:not(.l-feature) .c-entry-content", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "viewportWidth": { "max": 727 }, "hideIfPresent": { "selector": ".c-stream-list" } } }, { "name": "connatix-feature", "type": "connatix", "selector": ".l-feature .c-entry-content", "insertion": "after", "maxSlots": 1, "watcherEligible": false }, { "name": "connatix-feature-mobile", "type": "connatix", "selector": ".l-feature .c-entry-content", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "viewportWidth": { "max": 727 }, "hideIfPresent": { "selector": ".c-package-subnav__recirc" } } }, { "name": "connatix-feature-desktop", "type": "connatix", "selector": ".l-feature .c-entry-content", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "viewportWidth": { "min": 728 }, "hideIfPresent": { "selector": ".c-package-subnav__recirc" } } }, { "name": "connatix-feature-mobile-packaged-content", "type": "connatix", "selector": ".l-feature .c-package-subnav__recirc", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "viewportWidth": { "max": 727 } } }, { "name": "connatix-feature-desktop-packaged-content", "type": "connatix", "selector": ".l-feature .c-package-subnav__recirc", "insertion": "after", "maxSlots": 1, "watcherEligible": false, "filters": { "viewportWidth": { "min": 728 } } }, { "name": "editorially_placed_athena_mobile", "slotClassName": "m-ad__editorially_placed_athena", "prebidName": "mobile_article_body", "selector": ".m-ad.m-ad__editorial-athena-placement", "sizes": [[1030, 590], [620, 366], [325, 508], [325, 204], [300, 250], [300, "250v"]], "holdSize": [300, 500], "filters": { "viewportWidth": { "max": 727 } } }, { "name": "editorially_placed_athena_desktop", "slotClassName": "m-ad__editorially_placed_athena", "prebidName": "desktop_article_body", "selector": ".m-ad.m-ad__editorial-athena-placement", "sizes": [[1030, 590], [728, 90], { "size": [1060, 610], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [620, 366], "filters": { "containerWidth": { "max": 1059 } } }, { "size": [1060, 619], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [1060, 694], "filters": { "containerWidth": { "min": 1060 } } }], "holdSize": [728, 295], "filters": { "viewportWidth": { "min": 728 } } }, { "name": "editorially_placed_leaderboard", "prebidName": "desktop_article_body", "selector": ".m-ad.m-ad__editorial-leaderboard-placement", "sizes": [[728, 90]], "holdSize": [728, 90], "filters": { "viewportWidth": { "min": 728 } } }, { "name": "native_quicklistings", "selector": ".l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(2), .l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(6), .l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(8), .l-hub-page .river-segment-0 .c-compact-river__entry:nth-child(10)", "sizes": ["fluid"], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "filters": { "matchDomain": { "domains": "curbed.com, atlanta.curbed.com, austin.curbed.com, boston.curbed.com, chicago.curbed.com, detroit.curbed.com, hamptons.curbed.com, la.curbed.com, miami.curbed.com, nola.curbed.com, ny.curbed.com, philly.curbed.com, sf.curbed.com, seattle.curbed.com, dc.curbed.com" } } }, { "name": "native_quicklistings_article", "selector": ".l-segment .l-segment .c-compact-river__entry", "sizes": ["fluid"], "maxSlots": 1, "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "insertion": "after", "filters": { "matchDomain": { "domains": "curbed.com, atlanta.curbed.com, austin.curbed.com, boston.curbed.com, chicago.curbed.com, detroit.curbed.com, hamptons.curbed.com, la.curbed.com, miami.curbed.com, nola.curbed.com, ny.curbed.com, philly.curbed.com, sf.curbed.com, seattle.curbed.com, dc.curbed.com" } } }, { "name": "csk_mobile_article", "prebidName": "mobile_article_body_med_rec_dynamic", "slotClassName": "m-ad__csk_mobile_article", "selector": ".ad-placemarker-mobile", "sizes": [[300, 250], [300, "250v"], [320, 50]], "previewHoldSize": [300, 250], "maxSlots": 8, "insertion": "after", "filters": { "viewportWidth": { "max": 779 } } }, { "name": "csk_athena", "prebidName": "athena", "slotClassName": "m-ad__athena", "selector": ".ad-placemarker-athena", "sizes": [[1030, 590], [728, 90], [970, 250]], "holdSize": [728, 295], "insertion": "after", "maxSlots": 8, "filters": { "viewportWidth": { "min": 780 } } }, { "name": "csk_athena_mobile", "prebidName": "mobile_med_rec_athena", "selector": ".ad-placemarker-athena-mobile", "sizes": [[1030, 590], [325, 508], [325, 204], [300, 250], [300, "250v"]], "holdSize": [300, 250], "filters": { "viewportWidth": { "max": 779 } } }, { "name": "csk_article_sponsorship", "slotClassName": "m-ad__article_sponsorship", "selector": ".ad-placemarker-light-logo-desktop", "insertion": "after", "maxSlots": 1, "sizes": [[200, 40]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "prelude", "selector": ".l-root", "reveal": { "enabled": true, "offset": 0, "zIndex": -1000, "observationTarget": ".l-header" }, "sizes": [[1400, 600], [1180, 450]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "allowSiblings": true, "filters": { "viewportWidth": { "min": 881 }, "deviceType": "desktop" } }, { "name": "reskin", "selector": ".l-root", "sizes": [[2, 2]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "filters": { "viewportWidth": { "min": 1280 }, "hideIfPresent": { "selector": ".l-feature, .c-maps-hub" } } }, { "name": "desktop_leaderboard_variable", "selector": ".l-header", "sizes": [[728, 90], [970, 90], [1020, 90]], "holdSize": [728, 90], "insertion": "after", "filters": { "viewportWidth": { "min": 881 }, "hideIfPresent": { "selector": ".l-feature" } } }, { "name": "tablet_leaderboard", "selector": ".l-header", "sizes": [[728, 90]], "holdSize": [728, 90], "insertion": "after", "filters": { "viewportWidth": { "min": 729, "max": 880 } } }, { "name": "mobile_leaderboard_hub", "slotClassName": "m-ad__mobile_leaderboard", "prebidName": "mobile_leaderboard", "selector": ".l-hub-page .l-header", "sizes": [[320, 50], [300, 250], [300, "250v"]], "holdSize": [300, 250], "insertion": "after", "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 } } }, { "name": "mobile_leaderboard_group", "slotClassName": "m-ad__mobile_leaderboard", "prebidName": "mobile_leaderboard", "selector": ".l-group-page .l-header", "sizes": [[320, 50], [300, 250], [300, "250v"]], "holdSize": [320, 50], "insertion": "after", "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 } } }, { "name": "package_cover_ad", "prebidName": "desktop_leaderboard_variable", "selector": ".c-package-subnav", "sizes": [[728, 90], [970, 250], [970, 90], [1020, 90], [1030, 590], { "size": [1060, 610], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [620, 366], "filters": { "containerWidth": { "max": 1059 } } }, { "size": [1060, 619], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [1060, 694], "filters": { "containerWidth": { "min": 1060 } } }], "holdSize": [728, 90], "insertion": "after", "filters": { "viewportWidth": { "min": 729 } } }, { "name": "package_cover_ad_mobile", "prebidName": "mobile_leaderboard", "selector": ".c-package-subnav", "sizes": [[320, 50], [300, 250], [300, "250v"], [1030, 590], [325, 508], [325, 204]], "holdSize": [320, 50], "insertion": "after", "filters": { "viewportWidth": { "max": 729 } } }, { "name": "btf_leaderboard_variable", "classNames": ["mt-3", "mr-a", "mb-3", "ml-a"], "selector": ".c-footer", "sizes": [[728, 90], [1020, 90]], "holdSize": [728, 90], "filters": { "viewportWidth": { "min": 881 } } }, { "name": "tablet_btf_leaderboard", "selector": ".c-footer", "sizes": [[728, 90]], "holdSize": [728, 90], "filters": { "viewportWidth": { "min": 729, "max": 888 } } }, { "name": "mobile_footer", "classNames": ["mt-2", "mb-2"], "selector": "body:not(.entry_layout_unison_package_landing) .c-footer", "sizes": [[320, 50], [300, 250], [300, "250v"], [325, 204], [1030, 590]], "holdSize": [300, 250], "filters": { "viewportWidth": { "min": 0, "max": 728 } } }, { "name": "package_mobile_footer", "prebidName": "mobile_footer", "selector": ".entry_layout_unison_package_landing .c-footer", "sizes": [[320, 50], [300, 250], [300, "250v"], [1030, 590], [325, 508], [325, 204]], "holdSize": [300, 250], "filters": { "viewportWidth": { "min": 0, "max": 728 } } }, { "name": "desktop_feature_footer", "selector": ".l-feature .c-entry-content p:last-child", "insertion": "after", "maxSlots": 1, "sizes": [[728, 90], [1020, 90]], "holdSize": [728, 90], "filters": { "spacing": { "before": 700 }, "viewportWidth": { "min": 881 } } }, { "name": "mobile_feature_footer", "selector": ".c-entry-content", "insertion": "after", "sizes": [[320, 50], [300, 250], [300, "250v"], [325, 204], [325, 508]], "maxSlots": 1, "holdSize": [300, 250], "filters": { "spacing": { "before": 500 }, "viewportWidth": { "min": 0, "max": 728 }, "hideIfPresent": { "selector": ".c-stream-list" } } }, { "name": "mobile_feature_body", "slotClassName": "m-ad__mobile_article_body_med_rec_dynamic", "prebidName": "mobile_article_body_med_rec_dynamic", "selector": ".l-feature .c-entry-content \u003e p + p", "sizes": [[300, 250], [300, "250v"], [325, 508], [325, 204], [320, 50], [1030, 590]], "previewHoldSize": [300, 250], "maxSlots": 1, "filters": { "spacing": { "before": 150 }, "viewportWidth": { "max": 779 } } }, { "name": "desktop_feature_body", "prebidName": "desktop_article_body", "selector": ".l-feature .c-entry-content \u003e p + p", "sizes": [[728, 90], [620, 366], [1030, 590]], "previewHoldSize": [728, 90], "maxSlots": 1, "insertion": "after", "filters": { "avoidFloats": true, "spacing": { "before": 300, "after": 1200 }, "paragraphHeight": { "above": 100 }, "viewportWidth": { "min": 780 }, "hideIfPresent": { "selector": ".c-buying-guide" } } }, { "name": "desktop_feature_body_dynamic", "slotClassName": "m-ad__desktop_feature_body", "prebidName": "desktop_article_body", "selector": ".l-feature .c-entry-content \u003e p + p", "sizes": [[728, 90], [300, 250], [300, "250v"], [620, 366], [1030, 590]], "previewHoldSize": [728, 90], "maxSlots": 3, "filters": { "avoidFloats": true, "spacing": { "before": 1200, "after": 1200 }, "paragraphHeight": { "above": 200 }, "viewportWidth": { "min": 780 }, "hideIfPresent": { "selector": ".c-buying-guide" } } }, { "name": "athena_features_mobile", "slotClassName": "m-ad__athena_features", "prebidName": "athena_features", "selector": ".l-feature .c-entry-content \u003e p + p", "sizes": [[1030, 590], [325, 508], [300, 250], [300, "250v"], [300, 265], [325, 204]], "previewHoldSize": [300, 250], "maxSlots": 1, "filters": { "avoidFloats": true, "paragraphHeight": { "above": 200 }, "viewportWidth": { "max": 779 }, "spacing": { "before": 1500 } } }, { "name": "athena_features_dynamic_mobile", "slotClassName": "m-ad__athena_features_dynamic", "prebidName": "athena_features_dynamic", "selector": ".l-feature .c-entry-content \u003e p + p", "sizes": [[1030, 590], [325, 508], [300, 250], [300, "250v"], [300, 265], [325, 204]], "previewHoldSize": [300, 250], "maxSlots": 10, "filters": { "avoidFloats": true, "paragraphHeight": { "above": 200 }, "viewportWidth": { "max": 779 }, "spacing": { "before": 1500 } } }, { "name": "athena_features_desktop", "slotClassName": "m-ad__athena_features", "prebidName": "desktop_article_body", "selector": ".l-feature .c-entry-content \u003e p + p", "sizes": [[1030, 590], [620, 366], [620, 371], [620, 415], [728, 90]], "previewHoldSize": [726, 415], "filters": { "paragraphHeight": { "above": 200 }, "avoidFloats": true, "viewportWidth": { "min": 779 }, "spacing": { "after": 1200, "before": 1200 } } }, { "name": "mobile_leaderboard", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p + p", "sizes": [[1030, 590], [320, 50], [300, 250], [300, "250v"]], "holdSize": [300, 250], "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 } } }, { "name": "desktop_article_body", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p + p, .l-article .c-entry-content \u003e p + p", "sizes": [[1030, 590], [620, 366], [620, 371], [620, 415], { "size": [728, 90], "filters": { "containerWidth": { "min": 700 } } }], "previewHoldSize": [726, 415], "maxSlots": 1, "filters": { "avoidFloats": true, "paragraphHeight": { "above": 150, "below": 250 }, "spacing": { "before": 750, "after": 450 }, "containerWidth": { "min": 620 } } }, { "name": "mobile_article_body", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p + p", "sizes": [[1030, 590], [325, 508], [300, 250], [300, "250v"], [300, 265], [325, 204]], "previewHoldSize": [300, 250], "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 }, "spacing": { "before": 600 } } }, { "name": "native_ad_mobile", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p + p", "sizes": [[1030, 590], [325, 508], [300, 250], [300, "250v"], [300, 265], [325, 204]], "previewHoldSize": [300, 250], "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 }, "spacing": { "before": 600 } } }, { "name": "mobile_article_body_med_rec_dynamic", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p + p", "sizes": [[300, 250], [300, "250v"], [1030, 590], [325, 508], [325, 204], [320, 50]], "previewHoldSize": [300, 250], "filters": { "viewportWidth": { "max": 728 }, "spacing": { "before": 900 }, "paragraphHeight": { "above": 100, "below": 100 } } }, { "name": "desktop_article_medrec_dynamic", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p + p, .l-article .c-entry-content \u003e p + p", "sizes": [[300, 250], [300, "250v"]], "holdSize": [300, 250], "filters": { "paragraphHeight": { "above": 150, "below": 250 }, "viewportWidth": { "min": 729 }, "avoidFloats": true, "spacing": { "before": 1500, "after": 750 } } }, { "name": "medium_rectangle_variable", "selector": ".l-col__sidebar:not(.c-sports-blog-directory__filter) \u003e div:first-of-type, .l-article-sidebar \u003e *:first-child", "sizes": [[300, 250], [300, "250v"], [300, 600]], "holdSize": [300, 250], "maxSlots": 1, "allowSiblings": true, "filters": { "viewportWidth": { "min": 881 }, "hideIfPresent": { "selector": ".l-full-archives" }, "elementHeight": { "selector": ".l-article-body-segment .l-col__main, .l-main-content \u003e .l-col__main", "min": 2001 } } }, { "name": "medium_rectangle_short", "prebidName": "desktop_article_medrec_dynamic", "selector": ".l-col__sidebar:not(.c-sports-blog-directory__filter) \u003e div:first-of-type, .l-article-sidebar \u003e *:first-child", "sizes": [[300, 250], [300, "250v"]], "holdSize": [300, 250], "maxSlots": 1, "allowSiblings": true, "filters": { "viewportWidth": { "min": 881 }, "hideIfPresent": { "selector": ".l-full-archives" }, "elementHeight": { "selector": ".l-article-body-segment .l-col__main, .l-main-content \u003e .l-col__main", "max": 2000 } } }, { "name": "btf_medium_rectangle_variable_article", "slotClassName": "m-ad__btf_medium_rectangle_variable", "prebidName": "btf_medium_rectangle_variable", "selector": "body[data-entry-id] .l-col__sidebar:not(.c-sports-blog-directory__filter) \u003e div:last-of-type", "allowSiblings": true, "sticky": { "enabled": true, "offset": 100 }, "sizes": [[300, 250], [300, "250v"], { "size": [300, 600], "filters": { "viewportHeight": { "min": 600 } } }], "holdSize": [300, 250], "insertion": "after", "maxSlots": 1, "filters": { "viewportWidth": { "min": 881 } }, "refreshRate": 15 }, { "name": "btf_medium_rectangle_variable_hub", "slotClassName": "m-ad__btf_medium_rectangle_variable", "prebidName": "btf_medium_rectangle_variable", "selector": ".l-hub-page .l-col__sidebar \u003e div:last-of-type, .l-group-page .l-col__sidebar \u003e div:last-of-type", "sticky": { "enabled": true, "offset": 50 }, "sizes": [[300, 250], [300, "250v"], [300, 600]], "holdSize": [300, 250], "insertion": "after", "maxSlots": 2, "filters": { "viewportWidth": { "min": 881 }, "hideIfPresent": { "selector": ".l-full-archives" } }, "refreshRate": 15 }, { "name": "in_map_legacy", "slotClassName": "m-ad__in_map", "prebidName": "in_map", "selector": ".c-mapstack__ad", "sizes": [[300, 250], [300, "250v"]], "previewHoldSize": [300, 250] }, { "name": "in_map", "selector": ".c-mapstack__card--ad", "sizes": [[300, 250], [300, "250v"], [1030, 590], [620, 366], [620, 371], [620, 415]], "previewHoldSize": [300, 250], "insertion": "after" }, { "name": "mapstack_sponsorship", "slotClassName": "m-ad__mapstack_sponsorship", "selector": ".c-mapstack__content", "insertion": "before", "maxSlots": 1, "sizes": [[200, 40]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "athena_hub", "slotClassName": "m-ad__athena", "prebidName": "athena", "selector": ".l-hub-page .river-segment-0, .l-group-page .river-segment-0", "sizes": [[1030, 590], [970, 250], [728, 90], { "size": [1060, 610], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [620, 366], "filters": { "containerWidth": { "max": 1059 } } }, { "size": [1060, 619], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [1060, 694], "filters": { "containerWidth": { "min": 1060 } } }], "holdSize": [728, 295], "maxSlots": 1, "insertion": "after", "filters": { "viewportWidth": { "min": 728 } } }, { "name": "athena_article", "slotClassName": "m-ad__athena", "prebidName": "athena", "selector": ".l-article-body-segment", "sizes": [[1030, 590], [728, 90], { "size": [1060, 610], "filters": { "containerWidth": { "min": 1060 } } }, { "size": [620, 366], "filters": { "containerWidth": { "max": 1059 } } }, { "size": [970, 250], "filters": { "viewportWidth": { "min": 970 } } }, { "size": [620, 371], "filters": { "containerWidth": { "max": 1059 } } }, { "size": [620, 415], "filters": { "containerWidth": { "max": 1059 } } }], "holdSize": [728, 295], "maxSlots": 1, "insertion": "after", "filters": { "viewportWidth": { "min": 728 }, "hideIfPresent": { "selector": ".c-package-subnav" } } }, { "name": "hub_river_leaderboard", "classNames": ["mt-3", "mr-a", "mb-3", "ml-a"], "selector": ".l-hub-page .c-compact-river__entry, .l-group-page .c-compact-river__entry", "sizes": [[728, 90], [1030, 590], [620, 366]], "holdSize": [728, 90], "filters": { "spacing": { "before": 700, "after": 500, "exceptSlot": "native_quicklistings" }, "containerWidth": { "min": 728 } } }, { "name": "mobile_med_rec_athena", "selector": ".l-hub-page .river-segment-0", "sizes": [[300, 250], [300, "250v"], [1030, 590], [325, 508], [300, 265], [325, 204]], "holdSize": [300, 250], "maxSlots": 1, "insertion": "after", "filters": { "viewportWidth": { "max": 728 } } }, { "name": "hub_river_med_rec", "selector": ".l-hub-wrapper .c-compact-river__entry, .l-group-page .c-compact-river__entry", "sizes": [[300, 250], [300, "250v"], [1030, 590], [325, 204], [325, 508]], "customSizes": [{ "placement": 1, "sizes": [[300, 250], [300, "250v"], [1030, 590], [325, 204], [325, 508]] }], "holdSize": [300, 250], "filters": { "spacing": { "before": 600, "after": 400 }, "viewportWidth": { "max": 728 } } }, { "name": "gift_guide_leaderboard_variable_desktop", "slotClassName": "m-ad__desktop_article_body", "prebidName": "desktop_article_body", "selector": ".l-feature .c-buying-guide", "sizes": [[1030, 590], [620, 366], [728, 90], [620, 371], [620, 415]], "previewHoldSize": [726, 415], "maxSlots": 1, "filters": { "viewportWidth": { "min": 728 } } }, { "name": "gift_guide_leaderboard_mobile", "slotClassName": "m-ad__mobile_leaderboard", "prebidName": "mobile_leaderboard", "selector": ".l-feature .c-buying-guide", "sizes": [[320, 50], [300, 250], [300, "250v"], [1030, 590]], "holdSize": [300, 250], "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 } } }, { "name": "storystream_top_leaderboard_desktop", "slotClassName": "m-ad__hub_river_leaderboard", "prebidName": "desktop_leaderboard_variable", "selector": ".l-main-content \u003e .c-entry-group-labels--stream", "sizes": [[728, 90], [970, 90], [970, 250], [1020, 90]], "holdSize": [728, 90], "maxSlots": 1, "filters": { "viewportWidth": { "min": 880 } } }, { "name": "storystream_bottom_leaderboard_variable_desktop", "slotClassName": "m-ad__desktop_article_body", "prebidName": "btf_leaderboard_variable", "selector": ".c-entry-group-labels--stream ~ .c-entry-update-bar", "sizes": [[1030, 590], [620, 366], [620, 371], [620, 415], [728, 90]], "previewHoldSize": [726, 415], "maxSlots": 1, "filters": { "hideIfPresent": { "selector": ".connatix-article" }, "avoidFloats": true, "containerWidth": { "min": 729 } } }, { "name": "storystream_river_leaderboard_variable_desktop", "slotClassName": "m-ad__hub_river_leaderboard", "classNames": ["mt-3", "mb-3"], "prebidName": "hub_river_leaderboard", "selector": ".c-stream-list .c-stream-list__entry:nth-of-type(6n)", "sizes": [[1030, 590], [620, 366], [620, 371], [620, 415], [728, 90]], "previewHoldSize": [726, 415], "insertion": "after", "filters": { "viewportWidth": { "min": 729 } } }, { "name": "storystream_top_leaderboard_mobile", "slotClassName": "m-ad__hub_river_leaderboard", "prebidName": "mobile_leaderboard", "selector": ".l-main-content \u003e .c-entry-group-labels--stream", "sizes": [[320, 50], [300, 250], [300, "250v"]], "holdSize": [320, 50], "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 } } }, { "name": "storystream_bottom_leaderboard_variable_mobile", "slotClassName": "m-ad__mobile_article_body_med_rec_dynamic", "prebidName": "mobile_footer", "selector": ".c-entry-group-labels--stream ~ .c-entry-update-bar", "sizes": [[320, 50], [300, 250], [300, "250v"], [1030, 590], [325, 508], [325, 204], { "size": [620, 366], "filters": { "viewportWidth": { "min": 620 } } }], "previewHoldSize": [300, 250], "maxSlots": 1, "filters": { "containerWidth": { "max": 728 } } }, { "name": "storystream_river_leaderboard_variable_mobile", "slotClassName": "m-ad__mobile_article_body_med_rec_dynamic", "prebidName": "mobile_article_body_med_rec_dynamic", "selector": ".c-stream-list .c-stream-list__entry:nth-of-type(6n) .c-entry-box--stream-item", "sizes": [[320, 50], [300, 250], [300, "250v"]], "customSizes": [{ "placement": 2, "sizes": [[320, 50], [300, 250], [300, "250v"], [1030, 590], [325, 508], [325, 204]] }], "previewHoldSize": [300, 250], "insertion": "after", "filters": { "viewportWidth": { "max": 728 } } }, { "name": "site_sponsorship_logo_white", "selector": ".site_sponsorship_logo.site_sponsorship_logo-white", "sizes": [[26, 1]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "filters": { "viewportWidth": { "min": 601 } } }, { "name": "site_sponsorship_logo_color", "selector": ".site_sponsorship_logo:not(.site_sponsorship_logo-white), .c-tab-bar__sponsorship", "sizes": [[26, 2]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "filters": { "viewportWidth": { "min": 601 } } }, { "name": "site_sponsorship_logo_mobile_white", "selector": ".site_sponsorship_logo_mobile.site_sponsorship_logo-white", "sizes": [[26, 3]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "filters": { "viewportWidth": { "max": 600 } } }, { "name": "site_sponsorship_logo_mobile_color", "selector": ".site_sponsorship_logo_mobile:not(.site_sponsorship_logo-white), .c-tab-bar__sponsorship", "sizes": [[26, 4]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "filters": { "viewportWidth": { "max": 600 } } }, { "name": "native_ad_latest", "selector": ".dynamic-native-ad-native_ad_latest", "prebidName": "desktop_article_medrec_dynamic", "sizes": [[300, 100]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "native_ad_video", "selector": ".dynamic-native-ad-native_ad_video", "sizes": [[200, 200]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "native_ad_ymal_link", "selector": ".dynamic-native-ad-native_ad_ymal_link", "sizes": [[1200, 100]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "native_ad_linkset_link", "selector": ".dynamic-native-ad-native_ad_linkset_link", "sizes": [[1200, 100]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "native_ad_content_link", "selector": ".dynamic-native-ad-native_ad_content_link", "sizes": [[650, 150]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "native_ad_module", "selector": ".c-related-list", "sizes": ["fluid", [1100, 250]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "maxSlots": 1 }, { "name": "branded_content_feedback_form", "selector": ".branded_content_feedback_form", "sizes": [[300, 200]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false, "maxSlots": 1 }, { "name": "article_sponsorship", "slotClassName": "m-ad__article_sponsorship", "selector": ".entry_template_package_landing .c-package-cover__title-body, body.entry_layout_unison_main .c-entry-hero--feature .c-entry-hero__content .c-byline, body.entry_layout_unison_main div.c-entry-hero:not(.c-entry-hero--feature)", "insertion": "after", "maxSlots": 1, "sizes": [[200, 40]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "hub_sponsorship", "slotClassName": "m-ad__hub_sponsorship", "selector": ".c-hub-title__inner, .c-group-header .p-page-title", "insertion": "after", "maxSlots": 1, "sizes": [[200, 40]], "prebidEligible": false, "refreshEligible": false, "watcherEligible": false }, { "name": "failsafe_article_med_rec_athena_mobile", "slotClassName": "m-ad__mobile_med_rec_athena", "prebidName": "mobile_med_rec_athena", "selector": "body:not(.entry_template_stream):not(.entry_template_package_landing) .c-entry-content \u003e *:last-child", "sizes": [[300, 250], [300, "250v"], [1030, 590], [325, 508], [300, 265], [325, 204]], "holdSize": [300, 250], "maxSlots": 1, "insertion": "after", "filters": { "viewportWidth": { "max": 728 }, "spacing": { "before": 300 }, "hideIfPresent": { "selector": ".c-entry-content .m-ad", "count": 2 } } }, { "name": "failsafe_mobile_leaderboard", "selector": ".l-segment:not(.l-feature) .c-entry-content \u003e p:nth-of-type(2)", "sizes": [[320, 50], [300, 250], [300, "250v"]], "holdSize": [300, 250], "insertion": "after", "maxSlots": 1, "filters": { "viewportWidth": { "max": 728 }, "hideIfPresent": { "selector": ".m-ad__mobile_leaderboard" } } }, { "name": "desktop_article_body_failsafe", "classNames": ["mb-3"], "prebidName": "desktop_article_body", "selector": ".l-segment:not(.l-feature) .c-entry-content p + p, .l-article .c-entry-content p + p", "sizes": [[1030, 590], [620, 366], [620, 371], [620, 415], { "size": [728, 90], "filters": { "containerWidth": { "min": 700 } } }], "previewHoldSize": [726, 415], "insertion": "after", "maxSlots": 1, "filters": { "avoidFloats": true, "paragraphHeight": { "above": 100, "below": 100 }, "spacing": { "before": 200, "after": 200 }, "containerWidth": { "min": 620 }, "hideIfPresent": { "selector": ".c-entry-content .m-ad__desktop_article_body" } } }], "adConfigurationUrl": "https://concertads-configs.vox-cdn.com/sbn/verge/config.json" };
+  </script>
 
 
-      <link href="https://www.theverge.com/style/community/372/782bf9d1ae1e05068bc27d9c26f47512/chorus.css" data-chorus-theme="chorus" rel="stylesheet" media="all">
+  <link href="https://www.theverge.com/style/community/372/4beb0d39fe826e3d4344d52a6c479929/chorus.css"
+    data-chorus-theme="chorus" rel="stylesheet" media="all">
 
-    <meta name="style-tools" content="https://www.theverge.com/style/community/372/28cb80427845372171ae614260040cba/tools.css">
-    
-      <script class="kxct" data-id="JImcjrMY" data-timing="async" data-version="1.9" type="text/javascript" src="https://cdn.krxd.net/controltag?confid=JImcjrMY" async></script>
-<script src="https://cdn.vox-cdn.com/presto/chorus_ads.45e36d5921d13d340d87.js" async="async"></script>
-<script src="https://c.amazon-adsystem.com/aax2/apstag.js" async></script>
-<script src="https://www.googletagservices.com/tag/js/gpt.js" async></script>
+  <meta name="style-tools"
+    content="https://www.theverge.com/style/community/372/47d0893f4d3e1366fcfe2e9b83e73c93/tools.css">
 
-    
-    <meta name="description" content="Analysts at the James Martin Center for Nonproliferation Studies reconstructed a 3D model of the Pentagon’s nuclear bunker at Raven Rock based on satellite images, declassified information, and some guesswork." />
-<link rel="canonical" href="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" />
-<meta property="og:description" content="The zombies are only released on the weekends, the developers promise" />
-<meta property="fb:app_id" content="549923288395304" />
-<meta property="og:image" content="https://cdn.vox-cdn.com/thumbor/AtQQMyWrexi6-Xyk73jv6nqTO7s=/0x5:1247x658/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png" />
-<meta property="og:image:height" content="630" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:site_name" content="The Verge" />
-<meta property="og:title" content="You can visit the Pentagon’s secret nuclear bunker inside Minecraft" />
-<meta property="og:type" content="article" />
-<meta property="og:url" content="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" />
+  <script src="https://cdn.vox-cdn.com/packs/js/concert_ads-790635f551209930263f.js" async="async"
+    integrity="sha256-2cBitj17IQ9+B7we0AFAlsr81nXv0Aip6sKh3e2tXQk= sha384-gXOIxuMMiOP6RQwhlZhWkaBDL4bKZd2Tgn64LPWaMKZKx1tUJqjA3+c3e7yHitB1"
+    crossorigin="anonymous"></script>
+  <script type="text/javascript">
+    function instantiateConcertAds() {
+      var concertAdsConfig = {
+        cmd: window.concertAdsQueue
+      };
 
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:url" content="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" />
-      <meta name="twitter:title" content="You can visit the Pentagon’s secret nuclear bunker inside Minecraft" />
-      <meta name="twitter:description" content="The zombies are only released on the weekends, the developers promise" />
-      <meta name="twitter:image" content="https://cdn.vox-cdn.com/thumbor/d0eb9lq-0qa_LyzAh4Me6KNoQCM=/0x19:1247x643/fit-in/1200x600/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png" />
-      <meta name="twitter:site" content="verge" />
-    
+      for (var property in window.CONCERT_ADS_CONFIG) {
+        concertAdsConfig[property] = window.CONCERT_ADS_CONFIG[property];
+      }
 
-      <meta name="sailthru.title" content="You can visit the Pentagon’s secret nuclear bunker inside Minecraft" />
-      <meta name="sailthru.tags" content="general,the-verge" />
-      <meta name="sailthru.date" content="2018-01-22" />
-      <meta name="sailthru.description" content="Analysts at the James Martin Center for Nonproliferation Studies reconstructed a 3D model of the Pentagon’s nuclear bunker at Raven Rock based on satellite images, declassified information, and some guesswork." />
-    
-    <meta name="google-site-verification" content="IucFf_TKtbFFH8_YeFyEteQIwYPdANM1R46_U9DpAr4" />
-
-<meta name="msvalidate.01" content="D385D0326A3AE144205C298DB34B4E94" />
-
-<style>
-
-article quote em:before {
-content: none;
-}
-
-</style>
-
-    
-  <link rel="shortcut icon" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395361/favicon-64x64.0.ico">
+      window.concertAds = new ConcertAds(concertAdsConfig);
+    }
+  </script>
+  <script src="https://cdn.concert.io/lib/concert-ads/wh-dv-test-briar/concert_ads.js" onload="instantiateConcertAds()"
+    async=""></script>
+  <script src="https://c.amazon-adsystem.com/aax2/apstag.js" async=""></script>
+  <script src="https://www.googletagservices.com/tag/js/gpt.js" async=""></script>
 
 
-  
-    <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395367/favicon-16x16.0.png" sizes="16x16">
-  
-
-  
-    <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395363/favicon-32x32.0.png" sizes="32x32">
-  
-
-  
-    <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395365/favicon-96x96.0.png" sizes="96x96">
-  
+  <script src="https://cdn.concert.io/lib/concert-concierge.2.8.0.min.js" async=""></script>
 
 
-  
-    <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395351/android-chrome-192x192.0.png" sizes="192x192">
-  
+  <script defer="" type="text/javascript"
+    src="https://z.moatads.com/voxprebidheader841653991752/moatheader.js"></script>
 
 
-  
-    <link rel="apple-touch-icon" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395359/ios-icon.0.png" sizes="180x180">
-  
+  <meta name="google-site-verification" content="IucFf_TKtbFFH8_YeFyEteQIwYPdANM1R46_U9DpAr4">
+
+  <meta name="msvalidate.01" content="D385D0326A3AE144205C298DB34B4E94">
+
+  <meta name="ahrefs-site-verification" content="1e57a609922037a3fbdc1c22efd7334113f174f15608f37e1b8538a7b4ce64c3">
+  <meta name="description"
+    content="Analysts at the James Martin Center for Nonproliferation Studies reconstructed a 3D model of the Pentagon’s nuclear bunker at Raven Rock based on satellite images, declassified information, and some guesswork.">
+  <link rel="canonical"
+    href="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model">
+  <meta property="og:description" content="The zombies are only released on the weekends, the developers promise">
+  <meta property="fb:app_id" content="549923288395304">
+  <meta property="og:image"
+    content="https://cdn.vox-cdn.com/thumbor/AtQQMyWrexi6-Xyk73jv6nqTO7s=/0x5:1247x658/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:site_name" content="The Verge">
+  <meta property="og:title" content="You can visit the Pentagon’s secret nuclear bunker inside Minecraft">
+  <meta property="og:type" content="article">
+  <meta property="og:url"
+    content="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url"
+    content="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model">
+  <meta name="twitter:title" content="You can visit the Pentagon’s secret nuclear bunker inside Minecraft">
+  <meta name="twitter:description" content="The zombies are only released on the weekends, the developers promise">
+  <meta name="twitter:image"
+    content="https://cdn.vox-cdn.com/thumbor/d0eb9lq-0qa_LyzAh4Me6KNoQCM=/0x19:1247x643/fit-in/1200x600/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png">
+  <meta name="twitter:site" content="verge">
+
+  <meta name="parsely-title" content="You can visit the Pentagon’s secret nuclear bunker inside Minecraft">
+  <meta name="parsely-link"
+    content="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model">
+  <meta name="parsely-type" content="post">
+  <meta name="parsely-image-url"
+    content="https://cdn.vox-cdn.com/thumbor/EgetfaU6sRK3oTK92BEsP4lq9YQ=/0x0:1280x720/1600x900/cdn.vox-cdn.com/uploads/chorus_image/image/58416871/2018_01_22_14_19_55.0.gif">
+  <meta name="parsely-pub-date" content="2018-01-22T18:38:17-05:00">
+  <meta name="parsely-section" content="front-page">
+  <meta name="parsely-tags" content="verge,front-page,tldr,science,tech">
+  <meta name="parsely-author" content="Rachel Becker">
+
+  <link rel="shortcut icon" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/21956592/favicon-96x96.0.0.ico">
 
 
-  <meta name="msapplication-TileImage" content="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7396113/221a67c8-a10f-11e6-8fae-983107008690.0.png">
+
+  <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395367/favicon-16x16.0.png"
+    sizes="16x16">
+
+
+
+  <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395363/favicon-32x32.0.png"
+    sizes="32x32">
+
+
+
+  <link rel="icon" type="image/png" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395365/favicon-96x96.0.png"
+    sizes="96x96">
+
+
+
+
+  <link rel="icon" type="image/png"
+    href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395351/android-chrome-192x192.0.png" sizes="192x192">
+
+
+
+
+  <link rel="apple-touch-icon" href="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7395359/ios-icon.0.png"
+    sizes="180x180">
+
+
+
+  <meta name="msapplication-TileImage"
+    content="https://cdn.vox-cdn.com/uploads/chorus_asset/file/7396113/221a67c8-a10f-11e6-8fae-983107008690.0.png">
   <meta name="msapplication-TileColor" content="#393092">
   <meta name="theme-color" content="">
 
 
-    <meta data-chorus-version="d687f8ff40b1321685f9e19552b2fdaae4508ebe" />
+  <meta data-chorus-version="e96f3acbaa8b57bfb1ac57832719d4d7032362eb">
 
-    <link rel="amphtml" href="https://www.theverge.com/platform/amp/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model">
+  <link rel="amphtml"
+    href="https://www.theverge.com/platform/amp/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model">
 
+  <link rel="alternate" type="application/rss+xml" title="The Verge" href="/rss/index.xml">
 
-    <link rel="alternate" type="application/rss+xml" title="The Verge" href="/rss/index.xml" />
-    
-      <script type="application/ld+json">
-  {
-  "@context": "http://schema.org",
-  "@type": "NewsArticle",
-  "mainEntityOfPage": "https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model",
-  "headline": "You can visit the Pentagon’s secret nuclear bunker inside Minecraft",
-  "description": "Analysts at the James Martin Center for Nonproliferation Studies reconstructed a 3D model of the Pentagon’s nuclear bunker at Raven Rock based on satellite images, declassified information, and some guesswork. ",
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "xpath": [
-      "/html/head/title",
-      "/html/head/meta[@name='description']/@content"
-    ]
-  },
-    "datePublished": "2018-01-22T18:38:17-05:00",
-    "dateModified": "2018-01-22T18:38:17-05:00",
-    "image": {"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/AtQQMyWrexi6-Xyk73jv6nqTO7s=/0x5:1247x658/fit-in/1200x630/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png","width":1310,"height":873},
-  "author": {
-  "@type": "Person",
-  "name": "Rachel Becker"
-  },
-  "publisher": {
-  "@type": "Organization",
-    "logo": {"@type":"ImageObject","url":"https://www.theverge.com/v/verge/images/logos/google_amp.png","width":600,"height":60},
-  "name": "The Verge"
-  }
-  }
+  <script type="application/ld+json">
+{"@context":"http://schema.org","@type":"NewsArticle","mainEntityOfPage":"https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model","url":"https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model","headline":"You can visit the Pentagon’s secret nuclear bunker inside Minecraft","description":"Analysts at the James Martin Center for Nonproliferation Studies reconstructed a 3D model of the Pentagon’s nuclear bunker at Raven Rock based on satellite images, declassified information, and some guesswork. ","speakable":{"@type":"SpeakableSpecification","xpath":["/html/head/title","/html/head/meta[@name='description']/@content"]},"datePublished":"2018-01-22T18:38:17-05:00","dateModified":"2018-01-22T18:38:17-05:00","author":[{"@type":"Person","name":"Rachel Becker"}],"publisher":{"@type":"Organization","name":"The Verge","logo":{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/uploads/chorus_asset/file/13668586/google_amp.0.png","width":600,"height":60}},"articleSection":"Front Page","keywords":["Front Page","TL;DR","Science","Tech"],"image":[{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/uD9hE2uju4nGIb4AQCuCOlSy1Q4=/1400x1400/filters:format(png)/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png","width":1400,"height":1400},{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/Ob8auHXgrz7zV3esE5aG-N3QnsQ=/1400x1050/filters:format(png)/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png","width":1400,"height":1050},{"@type":"ImageObject","url":"https://cdn.vox-cdn.com/thumbor/CQr9vP_jyyeKG5x1T-rUbLs7vsw=/1400x788/filters:format(png)/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png","width":1400,"height":788}],"thumbnailUrl":"https://cdn.vox-cdn.com/thumbor/uD9hE2uju4nGIb4AQCuCOlSy1Q4=/1400x1400/filters:format(png)/cdn.vox-cdn.com/uploads/chorus_asset/file/10079811/Screen_Shot_2018_01_22_at_3.27.50_PM.png"}
 </script>
 
 
-    <meta name="outbrainsection" content="tldr"></meta>
-  </head>
-  <!--[if lte IE 9]><body class="ie9"><![endif]-->
-  <!--[if gte IE 10]><body class="ie"><![endif]-->
-  <body class="  entry_key_unison_standard entry_layout_unison_main entry_template_standard" data-entry-id=16685133>
-    <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W8JKW6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
+  <meta name="outbrainsection" content="tldr">
+</head>
+<!--[if lte IE 9]><body class="ie9"><![endif]-->
+<!--[if gte IE 10]><body class="ie"><![endif]-->
 
-      <svg width="0" height="0" style="position:absolute;display:none;"><symbol viewbox="90 0 689 645" id="icon-clock" xmlns="http://www.w3.org/2000/svg"><title>clock</title>
-<path d="M489.1 322.5c0 15-5.4 27.9-16 38.6-10.7 10.7-23.6 16-38.6 16-23.7 0-40.3-10.9-49.9-32.8h-125c-6.4 0-11.6-2.1-15.7-6.1-4-4.1-6.1-9.3-6.1-15.7 0-6.4 2.1-11.6 6.1-15.7 4.1-4.1 9.4-6.1 15.8-6.1h125c5.9-13.2 15.3-22.5 28-28V125.8c0-6.4 2.1-11.6 6.1-15.7 4.1-4.1 9.3-6.1 15.7-6.1 6.4 0 11.6 2 15.7 6.1s6.1 9.3 6.1 15.7v146.8c21.9 9.5 32.9 26.1 32.8 49.9zm-54.6-306c84.2 0 156.3 29.9 216.2 89.8 59.9 59.9 89.8 131.9 89.8 216.2s-29.9 156.3-89.8 216.2c-59.9 59.9-131.9 89.8-216.2 89.8s-156.3-29.9-216.2-89.8c-59.9-59.9-89.8-131.9-89.8-216.2s29.9-156.3 89.8-216.2c59.9-59.9 132-89.8 216.2-89.8zm0 546.4c66.5 0 123.2-23.4 170.1-70.4 46.9-46.9 70.4-103.6 70.4-170.1s-23.4-123.2-70.4-170.1C557.7 105.5 501 82.1 434.5 82.1s-123.2 23.4-170.1 70.4C217.5 199.4 194 256.1 194 322.6s23.4 123.2 70.4 170.1c46.9 46.8 103.6 70.2 170.1 70.2z"></path></symbol><symbol viewbox="0 0 1000 1000" id="icon-close" xmlns="http://www.w3.org/2000/svg"><path d="M638.6 500l322.7-322.7c38.3-38.3 38.3-100.3 0-138.6S861 .4 822.7 38.7L500 361.4 177.3 38.7C139 .4 77 .4 38.7 38.7S.4 139 38.7 177.3L361.4 500 38.7 822.7C.4 861 .4 923 38.7 961.3 57.9 980.4 82.9 990 108 990s50.1-9.6 69.3-28.7L500 638.6l322.7 322.7c19.1 19.1 44.2 28.7 69.3 28.7 25.1 0 50.1-9.6 69.3-28.7 38.3-38.3 38.3-100.3 0-138.6L638.6 500z"></path></symbol><symbol viewbox="0 0 18 17" id="icon-comment" xmlns="http://www.w3.org/2000/svg"><path d="M15.667 6.654c0 3.532-3.432 6.397-7.667 6.397-.945 0-1.85-.14-2.686-.4l-4.406 2.1 1.725-3.52c-1.42-1.16-2.3-2.78-2.3-4.56C.333 3.12 3.765.257 8 .257c4.235 0 7.667 2.863 7.667 6.4z"></path></symbol><symbol viewbox="-135.7 744.2 1008.1 429.7" id="icon-down" xmlns="http://www.w3.org/2000/svg"><path d="M872.3 788.5c0 12.1-5.1 25.2-18.2 35.3l-446 335c-12.1 10.1-28.3 15.2-40.4 15.2-15.2 0-28.3-5.1-40.4-15.2l-446.1-335c-18.2-15.2-22.2-40.4-10.1-60.5s40.4-22.2 58.5-10.1l439.1 330.9 435.9-331c18.2-15.2 45.4-10.1 58.5 10.1 7.2 8.1 9.2 15.1 9.2 25.3"></path></symbol><symbol viewbox="0 0 50.062 37.479" id="icon-email" xmlns="http://www.w3.org/2000/svg"><path d="M25.085 21.866L.082 3.114A3.114 3.114 0 0 1 3.207-.012H46.96a3.113 3.113 0 0 1 3.126 3.126l-25 18.752zm0 5.613L50.087 8.726v25.64a3.113 3.113 0 0 1-3.125 3.125H3.208a3.113 3.113 0 0 1-3.125-3.125V8.727L25.085 27.48z" class="aeshape-1"></path></symbol><symbol viewbox="0 0 21.406 43.754" id="icon-facebook" xmlns="http://www.w3.org/2000/svg"><path d="M5.43 43.754v-20.53H0V15.83h5.43V9.518C5.43 4.558 8.635 0 16.024 0c2.99 0 5.204.286 5.204.286l-.175 6.903s-2.257-.03-4.72-.03c-2.663 0-3.09 1.23-3.09 3.26v5.4h8.022l-.35 7.39h-7.672v20.53H5.43z"></path></symbol><symbol viewbox="0 0 140 200" id="icon-foursquare" xmlns="http://www.w3.org/2000/svg"><path d="M114.697 27.581l-4.278 22.294c-.511 2.41-3.545 4.945-6.358 4.945h-39.7c-4.467 0-7.664 3.045-7.664 7.508v4.86c0 4.467 3.216 7.632 7.686 7.632h33.681c3.154 0 6.25 3.459 5.568 6.826-.685 3.373-3.886 20.08-4.271 21.924-.387 1.846-2.5 5-6.25 5H65.618c-5.007 0-6.521.654-9.87 4.818-3.353 4.166-33.477 40.342-33.477 40.342-.305.35-.603.249-.603-.134V27.25c0-2.85 2.478-6.194 6.194-6.194h81.78c3.01 0 5.822 2.829 5.055 6.525m3.59 87.418c1.137-4.602 13.899-69.93 18.16-90.656M120.716 0H18.809C4.745 0 .61 10.575.61 17.235v161.916c0 7.503 4.032 10.285 6.296 11.203 2.267.919 8.519 1.692 12.266-2.632 0 0 48.111-55.826 48.938-56.652 1.25-1.25 1.25-1.25 2.5-1.25h31.127c13.08 0 15.183-9.327 16.549-14.821 1.137-4.602 13.899-69.93 18.16-90.656C139.699 8.526 135.681 0 120.716 0"></path></symbol><symbol viewbox="-295 387 20 20" id="icon-full-screen" xmlns="http://www.w3.org/2000/svg"><path fill="#ccc" d="M-275 387.7c0-.2-.1-.4-.2-.5-.1-.1-.3-.2-.5-.2h-5.5c-.4 0-.7.3-.7.7 0 .4.4.8.6 1l1.4 1.4-3.9 3.9 1.9 1.9 3.9-3.9 1.4 1.4c.3.3.6.6 1 .6s.7-.3.7-.7l-.1-5.6zm-13.1 10.5l-3.9 4-1.4-1.4c-.3-.3-.6-.6-1-.6s-.6.3-.6.6v5.4c0 .2.1.4.2.5.1.1.3.2.5.2h5.4c.4 0 .6-.3.6-.6 0-.4-.4-.8-.6-.9l-1.4-1.4 4-3.9-1.8-1.9z"></path></symbol><symbol viewbox="-295 387 20 20" id="icon-full-screen-exit" xmlns="http://www.w3.org/2000/svg"><path fill="#ccc" d="M-293.2 406.9l3.9-4 1.4 1.4c.3.3.6.6 1 .6s.6-.3.6-.6v-5.4c0-.2-.1-.4-.2-.5-.1-.1-.3-.2-.5-.2h-5.4c-.4 0-.6.3-.6.6 0 .4.4.8.6.9l1.4 1.4-4 3.9 1.8 1.9zM-276.91 387.05l-3.9 4-1.4-1.4c-.3-.3-.6-.6-1-.6s-.6.3-.6.6v5.4c0 .2.1.4.2.5.1.1.3.2.5.2h5.4c.4 0 .6-.3.6-.6 0-.4-.4-.8-.6-.9l-1.4-1.4 4-3.9-1.8-1.9z"></path></symbol><symbol viewbox="0 0 39.605 39.633" id="icon-google-plus" xmlns="http://www.w3.org/2000/svg"><path d="M12.488 37.682c-4.69 0-8.08-2.97-8.08-6.537 0-3.496 3.976-6.51 8.667-6.46a10.21 10.21 0 0 1 3.04.488c2.547 1.77 4.6 2.876 5.117 4.894.096.41.15.83.15 1.26 0 3.567-2.3 6.355-8.894 6.355m1.233-21.46c-3.14-.093-6.14-2.982-6.68-7.116-.54-4.136 1.57-7.3 4.72-7.206 3.15.094 5.84 3.486 6.39 7.62.55 4.136-1.27 6.797-4.41 6.703m6.75 6.457c-1.08-.813-3.44-2.478-3.44-3.596 0-1.31.38-1.955 2.35-3.495 2.03-1.58 3.46-3.67 3.46-6.25 0-2.82-1.15-5.37-3.31-6.61h3.06L25.2 0H13.51C7.584 0 2.644 4.37 2.644 9.18c0 4.912 3.246 8.83 8.82 8.83.388 0 .764-.02 1.133-.048-.36.694-.62 1.467-.62 2.277 0 1.36.75 2.14 1.68 3.04-.702 0-1.38.02-2.12.02C4.75 23.3 0 27.97 0 32.46c0 4.412 5.726 7.173 12.513 7.173 7.737 0 12.495-4.39 12.495-8.8 0-3.54-.764-5.32-4.536-8.15M31.52.54v5.388h-5.388v2.695h5.39v5.39h2.694v-5.39h5.39V5.928h-5.39V.538"></path></symbol><symbol viewbox="0 0 105.4 105.7" class="akinline-svg" id="icon-grid" xmlns="http://www.w3.org/2000/svg"><path fill="#ccc" d="M0 0h47.7v47.7H0z" class="akshape-1"></path><path fill="#ccc" d="M57.7 0h47.7v47.7H57.7z" class="akshape-2"></path><path fill="#ccc" d="M0 58h47.7v47.7H0z" class="akshape-3"></path><path fill="#ccc" d="M57.7 58h47.7v47.7H57.7z" class="akshape-4"></path></symbol><symbol viewbox="0 0 64.37 40.34" id="icon-hamburger" xmlns="http://www.w3.org/2000/svg"><path class="alcls-1" d="M0 30h64.37v10.34H0zm0-15h64.37v10.34H0zM0 0h64.37v10.34H0z"></path></symbol><symbol viewbox="0 0 671.78668 671.78668" id="icon-instagram" xmlns="http://www.w3.org/2000/svg"><g transform="matrix(.13333 0 0 -.13333 0 671.787)"><path d="M2519.21 5038.41c-684.18 0-769.97-2.9-1038.67-15.16-268.14-12.23-451.27-54.82-611.513-117.09-165.66-64.38-306.148-150.52-446.203-290.57-140.051-140.05-226.191-280.55-290.57-446.21-62.273-160.24-104.86-343.37-117.098-611.51C2.898 3289.17 0 3203.38 0 2519.2c0-684.17 2.898-769.96 15.156-1038.66 12.239-268.14 54.825-451.27 117.098-611.509 64.379-165.66 150.519-306.152 290.57-446.211 140.055-140.05 280.543-226.191 446.203-290.57C1029.27 69.98 1212.4 27.39 1480.54 15.16 1749.24 2.902 1835.03 0 2519.21 0c684.17 0 769.96 2.902 1038.66 15.16 268.14 12.23 451.27 54.82 611.51 117.09 165.66 64.379 306.15 150.52 446.21 290.57 140.05 140.059 226.19 280.551 290.57 446.211 62.27 160.239 104.86 343.369 117.09 611.509 12.26 268.7 15.16 354.49 15.16 1038.66 0 684.18-2.9 769.97-15.16 1038.67-12.23 268.14-54.82 451.27-117.09 611.51-64.38 165.66-150.52 306.16-290.57 446.21-140.06 140.05-280.55 226.19-446.21 290.57-160.24 62.27-343.37 104.86-611.51 117.09-268.7 12.26-354.49 15.16-1038.66 15.16zm0-453.91c672.65 0 752.33-2.57 1017.97-14.69 245.62-11.2 379.01-52.24 467.78-86.74 117.59-45.7 201.51-100.29 289.66-188.44 88.16-88.16 142.75-172.08 188.45-289.67 34.5-88.77 75.54-222.16 86.74-467.78 12.12-265.64 14.69-345.32 14.69-1017.98 0-672.65-2.57-752.33-14.69-1017.97-11.2-245.62-52.24-379.01-86.74-467.78-45.7-117.591-100.29-201.509-188.45-289.661-88.15-88.16-172.07-142.75-289.66-188.449-88.77-34.5-222.16-75.539-467.78-86.738-265.6-12.122-345.27-14.692-1017.97-14.692-672.71 0-752.37 2.57-1017.98 14.692-245.62 11.199-379.01 52.238-467.78 86.738-117.591 45.699-201.509 100.289-289.661 188.449-88.152 88.152-142.75 172.07-188.449 289.661-34.5 88.77-75.535 222.16-86.742 467.78-12.121 265.64-14.688 345.32-14.688 1017.97 0 672.66 2.567 752.34 14.688 1017.98 11.207 245.62 52.242 379.01 86.742 467.78 45.699 117.59 100.293 201.51 188.445 289.66 88.156 88.16 172.074 142.75 289.665 188.45 88.77 34.5 222.16 75.54 467.78 86.74 265.64 12.12 345.32 14.69 1017.98 14.69"></path><path d="M2519.21 1679.47c-463.78 0-839.74 375.96-839.74 839.73 0 463.78 375.96 839.74 839.74 839.74 463.77 0 839.73-375.96 839.73-839.74 0-463.77-375.96-839.73-839.73-839.73zm0 2133.38c-714.47 0-1293.65-579.18-1293.65-1293.65 0-714.46 579.18-1293.64 1293.65-1293.64 714.46 0 1293.64 579.18 1293.64 1293.64 0 714.47-579.18 1293.65-1293.64 1293.65M4166.27 3863.96c0-166.96-135.35-302.3-302.31-302.3-166.95 0-302.3 135.34-302.3 302.3s135.35 302.31 302.3 302.31c166.96 0 302.31-135.35 302.31-302.31"></path></g></symbol><symbol viewbox="-27.7 455.1 337.2 791.1" id="icon-left" xmlns="http://www.w3.org/2000/svg"><path fill="inherit" d="M274.8 1246.2c-9.5 0-19.8-4-27.7-14.3l-262.9-350c-7.9-9.5-11.9-22.2-11.9-31.7 0-11.9 4-22.2 11.9-31.7l262.9-350.1c11.9-14.3 31.7-17.4 47.5-7.9 15.8 9.5 17.4 31.7 7.9 45.9L42.8 851l259.8 342.1c11.9 14.3 7.9 35.6-7.9 45.9-6.4 5.6-11.9 7.2-19.9 7.2"></path></symbol><symbol viewbox="0 0 16 16" id="icon-linkedin" xmlns="http://www.w3.org/2000/svg"><path d="M.2 15.876h3.394V5.222H.2v10.654zM1.997 0C.8 0 0 .836 0 1.88s.8 1.88 1.997 1.88 1.997-.836 1.997-1.88C3.794.836 2.994 0 1.997 0zm9.985 4.804c-1.798 0-2.596 1.045-2.996 1.88V5.222H5.392c.2 1.045 0 10.862 0 10.862h3.395V9.818c0-.21 0-.627.2-.836.2-.626.798-1.253 1.796-1.253 1.2 0 1.798 1.04 1.798 2.5v5.64h3.4V9.82c0-3.342-1.79-5.014-3.99-5.014z"></path></symbol><symbol viewbox="-375 489.5 37.2 30.3" id="icon-menu" xmlns="http://www.w3.org/2000/svg"><title>menu</title>
-<path d="M-367 489.5h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4zm8 12.8h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4zm8 13.7h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4z"></path></symbol><symbol viewbox="0 0 179 96" id="icon-more" xmlns="http://www.w3.org/2000/svg"><title>more-arrow</title>
-<path d="M178.86 47.677L129.776 0v34.313H0v26.625h116.296v.103h13.48v34.31l49.084-47.67"></path></symbol><symbol viewbox="0 0 50.062 37.479" id="icon-newsletter_signup" xmlns="http://www.w3.org/2000/svg"><path d="M25.085 21.866L.082 3.114A3.114 3.114 0 0 1 3.207-.012H46.96a3.113 3.113 0 0 1 3.126 3.126l-25 18.752zm0 5.613L50.087 8.726v25.64a3.113 3.113 0 0 1-3.125 3.125H3.208a3.113 3.113 0 0 1-3.125-3.125V8.727L25.085 27.48z" class="arshape-1"></path></symbol><symbol viewbox="0 0 832 512" id="icon-norgie-down" xmlns="http://www.w3.org/2000/svg"><path d="M15.244 98.497L379.433 495.43c20.249 22.24 53.137 22.23 73.373-.021.51-.608.71-1.47 1.25-2.077L817.152 98.259c20.233-22.224 20.223-58.326-.028-80.54-.202-.1-.531-.202-.735-.404C807.065 6.732 793.993-.005 779.353 0L52.923.208C38.073.212 24.903 7.286 15.43 18.18l-.2-.227c-20.314 22.325-20.304 58.33.023 80.543h-.008z"></path></symbol><symbol viewbox="0 0 512 832.328" id="icon-norgie-right" xmlns="http://www.w3.org/2000/svg"><path d="M98.278 817.088l397.038-364.076c22.245-20.243 22.245-53.13 0-73.373-.608-.51-1.47-.71-2.077-1.25L98.27 15.18c-22.218-20.24-58.32-20.24-80.54.005-.1.202-.202.53-.404.734C6.74 25.24 0 38.31 0 52.95v726.43c0 14.85 7.07 28.022 17.963 37.5l-.228.2c22.32 20.32 58.324 20.32 80.543 0z"></path></symbol><symbol viewbox="0 0 47.3 34.3" id="icon-opentable" xmlns="http://www.w3.org/2000/svg"><path d="M30.1 0C20.7 0 13 7.7 13 17.2s7.7 17.2 17.2 17.2 17.2-7.7 17.2-17.2C47.3 7.7 39.6 0 30.1 0zm0 21.5c-2.4 0-4.3-1.9-4.3-4.3s1.9-4.3 4.3-4.3 4.3 1.9 4.3 4.3c0 2.3-1.9 4.3-4.3 4.3zM0 17.2c0 2.4 1.9 4.3 4.3 4.3s4.3-1.9 4.3-4.3-1.9-4.3-4.3-4.3S0 14.8 0 17.2"></path></symbol><symbol viewbox="0 0 12 12" id="icon-pencil" xmlns="http://www.w3.org/2000/svg"><path d="M1.3 8.4c0 .1 0 .1 0 0L0 11.6c0 .1 0 .2.1.3 0 .1.1.1.1.1h.1l3.1-1.2s.1 0 .1-.1l6.2-6.2-2.2-2.3-6.2 6.2zm10.5-7L10.6.2c-.3-.3-.8-.3-1.1 0L8.2 1.5l2.2 2.2 1.3-1.3c.4-.2.4-.7.1-1z"></path></symbol><symbol viewbox="0 0 60.7 93.3" id="icon-pin" xmlns="http://www.w3.org/2000/svg"><path d="M57.2 34.6c0 4.8-1.3 9.3-3.5 13.2L31.8 87.5c-.3.5-.9.8-1.5.8-.7 0-1.2-.4-1.5-.8L6.9 47.7c-2.2-3.8-3.5-8.4-3.5-13.2 0-14.8 12-26.9 26.9-26.9 14.9.1 26.9 12.1 26.9 27zm-16.8 0c0-5.6-4.5-10.1-10.1-10.1S20.2 29 20.2 34.6s4.5 10.1 10.1 10.1 10.1-4.5 10.1-10.1z" xmlns="http://www.w3.org/2000/svg"></path></symbol><symbol viewbox="-285 377 40 40" id="icon-pinterest" xmlns="http://www.w3.org/2000/svg"><path d="M-265 377.1c-10.9 0-19.7 8.9-19.7 19.8 0 8.1 4.9 15 11.8 18.1-.1-1.4 0-3 .3-4.5.4-1.6 2.5-10.8 2.5-10.8s-.6-1.3-.6-3.1c0-2.9 1.7-5.1 3.8-5.1 1.8 0 2.7 1.3 2.7 3 0 1.8-1.2 4.5-1.7 7-.5 2.1 1 3.8 3.1 3.8 3.7 0 6.3-4.8 6.3-10.5 0-4.3-2.9-7.6-8.2-7.6-6 0-9.7 4.5-9.7 9.5 0 1.7.5 2.9 1.3 3.9.4.4.4.6.3 1.1l-.4 1.6c-.1.5-.5.7-1 .5-2.8-1.1-4-4.1-4-7.5 0-5.6 4.7-12.3 14.1-12.3 7.5 0 12.5 5.5 12.5 11.3 0 7.7-4.3 13.5-10.7 13.5-2.1 0-4.1-1.2-4.8-2.5 0 0-1.1 4.5-1.4 5.4-.4 1.5-1.2 3-2 4.2 1.8.5 3.7.8 5.6.8 10.9 0 19.7-8.8 19.7-19.7 0-11-8.9-19.9-19.8-19.9z"></path></symbol><symbol viewbox="-230 372 50 50" id="icon-play" xmlns="http://www.w3.org/2000/svg"><path fill="#999" d="M-214 376l25.6 21.1L-214 418v-42z"></path></symbol><symbol viewbox="0 0 17 17" id="icon-rec" xmlns="http://www.w3.org/2000/svg"><path d="M7.544.405l2.305 4.64 5.15.743L11.27 9.4l.88 5.1-4.61-2.407-4.6 2.407.88-5.1L.087 5.79l5.153-.744L7.545.404z"></path></symbol><symbol viewbox="0 0 450 386" id="icon-refresh" xmlns="http://www.w3.org/2000/svg"><path d="M352.629 288.14l96-111.9h-64.7c-2.3-27.9-10.5-54-23.5-77.3-27.4-49.2-75.8-85.1-133-95.6-.7-.1-1.5-.3-2.2-.4-.5-.1-.9-.2-1.4-.2-10.1-1.7-20.6-2.6-31.2-2.6h-.4c-90.9.2-167 63.6-186.7 148.6v.1c-.3 1.1-.5 2.2-.7 3.3-.1.5-.2.9-.3 1.4-.1.7-.3 1.4-.4 2.1-.2.9-.3 1.7-.5 2.6-.1.4-.1.7-.2 1.1l-.6 3.6v.2c-1 6.3-1.6 12.7-1.9 19.1v.8c-.1 1.4-.1 2.7-.2 4.1 0 1.6-.1 3.3-.1 5 0 1.7 0 3.3.1 5 0 1.4.1 2.7.2 4.1v.9c.3 6.5 1 12.9 1.9 19.1v.2l.6 3.6c.1.4.1.7.2 1.1.2.9.3 1.8.5 2.6.1.7.3 1.4.4 2.1.1.5.2 1 .3 1.4.2 1.1.5 2.2.7 3.2v.1c19.7 85 96.1 148.4 187.1 148.6 42.9-.1 83.1-14.2 116.9-40.7l7.5-5.9-43.2-46.2-6.2 4.6c-22.1 16.3-47.5 24.2-75 24.2-70.6 0-128-57-128-128s57.4-128 128-128c66.4 0 122.8 46.6 129.5 112h-73.5l104 112z" xmlns:bx="https://boxy-svg.com" bx:origin="0.5 0.5"></path></symbol><symbol viewbox="-27.7 455.1 337.2 791.1" id="icon-right" xmlns="http://www.w3.org/2000/svg"><path fill="inherit" d="M6.9 455.1c9.5 0 19.8 4 27.7 14.3l262.9 350.1c7.9 9.5 11.9 22.2 11.9 31.7 0 11.9-4 22.2-11.9 31.7l-262.8 350c-11.9 14.3-31.7 17.4-47.5 7.9-15.8-9.5-17.4-31.7-7.9-45.9L239 850.3-20.8 508.2c-11.9-14.3-7.9-35.6 7.9-45.9 6.4-5.6 11.9-7.2 19.8-7.2"></path></symbol><symbol viewbox="0 0 1000 1000" preserveaspectratio="xMinYMin meet" id="icon-rss" xmlns="http://www.w3.org/2000/svg"><path d="M0 866q0-55 39-94t94-39 94 39 39 94q0 56-39 94.5T133 999t-94-39-39-94zm0-335V340q179 0 331 88.5T571.5 669t88.5 331H468q0-194-137-331Q193 531 0 531zm0-339V0q203 0 388 79.5T707 293t213.5 319 79.5 388H808q0-164-64-314T571.5 428t-258-172T0 192z"></path></symbol><symbol viewbox="373.3 133.3 533.3 533.3" id="icon-search" xmlns="http://www.w3.org/2000/svg"><path d="M754.7 468.7l-22.3-22.3c24.3-33.3 37.5-73.4 37.7-114.7 0-109.5-88.8-198.3-198.3-198.3s-198.3 88.8-198.3 198.3S462.1 530 571.7 530c41.2-.2 81.3-13.4 114.7-37.7l22.3 22.3 152.7 152 45.3-45.3-152-152.6zm-183 0c-75.8 0-137.3-61.5-137.3-137.3S495.8 194 571.7 194 709 255.5 709 331.3c.2 75.7-61 137.1-136.7 137.3-.2.1-.4.1-.6.1z"></path></symbol><symbol viewbox="206 29.9 642.1 681.3" id="icon-settings" xmlns="http://www.w3.org/2000/svg"><path d="M843 467.2c4.8 3.2 6.3 9.5 4 15-13.5 41.2-36.4 79.2-64.2 111.7-4 4.8-9.5 6.3-15 4l-81.6-28.5c-20.6 16.6-43.6 30.1-67.3 39.6l-16.6 84.7c-.8 5.5-5.5 10.3-11.1 11.1-21.4 4-42.8 6.3-64.2 6.3-22.2 0-43.6-2.4-64.2-6.3-5.5-.8-10.3-5.5-11.1-11.1L435.2 609c-24.6-9.5-48.3-23-67.3-39.6l-81.6 28.5c-5.5 2.4-11.1.8-15-4-28.5-32.5-51.5-70.5-64.2-111.7-2.4-5.5-.8-11.9 4-15l64.9-57c-2.4-12.7-3.2-26.1-3.2-39.6s.8-26.9 3.2-39.6l-65-57c-4.8-3.2-6.3-9.5-4-15 13.5-41.2 36.4-79.2 64.2-111.7 4-4.8 9.5-6.3 15-4l81.6 28.5c19.8-16.6 43.6-30.1 67.3-39.6l16.6-84.7c.8-5.5 5.5-10.3 11.1-11.1 42.8-8.7 86.3-8.7 129.1 0 5.5.8 10.3 5.5 11.1 11.1l15 85.5c24.6 9.5 47.5 23 67.3 39.6l81.6-28.5c5.5-2.4 11.1-.8 15 4 28.5 32.5 51.5 70.5 64.2 111.7 2.4 5.5.8 11.9-4 15l-65.7 57c2.4 12.7 3.2 26.1 3.2 39.6s-.8 26.9-3.2 39.6l66.6 56.2zm-190-95.8c0-69.7-57.8-127.5-127.5-127.5-70.5 0-127.5 57-127.5 127.5s57 127.5 127.5 127.5S653 441.9 653 371.4z"></path></symbol><symbol viewbox="0 0 16 16" id="icon-snapchat" xmlns="http://www.w3.org/2000/svg"><path d="M8.155.48c.662 0 2.903.185 3.96 2.552.354.797.27 2.15.2 3.237l-.002.04c-.008.12-.015.23-.02.34.05.03.135.06.268.06.2-.01.44-.08.69-.2.11-.06.23-.07.31-.07.12 0 .24.02.34.06.3.1.49.32.49.56.01.3-.26.56-.81.78-.06.02-.14.05-.23.08-.3.09-.76.24-.89.54-.06.15-.04.35.08.58l.01.01c.04.09 1.02 2.32 3.2 2.68.17.03.29.18.28.34 0 .05-.01.1-.03.15-.16.38-.85.66-2.1.85-.04.06-.08.25-.11.38-.02.12-.05.24-.09.37-.05.18-.18.27-.37.27h-.02c-.09 0-.21-.02-.36-.05-.24-.05-.51-.09-.85-.09-.2 0-.4.01-.61.05-.4.07-.75.31-1.15.59-.57.4-1.22.86-2.2.86-.04 0-.08-.01-.12-.01h-.1c-.98 0-1.62-.45-2.19-.86-.4-.28-.74-.52-1.14-.59-.21-.03-.42-.05-.62-.05-.36 0-.64.06-.85.1-.14.03-.26.05-.36.05-.25 0-.35-.15-.39-.28-.04-.13-.06-.26-.09-.38s-.07-.33-.11-.38C.89 12.9.2 12.62.04 12.23a.413.413 0 0 1-.036-.15.332.332 0 0 1 .28-.34c2.18-.36 3.16-2.59 3.2-2.684l.01-.02c.12-.23.15-.43.08-.58-.13-.29-.59-.44-.89-.54-.08-.02-.16-.05-.23-.08-.74-.29-.84-.62-.8-.85.06-.32.45-.53.78-.53.097 0 .18.02.256.05.28.13.527.2.737.2a.63.63 0 0 0 .31-.07l-.03-.38c-.065-1.086-.15-2.438.205-3.23C4.94.67 7.175.49 7.835.49l.28-.01h.04z"></path></symbol><symbol viewbox="0 0 17 17" id="icon-star" xmlns="http://www.w3.org/2000/svg"><path d="M7.544.405l2.305 4.64 5.15.743L11.27 9.4l.88 5.1-4.61-2.407-4.6 2.407.88-5.1L.087 5.79l5.153-.744L7.545.404z"></path></symbol><symbol viewbox="19.3 54.3 26.9 33.7" id="icon-thumb-down" xmlns="http://www.w3.org/2000/svg"><title>no</title>
-<path d="M19.3 84.4c0-4.8 0-9.4.1-14 0-.4 1-1 1.6-1.2 4.2-1.1 7.7-3.2 9.6-7.3.7-1.6.9-3.4 1.5-5 .4-.9 1.2-1.7 1.8-2.5.7.8 2 1.6 2.1 2.5.2 2.2 0 4.5-.2 6.8-.1.9-.4 1.8-.6 3h5.1c1.2 0 2.4 0 3.5.2 1.9.3 2.4 1.3 2.2 3.2-.1 1.2.1 2.4.1 3.6 0 1 0 1.9-.1 2.9-.1 1.1 0 2.2-.3 3.1-1 2.6-2.1 5.2-3.4 7.6-.3.6-1.8.7-2.7.7-2.4.1-4.8.2-7.2 0-1.4-.1-2.9-.5-4-1.3-2.2-1.7-4.4-2.3-7.1-2.1-.6-.1-1.2-.2-2-.2z"></path></symbol><symbol viewbox="19.3 54.3 26.9 33.7" id="icon-thumb-up" xmlns="http://www.w3.org/2000/svg"><title>yes</title>
-<path d="M19.3 84.4c0-4.8 0-9.4.1-14 0-.4 1-1 1.6-1.2 4.2-1.1 7.7-3.2 9.6-7.3.7-1.6.9-3.4 1.5-5 .4-.9 1.2-1.7 1.8-2.5.7.8 2 1.6 2.1 2.5.2 2.2 0 4.5-.2 6.8-.1.9-.4 1.8-.6 3h5.1c1.2 0 2.4 0 3.5.2 1.9.3 2.4 1.3 2.2 3.2-.1 1.2.1 2.4.1 3.6 0 1 0 1.9-.1 2.9-.1 1.1 0 2.2-.3 3.1-1 2.6-2.1 5.2-3.4 7.6-.3.6-1.8.7-2.7.7-2.4.1-4.8.2-7.2 0-1.4-.1-2.9-.5-4-1.3-2.2-1.7-4.4-2.3-7.1-2.1-.6-.1-1.2-.2-2-.2z"></path></symbol><symbol viewbox="0 0 60.7 93.3" id="icon-topics" xmlns="http://www.w3.org/2000/svg"><g xmlns="http://www.w3.org/2000/svg"><path d="M2.5 21.5h55.2v11.8H2.5zM2.5 42.1h55.2v11.8H2.5zM2.5 64.3h55.2v11.8H2.5z"></path></g></symbol><symbol viewbox="0 0 87 60" id="icon-trending" xmlns="http://www.w3.org/2000/svg"><path d="M1.906 46.826c2.213 1.787 5.466 1.46 7.262-.743v-.006l5.26-6.45 8.378 11.286a5.171 5.171 0 0 0 4.827 2.035 5.128 5.128 0 0 0 4.124-3.215l7.96-20.208L51.26 56.577a5.155 5.155 0 0 0 4.754 3.13c.097 0 .19 0 .286-.007a5.172 5.172 0 0 0 4.66-3.667l10.98-36.787 4.854 9.902c1.234 2.552 4.33 3.613 6.89 2.37 2.56-1.234 3.636-4.314 2.386-6.86L75.42 2.888a5.15 5.15 0 0 0-5.067-2.87 5.135 5.135 0 0 0-4.52 3.653L55.146 39.42 44.28 13.93a5.142 5.142 0 0 0-4.827-3.127 5.157 5.157 0 0 0-4.73 3.263L25.56 37.343l-6.79-9.148a5.197 5.197 0 0 0-4.033-2.08 5.139 5.139 0 0 0-4.124 1.897L1.153 39.6a5.125 5.125 0 0 0 .753 7.226" fill-rule="evenodd"></path></symbol><symbol viewbox="0 0 23.62 41.098" id="icon-tumblr" xmlns="http://www.w3.org/2000/svg"><path d="M21.643 32.826c-.764.364-2.226.682-3.316.71-3.29.088-3.927-2.31-3.955-4.052V16.69h8.252v-6.22h-8.222V0h-6.02c-.1 0-.272.087-.296.307C7.734 3.512 6.234 9.135 0 11.382v5.31h4.16V30.12c0 4.595 3.39 11.126 12.343 10.974 3.02-.053 6.375-1.318 7.117-2.408l-1.977-5.86z"></path></symbol><symbol viewbox="0 0 44.71 36.327" id="icon-twitter" xmlns="http://www.w3.org/2000/svg"><path d="M44.71 4.295c-1.656.724-3.415 1.242-5.278 1.45A9.146 9.146 0 0 0 43.468.673a18.75 18.75 0 0 1-5.796 2.225C35.965 1.138 33.584 0 30.945 0a9.145 9.145 0 0 0-9.16 9.16c0 .724.052 1.448.208 2.12-7.607-.413-14.335-3.88-18.888-9.417-.777 1.345-1.242 2.742-1.242 4.45 0 3.157 1.604 5.95 4.088 7.607a9.376 9.376 0 0 1-4.14-1.138v.103c0 4.45 3.16 8.176 7.35 9.004-.77.2-1.6.31-2.43.31-.57 0-1.14-.06-1.71-.16 1.14 3.62 4.56 6.31 8.54 6.36-3.1 2.48-7.09 4.34-11.38 4.34-.72 0-1.45-.05-2.17-.16 4.04 2.59 8.9 3.72 14.08 3.72 16.87 0 26.08-13.97 26.08-26.08V9.05c1.76-1.294 3.32-2.9 4.56-4.76"></path></symbol><symbol viewbox="-235.8 423.2 35.7 21.3" id="icon-up" xmlns="http://www.w3.org/2000/svg"><path fill="none" d="M-200.5 444.2L-218 424l-17.5 20.2"></path></symbol><symbol viewbox="373.3 133.3 533.3 533.3" id="icon-user" xmlns="http://www.w3.org/2000/svg"><path d="M640 400c73.6 0 133.3-59.7 133.3-133.3S713.6 133.3 640 133.3 506.7 193 506.7 266.7 566.4 400 640 400zm0 66.7c-89 0-266.7 44.7-266.7 133.3v66.7h533.3V600c.1-88.7-177.6-133.3-266.6-133.3z"></path></symbol><symbol viewbox="0 0 1146 1000" id="icon-vimeo" xmlns="http://www.w3.org/2000/svg"><path d="M0 272q55-65 110-116t95.5-77.5 72.5-43T326 14l17-4q12-2 24-2 19 0 35 6 26 10 42.5 34.5t29 55 21.5 72 15 77.5 13.5 79.5T538 403q32 125 51.5 177.5T631 633q24 0 66.5-55.5T791 426q26-48 26-91 0-13-2-23-9-52-51-65-11-4-24-4-35 0-83 26 22-130 134-209Q876 0 965 0q12 0 24 1 102 8 139 90 18 38 18 88 0 29-6 61-18 102-69.5 208t-113 187.5-132.5 155-123.5 117T611 976q-42 24-78.5 24T463 979t-56-48-38-57q-18-38-97.5-298.5T175 295q-1-2-4-4t-13.5-4.5-24 0-36.5 14T47 333z"></path></symbol><symbol viewbox="0 0 86.965 87.642" id="icon-whatsapp" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M44.038 13.007c-16.58 0-30.02 13.44-30.02 30.02a29.883 29.883 0 0 0 4.307 15.503l-5.418 16.106 16.62-5.32a29.915 29.915 0 0 0 14.512 3.733c16.58 0 30.02-13.45 30.02-30.03C74.06 26.44 60.61 13 44.03 13zm0 55.013a24.85 24.85 0 0 1-13.75-4.132l-9.604 3.074 3.122-9.28a24.858 24.858 0 0 1-4.76-14.653c0-13.79 11.212-25 24.993-25 13.78 0 24.99 11.21 24.99 24.99 0 13.78-11.22 24.99-25 24.99zm14.075-18.17c-.753-.412-4.45-2.407-5.143-2.69-.693-.28-1.2-.427-1.74.32s-2.072 2.418-2.538 2.913c-.467.495-.916.54-1.668.128-.752-.41-3.19-1.31-6.02-4.03-2.202-2.11-3.646-4.68-4.065-5.46-.42-.78-.01-1.18.39-1.55.35-.33.8-.86 1.2-1.3.4-.43.54-.74.81-1.25.27-.5.16-.95-.02-1.34s-1.57-4.22-2.15-5.77c-.58-1.56-1.23-1.32-1.68-1.34-.45-.01-.96-.1-1.47-.12-.51-.02-1.35.14-2.08.89-.73.74-2.78 2.52-2.92 6.29-.14 3.77 2.47 7.52 2.83 8.04.36.53 4.98 8.7 12.66 12.06 7.67 3.36 7.71 2.34 9.12 2.26 1.41-.07 4.6-1.68 5.31-3.45.7-1.76.76-3.3.58-3.62-.18-.32-.68-.54-1.43-.95z"></path></symbol><symbol viewbox="130.35156 177.43359 300 300" overflow="visible" id="icon-yahoo" xmlns="http://www.w3.org/2000/svg"><path d="M420.926 272.27c-5.2.514-26.85 5.365-34.13 6.925-7.79 2.073-78.983 57.075-83.66 70.58-1.036 4.674-1.556 11.866-1.556 18.624l-.52 10.91c-.002 7.79 2.162 20.35 3.198 27.1 4.68 1.04 38.555.13 44.79 1.17l-.768 13.97c-6.09-.45-49.106-.34-73.68-.34-12.475 0-52.576 1.37-64.897 1l2.33-13.29c6.755-.53 34.728 1.2 40.878-5.29 3.06-3.22 2.09-6.67 2.09-25.38v-8.83c0-4.16 0-11.96-1.04-19.24-2.59-7.8-65.3-86.09-81.41-98.56-4.68-1.56-33.99-4.49-41.26-6.05l-.36-11.97c3.63-1.82 36.22.44 67.85-.73 20.79-.77 68.22 0 74.07.7l-1.5 10.55c-6.23 1.56-36.26 2.14-44.06 4.21 20.27 30.14 52.31 68.94 62.71 84.01 5.72-8.31 55.96-42.87 57.51-54.82-7.79-1.57-33.6-5.28-37.76-5.28l-2.47-13.61c7.08-1.11 44.28 0 62.78 0 15.96 0 50.07 0 59.76.79l-8.86 12.81"></path></symbol><symbol viewbox="0 0 462 325" id="icon-youtube" xmlns="http://www.w3.org/2000/svg"><path d="M234.28 1.691c-53.492 0-132.53 3.24-156.188 4.031C52.396 8.02 42.884 9.366 28.811 21.41 7.368 40.48 2.28 77.954 2.28 135.285v54.562c0 65.439 8.69 98.684 23 110.844 16.517 14.17 27.407 15.302 38.406 17 4.27.646 34.49 6 168.594 6 83.626 0 155.507-3.95 162.937-4.906 11.945-1.508 29.104-3.696 42.063-18.094 19.183-21.803 23-57.999 23-110.437V126.69c0-33.943-1.891-81.916-23-102-15.991-13.536-21.848-17.367-54.938-19.031-9.358-.462-91.02-3.969-148.062-3.969zm-49.5 97l123.5 63.75-123.5 64.25v-128z"></path></symbol></svg>
+<body class="entry_key_unison_standard entry_layout_unison_main entry_template_standard" data-entry-id="16685133"
+  data-new-gr-c-s-check-loaded="14.997.0" data-gr-ext-installed="" cz-shortcut-listen="true">
+  <a class="sr-only link-skip" href="#content">Skip to main content</a>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-W8JKW6" height="0" width="0"
+      style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
-      <div class="l-root l-reskin">
+
+
+  <svg width="0" height="0" style="position:absolute;display:none;">
+    <symbol viewBox="90 0 689 645" id="icon-clock" xmlns="http://www.w3.org/2000/svg">
+      <title>clock</title>
+      <path
+        d="M489.1 322.5c0 15-5.4 27.9-16 38.6-10.7 10.7-23.6 16-38.6 16-23.7 0-40.3-10.9-49.9-32.8h-125c-6.4 0-11.6-2.1-15.7-6.1-4-4.1-6.1-9.3-6.1-15.7 0-6.4 2.1-11.6 6.1-15.7 4.1-4.1 9.4-6.1 15.8-6.1h125c5.9-13.2 15.3-22.5 28-28V125.8c0-6.4 2.1-11.6 6.1-15.7 4.1-4.1 9.3-6.1 15.7-6.1 6.4 0 11.6 2 15.7 6.1s6.1 9.3 6.1 15.7v146.8c21.9 9.5 32.9 26.1 32.8 49.9zm-54.6-306c84.2 0 156.3 29.9 216.2 89.8 59.9 59.9 89.8 131.9 89.8 216.2s-29.9 156.3-89.8 216.2c-59.9 59.9-131.9 89.8-216.2 89.8s-156.3-29.9-216.2-89.8c-59.9-59.9-89.8-131.9-89.8-216.2s29.9-156.3 89.8-216.2c59.9-59.9 132-89.8 216.2-89.8zm0 546.4c66.5 0 123.2-23.4 170.1-70.4 46.9-46.9 70.4-103.6 70.4-170.1s-23.4-123.2-70.4-170.1C557.7 105.5 501 82.1 434.5 82.1s-123.2 23.4-170.1 70.4C217.5 199.4 194 256.1 194 322.6s23.4 123.2 70.4 170.1c46.9 46.8 103.6 70.2 170.1 70.2z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 1000 1000" id="icon-close" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M638.6 500l322.7-322.7c38.3-38.3 38.3-100.3 0-138.6S861 .4 822.7 38.7L500 361.4 177.3 38.7C139 .4 77 .4 38.7 38.7S.4 139 38.7 177.3L361.4 500 38.7 822.7C.4 861 .4 923 38.7 961.3 57.9 980.4 82.9 990 108 990s50.1-9.6 69.3-28.7L500 638.6l322.7 322.7c19.1 19.1 44.2 28.7 69.3 28.7 25.1 0 50.1-9.6 69.3-28.7 38.3-38.3 38.3-100.3 0-138.6L638.6 500z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 14 14" id="icon-close-map" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd"
+        d="M13.074 12.27L7.698 6.958l5.376-5.312-.896-.896-5.312 5.376L1.554.75l-.896.864 5.376 5.312L.658 12.27l.896.896L6.898 7.79l5.312 5.376z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 18 17" id="icon-comment" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M15.667 6.654c0 3.532-3.432 6.397-7.667 6.397-.945 0-1.85-.14-2.686-.4l-4.406 2.1 1.725-3.52c-1.42-1.16-2.3-2.78-2.3-4.56C.333 3.12 3.765.257 8 .257c4.235 0 7.667 2.863 7.667 6.4z">
+      </path>
+    </symbol>
+    <symbol viewBox="-135.7 744.2 1008.1 429.7" id="icon-down" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M872.3 788.5c0 12.1-5.1 25.2-18.2 35.3l-446 335c-12.1 10.1-28.3 15.2-40.4 15.2-15.2 0-28.3-5.1-40.4-15.2l-446.1-335c-18.2-15.2-22.2-40.4-10.1-60.5s40.4-22.2 58.5-10.1l439.1 330.9 435.9-331c18.2-15.2 45.4-10.1 58.5 10.1 7.2 8.1 9.2 15.1 9.2 25.3">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 50.062 37.479" id="icon-email" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M25.085 21.866L.082 3.114A3.114 3.114 0 0 1 3.207-.012H46.96a3.113 3.113 0 0 1 3.126 3.126l-25 18.752zm0 5.613L50.087 8.726v25.64a3.113 3.113 0 0 1-3.125 3.125H3.208a3.113 3.113 0 0 1-3.125-3.125V8.727L25.085 27.48z"
+        class="afshape-1"></path>
+    </symbol>
+    <symbol viewBox="0 0 21.406 43.754" id="icon-facebook" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M5.43 43.754v-20.53H0V15.83h5.43V9.518C5.43 4.558 8.635 0 16.024 0c2.99 0 5.204.286 5.204.286l-.175 6.903s-2.257-.03-4.72-.03c-2.663 0-3.09 1.23-3.09 3.26v5.4h8.022l-.35 7.39h-7.672v20.53H5.43z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 140 200" id="icon-foursquare" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M114.697 27.581l-4.278 22.294c-.511 2.41-3.545 4.945-6.358 4.945h-39.7c-4.467 0-7.664 3.045-7.664 7.508v4.86c0 4.467 3.216 7.632 7.686 7.632h33.681c3.154 0 6.25 3.459 5.568 6.826-.685 3.373-3.886 20.08-4.271 21.924-.387 1.846-2.5 5-6.25 5H65.618c-5.007 0-6.521.654-9.87 4.818-3.353 4.166-33.477 40.342-33.477 40.342-.305.35-.603.249-.603-.134V27.25c0-2.85 2.478-6.194 6.194-6.194h81.78c3.01 0 5.822 2.829 5.055 6.525m3.59 87.418c1.137-4.602 13.899-69.93 18.16-90.656M120.716 0H18.809C4.745 0 .61 10.575.61 17.235v161.916c0 7.503 4.032 10.285 6.296 11.203 2.267.919 8.519 1.692 12.266-2.632 0 0 48.111-55.826 48.938-56.652 1.25-1.25 1.25-1.25 2.5-1.25h31.127c13.08 0 15.183-9.327 16.549-14.821 1.137-4.602 13.899-69.93 18.16-90.656C139.699 8.526 135.681 0 120.716 0">
+      </path>
+    </symbol>
+    <symbol viewBox="-295 387 20 20" id="icon-full-screen" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#ccc"
+        d="M-275 387.7c0-.2-.1-.4-.2-.5-.1-.1-.3-.2-.5-.2h-5.5c-.4 0-.7.3-.7.7 0 .4.4.8.6 1l1.4 1.4-3.9 3.9 1.9 1.9 3.9-3.9 1.4 1.4c.3.3.6.6 1 .6s.7-.3.7-.7l-.1-5.6zm-13.1 10.5l-3.9 4-1.4-1.4c-.3-.3-.6-.6-1-.6s-.6.3-.6.6v5.4c0 .2.1.4.2.5.1.1.3.2.5.2h5.4c.4 0 .6-.3.6-.6 0-.4-.4-.8-.6-.9l-1.4-1.4 4-3.9-1.8-1.9z">
+      </path>
+    </symbol>
+    <symbol viewBox="-295 387 20 20" id="icon-full-screen-exit" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#ccc"
+        d="M-293.2 406.9l3.9-4 1.4 1.4c.3.3.6.6 1 .6s.6-.3.6-.6v-5.4c0-.2-.1-.4-.2-.5-.1-.1-.3-.2-.5-.2h-5.4c-.4 0-.6.3-.6.6 0 .4.4.8.6.9l1.4 1.4-4 3.9 1.8 1.9zM-276.91 387.05l-3.9 4-1.4-1.4c-.3-.3-.6-.6-1-.6s-.6.3-.6.6v5.4c0 .2.1.4.2.5.1.1.3.2.5.2h5.4c.4 0 .6-.3.6-.6 0-.4-.4-.8-.6-.9l-1.4-1.4 4-3.9-1.8-1.9z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 39.605 39.633" id="icon-google-plus" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12.488 37.682c-4.69 0-8.08-2.97-8.08-6.537 0-3.496 3.976-6.51 8.667-6.46a10.21 10.21 0 0 1 3.04.488c2.547 1.77 4.6 2.876 5.117 4.894.096.41.15.83.15 1.26 0 3.567-2.3 6.355-8.894 6.355m1.233-21.46c-3.14-.093-6.14-2.982-6.68-7.116-.54-4.136 1.57-7.3 4.72-7.206 3.15.094 5.84 3.486 6.39 7.62.55 4.136-1.27 6.797-4.41 6.703m6.75 6.457c-1.08-.813-3.44-2.478-3.44-3.596 0-1.31.38-1.955 2.35-3.495 2.03-1.58 3.46-3.67 3.46-6.25 0-2.82-1.15-5.37-3.31-6.61h3.06L25.2 0H13.51C7.584 0 2.644 4.37 2.644 9.18c0 4.912 3.246 8.83 8.82 8.83.388 0 .764-.02 1.133-.048-.36.694-.62 1.467-.62 2.277 0 1.36.75 2.14 1.68 3.04-.702 0-1.38.02-2.12.02C4.75 23.3 0 27.97 0 32.46c0 4.412 5.726 7.173 12.513 7.173 7.737 0 12.495-4.39 12.495-8.8 0-3.54-.764-5.32-4.536-8.15M31.52.54v5.388h-5.388v2.695h5.39v5.39h2.694v-5.39h5.39V5.928h-5.39V.538">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 105.4 105.7" class="alinline-svg" id="icon-grid" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#ccc" d="M0 0h47.7v47.7H0z" class="alshape-1"></path>
+      <path fill="#ccc" d="M57.7 0h47.7v47.7H57.7z" class="alshape-2"></path>
+      <path fill="#ccc" d="M0 58h47.7v47.7H0z" class="alshape-3"></path>
+      <path fill="#ccc" d="M57.7 58h47.7v47.7H57.7z" class="alshape-4"></path>
+    </symbol>
+    <symbol viewBox="0 0 64.37 40.34" id="icon-hamburger" xmlns="http://www.w3.org/2000/svg">
+      <path class="amcls-1" d="M0 30h64.37v10.34H0zm0-15h64.37v10.34H0zM0 0h64.37v10.34H0z"></path>
+    </symbol>
+    <symbol viewBox="0 0 671.78668 671.78668" id="icon-instagram" xmlns="http://www.w3.org/2000/svg">
+      <g transform="matrix(.13333 0 0 -.13333 0 671.787)">
+        <path
+          d="M2519.21 5038.41c-684.18 0-769.97-2.9-1038.67-15.16-268.14-12.23-451.27-54.82-611.513-117.09-165.66-64.38-306.148-150.52-446.203-290.57-140.051-140.05-226.191-280.55-290.57-446.21-62.273-160.24-104.86-343.37-117.098-611.51C2.898 3289.17 0 3203.38 0 2519.2c0-684.17 2.898-769.96 15.156-1038.66 12.239-268.14 54.825-451.27 117.098-611.509 64.379-165.66 150.519-306.152 290.57-446.211 140.055-140.05 280.543-226.191 446.203-290.57C1029.27 69.98 1212.4 27.39 1480.54 15.16 1749.24 2.902 1835.03 0 2519.21 0c684.17 0 769.96 2.902 1038.66 15.16 268.14 12.23 451.27 54.82 611.51 117.09 165.66 64.379 306.15 150.52 446.21 290.57 140.05 140.059 226.19 280.551 290.57 446.211 62.27 160.239 104.86 343.369 117.09 611.509 12.26 268.7 15.16 354.49 15.16 1038.66 0 684.18-2.9 769.97-15.16 1038.67-12.23 268.14-54.82 451.27-117.09 611.51-64.38 165.66-150.52 306.16-290.57 446.21-140.06 140.05-280.55 226.19-446.21 290.57-160.24 62.27-343.37 104.86-611.51 117.09-268.7 12.26-354.49 15.16-1038.66 15.16zm0-453.91c672.65 0 752.33-2.57 1017.97-14.69 245.62-11.2 379.01-52.24 467.78-86.74 117.59-45.7 201.51-100.29 289.66-188.44 88.16-88.16 142.75-172.08 188.45-289.67 34.5-88.77 75.54-222.16 86.74-467.78 12.12-265.64 14.69-345.32 14.69-1017.98 0-672.65-2.57-752.33-14.69-1017.97-11.2-245.62-52.24-379.01-86.74-467.78-45.7-117.591-100.29-201.509-188.45-289.661-88.15-88.16-172.07-142.75-289.66-188.449-88.77-34.5-222.16-75.539-467.78-86.738-265.6-12.122-345.27-14.692-1017.97-14.692-672.71 0-752.37 2.57-1017.98 14.692-245.62 11.199-379.01 52.238-467.78 86.738-117.591 45.699-201.509 100.289-289.661 188.449-88.152 88.152-142.75 172.07-188.449 289.661-34.5 88.77-75.535 222.16-86.742 467.78-12.121 265.64-14.688 345.32-14.688 1017.97 0 672.66 2.567 752.34 14.688 1017.98 11.207 245.62 52.242 379.01 86.742 467.78 45.699 117.59 100.293 201.51 188.445 289.66 88.156 88.16 172.074 142.75 289.665 188.45 88.77 34.5 222.16 75.54 467.78 86.74 265.64 12.12 345.32 14.69 1017.98 14.69">
+        </path>
+        <path
+          d="M2519.21 1679.47c-463.78 0-839.74 375.96-839.74 839.73 0 463.78 375.96 839.74 839.74 839.74 463.77 0 839.73-375.96 839.73-839.74 0-463.77-375.96-839.73-839.73-839.73zm0 2133.38c-714.47 0-1293.65-579.18-1293.65-1293.65 0-714.46 579.18-1293.64 1293.65-1293.64 714.46 0 1293.64 579.18 1293.64 1293.64 0 714.47-579.18 1293.65-1293.64 1293.65M4166.27 3863.96c0-166.96-135.35-302.3-302.31-302.3-166.95 0-302.3 135.34-302.3 302.3s135.35 302.31 302.3 302.31c166.96 0 302.31-135.35 302.31-302.31">
+        </path>
+      </g>
+    </symbol>
+    <symbol viewBox="-27.7 455.1 337.2 791.1" id="icon-left" xmlns="http://www.w3.org/2000/svg">
+      <path fill="inherit"
+        d="M274.8 1246.2c-9.5 0-19.8-4-27.7-14.3l-262.9-350c-7.9-9.5-11.9-22.2-11.9-31.7 0-11.9 4-22.2 11.9-31.7l262.9-350.1c11.9-14.3 31.7-17.4 47.5-7.9 15.8 9.5 17.4 31.7 7.9 45.9L42.8 851l259.8 342.1c11.9 14.3 7.9 35.6-7.9 45.9-6.4 5.6-11.9 7.2-19.9 7.2">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 18 18" id="icon-link" xmlns="http://www.w3.org/2000/svg">
+      <g opacity=".4">
+        <path
+          d="M10.546 13.732l.623-.623a.957.957 0 0 0 .121-.137c.263-.273.48-.582.65-.905a4.44 4.44 0 0 0 .46-2.733 3.766 3.766 0 0 0-.158-.692 3.61 3.61 0 0 0-.244-.604 4.355 4.355 0 0 0-.877-1.245 4.35 4.35 0 0 0-1.245-.876l-1.14 1.14c-.08.08-.146.163-.204.256a2.735 2.735 0 0 1 2.07 2.07c.044.21.066.426.06.644a2.601 2.601 0 0 1-.765 1.81l-.69.689-.513.513-.485.485-1.237 1.237c-1.037 1.037-2.737 1.024-3.79-.029-1.052-1.052-1.064-2.753-.028-3.789L4.39 9.706a5.663 5.663 0 0 1-.208-2.338L1.881 9.67c-1.73 1.73-1.709 4.56.048 6.316 1.757 1.757 4.586 1.778 6.316.048l2.302-2.302z">
+        </path>
+        <path
+          d="M7.339 7.802a2.54 2.54 0 0 1 .1-.668c.114-.42.339-.814.665-1.14l.693-.694.51-.51.48-.48 1.242-1.241c1.036-1.036 2.736-1.024 3.789.029 1.052 1.052 1.064 2.753.029 3.789l-1.241 1.24c.233.76.302 1.556.211 2.335l2.303-2.303c1.73-1.73 1.708-4.558-.049-6.315C14.314.087 11.485.066 9.756 1.796L7.453 4.098l-.623.623a.934.934 0 0 0-.121.138 3.904 3.904 0 0 0-.645.9 4.39 4.39 0 0 0-.46 2.733c.028.244.08.472.153.696.065.206.142.41.245.604.209.452.503.87.877 1.244.373.374.791.668 1.244.878l1.14-1.141a1.38 1.38 0 0 0 .204-.256 2.68 2.68 0 0 1-1.335-.734 2.685 2.685 0 0 1-.793-1.98z">
+        </path>
+      </g>
+    </symbol>
+    <symbol viewBox="0 0 16 16" id="icon-linkedin" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M.2 15.876h3.394V5.222H.2v10.654zM1.997 0C.8 0 0 .836 0 1.88s.8 1.88 1.997 1.88 1.997-.836 1.997-1.88C3.794.836 2.994 0 1.997 0zm9.985 4.804c-1.798 0-2.596 1.045-2.996 1.88V5.222H5.392c.2 1.045 0 10.862 0 10.862h3.395V9.818c0-.21 0-.627.2-.836.2-.626.798-1.253 1.796-1.253 1.2 0 1.798 1.04 1.798 2.5v5.64h3.4V9.82c0-3.342-1.79-5.014-3.99-5.014z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 35.4 51" id="icon-map-marker" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M18 51.733c11.8-15.9 17.7-27.1 17.7-33.5 0-9.7-7.9-17.5-17.7-17.5S.3 8.533.3 18.233c0 6.4 5.9 17.6 17.7 33.5z">
+      </path>
+      <circle r="8" cy="18" cx="18" fill="#fff"></circle>
+    </symbol>
+    <symbol viewBox="-375 489.5 37.2 30.3" id="icon-menu" xmlns="http://www.w3.org/2000/svg">
+      <title>menu</title>
+      <path
+        d="M-367 489.5h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4zm8 12.8h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4zm8 13.7h29.1v3.8H-367zm-8 0h4.4v3.8h-4.4z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 179 96" id="icon-more" xmlns="http://www.w3.org/2000/svg">
+      <title>more-arrow</title>
+      <path d="M178.86 47.677L129.776 0v34.313H0v26.625h116.296v.103h13.48v34.31l49.084-47.67"></path>
+    </symbol>
+    <symbol viewBox="0 0 50.062 37.479" id="icon-newsletter_signup" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M25.085 21.866L.082 3.114A3.114 3.114 0 0 1 3.207-.012H46.96a3.113 3.113 0 0 1 3.126 3.126l-25 18.752zm0 5.613L50.087 8.726v25.64a3.113 3.113 0 0 1-3.125 3.125H3.208a3.113 3.113 0 0 1-3.125-3.125V8.727L25.085 27.48z"
+        class="aushape-1"></path>
+    </symbol>
+    <symbol viewBox="0 0 832 512" id="icon-norgie-down" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M15.244 98.497L379.433 495.43c20.249 22.24 53.137 22.23 73.373-.021.51-.608.71-1.47 1.25-2.077L817.152 98.259c20.233-22.224 20.223-58.326-.028-80.54-.202-.1-.531-.202-.735-.404C807.065 6.732 793.993-.005 779.353 0L52.923.208C38.073.212 24.903 7.286 15.43 18.18l-.2-.227c-20.314 22.325-20.304 58.33.023 80.543h-.008z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 512 832.328" id="icon-norgie-right" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M98.278 817.088l397.038-364.076c22.245-20.243 22.245-53.13 0-73.373-.608-.51-1.47-.71-2.077-1.25L98.27 15.18c-22.218-20.24-58.32-20.24-80.54.005-.1.202-.202.53-.404.734C6.74 25.24 0 38.31 0 52.95v726.43c0 14.85 7.07 28.022 17.963 37.5l-.228.2c22.32 20.32 58.324 20.32 80.543 0z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 47.3 34.3" id="icon-opentable" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M30.1 0C20.7 0 13 7.7 13 17.2s7.7 17.2 17.2 17.2 17.2-7.7 17.2-17.2C47.3 7.7 39.6 0 30.1 0zm0 21.5c-2.4 0-4.3-1.9-4.3-4.3s1.9-4.3 4.3-4.3 4.3 1.9 4.3 4.3c0 2.3-1.9 4.3-4.3 4.3zM0 17.2c0 2.4 1.9 4.3 4.3 4.3s4.3-1.9 4.3-4.3-1.9-4.3-4.3-4.3S0 14.8 0 17.2">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 12 12" id="icon-pencil" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M1.3 8.4c0 .1 0 .1 0 0L0 11.6c0 .1 0 .2.1.3 0 .1.1.1.1.1h.1l3.1-1.2s.1 0 .1-.1l6.2-6.2-2.2-2.3-6.2 6.2zm10.5-7L10.6.2c-.3-.3-.8-.3-1.1 0L8.2 1.5l2.2 2.2 1.3-1.3c.4-.2.4-.7.1-1z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 60.7 93.3" id="icon-pin" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M57.2 34.6c0 4.8-1.3 9.3-3.5 13.2L31.8 87.5c-.3.5-.9.8-1.5.8-.7 0-1.2-.4-1.5-.8L6.9 47.7c-2.2-3.8-3.5-8.4-3.5-13.2 0-14.8 12-26.9 26.9-26.9 14.9.1 26.9 12.1 26.9 27zm-16.8 0c0-5.6-4.5-10.1-10.1-10.1S20.2 29 20.2 34.6s4.5 10.1 10.1 10.1 10.1-4.5 10.1-10.1z"
+        xmlns="http://www.w3.org/2000/svg"></path>
+    </symbol>
+    <symbol viewBox="-285 377 40 40" id="icon-pinterest" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M-265 377.1c-10.9 0-19.7 8.9-19.7 19.8 0 8.1 4.9 15 11.8 18.1-.1-1.4 0-3 .3-4.5.4-1.6 2.5-10.8 2.5-10.8s-.6-1.3-.6-3.1c0-2.9 1.7-5.1 3.8-5.1 1.8 0 2.7 1.3 2.7 3 0 1.8-1.2 4.5-1.7 7-.5 2.1 1 3.8 3.1 3.8 3.7 0 6.3-4.8 6.3-10.5 0-4.3-2.9-7.6-8.2-7.6-6 0-9.7 4.5-9.7 9.5 0 1.7.5 2.9 1.3 3.9.4.4.4.6.3 1.1l-.4 1.6c-.1.5-.5.7-1 .5-2.8-1.1-4-4.1-4-7.5 0-5.6 4.7-12.3 14.1-12.3 7.5 0 12.5 5.5 12.5 11.3 0 7.7-4.3 13.5-10.7 13.5-2.1 0-4.1-1.2-4.8-2.5 0 0-1.1 4.5-1.4 5.4-.4 1.5-1.2 3-2 4.2 1.8.5 3.7.8 5.6.8 10.9 0 19.7-8.8 19.7-19.7 0-11-8.9-19.9-19.8-19.9z">
+      </path>
+    </symbol>
+    <symbol viewBox="-230 372 50 50" id="icon-play" xmlns="http://www.w3.org/2000/svg">
+      <path fill="#999" d="M-214 376l25.6 21.1L-214 418v-42z"></path>
+    </symbol>
+    <symbol viewBox="0 0 17 17" id="icon-rec" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M7.544.405l2.305 4.64 5.15.743L11.27 9.4l.88 5.1-4.61-2.407-4.6 2.407.88-5.1L.087 5.79l5.153-.744L7.545.404z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 450 386" id="icon-refresh" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M352.629 288.14l96-111.9h-64.7c-2.3-27.9-10.5-54-23.5-77.3-27.4-49.2-75.8-85.1-133-95.6-.7-.1-1.5-.3-2.2-.4-.5-.1-.9-.2-1.4-.2-10.1-1.7-20.6-2.6-31.2-2.6h-.4c-90.9.2-167 63.6-186.7 148.6v.1c-.3 1.1-.5 2.2-.7 3.3-.1.5-.2.9-.3 1.4-.1.7-.3 1.4-.4 2.1-.2.9-.3 1.7-.5 2.6-.1.4-.1.7-.2 1.1l-.6 3.6v.2c-1 6.3-1.6 12.7-1.9 19.1v.8c-.1 1.4-.1 2.7-.2 4.1 0 1.6-.1 3.3-.1 5 0 1.7 0 3.3.1 5 0 1.4.1 2.7.2 4.1v.9c.3 6.5 1 12.9 1.9 19.1v.2l.6 3.6c.1.4.1.7.2 1.1.2.9.3 1.8.5 2.6.1.7.3 1.4.4 2.1.1.5.2 1 .3 1.4.2 1.1.5 2.2.7 3.2v.1c19.7 85 96.1 148.4 187.1 148.6 42.9-.1 83.1-14.2 116.9-40.7l7.5-5.9-43.2-46.2-6.2 4.6c-22.1 16.3-47.5 24.2-75 24.2-70.6 0-128-57-128-128s57.4-128 128-128c66.4 0 122.8 46.6 129.5 112h-73.5l104 112z"
+        xmlns:bx="https://boxy-svg.com" bx:origin="0.5 0.5"></path>
+    </symbol>
+    <symbol viewBox="-27.7 455.1 337.2 791.1" id="icon-right" xmlns="http://www.w3.org/2000/svg">
+      <path fill="inherit"
+        d="M6.9 455.1c9.5 0 19.8 4 27.7 14.3l262.9 350.1c7.9 9.5 11.9 22.2 11.9 31.7 0 11.9-4 22.2-11.9 31.7l-262.8 350c-11.9 14.3-31.7 17.4-47.5 7.9-15.8-9.5-17.4-31.7-7.9-45.9L239 850.3-20.8 508.2c-11.9-14.3-7.9-35.6 7.9-45.9 6.4-5.6 11.9-7.2 19.8-7.2">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 1000 1000" preserveAspectRatio="xMinYMin meet" id="icon-rss"
+      xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M0 866q0-55 39-94t94-39 94 39 39 94q0 56-39 94.5T133 999t-94-39-39-94zm0-335V340q179 0 331 88.5T571.5 669t88.5 331H468q0-194-137-331Q193 531 0 531zm0-339V0q203 0 388 79.5T707 293t213.5 319 79.5 388H808q0-164-64-314T571.5 428t-258-172T0 192z">
+      </path>
+    </symbol>
+    <symbol viewBox="373.3 133.3 533.3 533.3" id="icon-search" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M754.7 468.7l-22.3-22.3c24.3-33.3 37.5-73.4 37.7-114.7 0-109.5-88.8-198.3-198.3-198.3s-198.3 88.8-198.3 198.3S462.1 530 571.7 530c41.2-.2 81.3-13.4 114.7-37.7l22.3 22.3 152.7 152 45.3-45.3-152-152.6zm-183 0c-75.8 0-137.3-61.5-137.3-137.3S495.8 194 571.7 194 709 255.5 709 331.3c.2 75.7-61 137.1-136.7 137.3-.2.1-.4.1-.6.1z">
+      </path>
+    </symbol>
+    <symbol viewBox="206 29.9 642.1 681.3" id="icon-settings" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M843 467.2c4.8 3.2 6.3 9.5 4 15-13.5 41.2-36.4 79.2-64.2 111.7-4 4.8-9.5 6.3-15 4l-81.6-28.5c-20.6 16.6-43.6 30.1-67.3 39.6l-16.6 84.7c-.8 5.5-5.5 10.3-11.1 11.1-21.4 4-42.8 6.3-64.2 6.3-22.2 0-43.6-2.4-64.2-6.3-5.5-.8-10.3-5.5-11.1-11.1L435.2 609c-24.6-9.5-48.3-23-67.3-39.6l-81.6 28.5c-5.5 2.4-11.1.8-15-4-28.5-32.5-51.5-70.5-64.2-111.7-2.4-5.5-.8-11.9 4-15l64.9-57c-2.4-12.7-3.2-26.1-3.2-39.6s.8-26.9 3.2-39.6l-65-57c-4.8-3.2-6.3-9.5-4-15 13.5-41.2 36.4-79.2 64.2-111.7 4-4.8 9.5-6.3 15-4l81.6 28.5c19.8-16.6 43.6-30.1 67.3-39.6l16.6-84.7c.8-5.5 5.5-10.3 11.1-11.1 42.8-8.7 86.3-8.7 129.1 0 5.5.8 10.3 5.5 11.1 11.1l15 85.5c24.6 9.5 47.5 23 67.3 39.6l81.6-28.5c5.5-2.4 11.1-.8 15 4 28.5 32.5 51.5 70.5 64.2 111.7 2.4 5.5.8 11.9-4 15l-65.7 57c2.4 12.7 3.2 26.1 3.2 39.6s-.8 26.9-3.2 39.6l66.6 56.2zm-190-95.8c0-69.7-57.8-127.5-127.5-127.5-70.5 0-127.5 57-127.5 127.5s57 127.5 127.5 127.5S653 441.9 653 371.4z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 16 16" id="icon-snapchat" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8.155.48c.662 0 2.903.185 3.96 2.552.354.797.27 2.15.2 3.237l-.002.04c-.008.12-.015.23-.02.34.05.03.135.06.268.06.2-.01.44-.08.69-.2.11-.06.23-.07.31-.07.12 0 .24.02.34.06.3.1.49.32.49.56.01.3-.26.56-.81.78-.06.02-.14.05-.23.08-.3.09-.76.24-.89.54-.06.15-.04.35.08.58l.01.01c.04.09 1.02 2.32 3.2 2.68.17.03.29.18.28.34 0 .05-.01.1-.03.15-.16.38-.85.66-2.1.85-.04.06-.08.25-.11.38-.02.12-.05.24-.09.37-.05.18-.18.27-.37.27h-.02c-.09 0-.21-.02-.36-.05-.24-.05-.51-.09-.85-.09-.2 0-.4.01-.61.05-.4.07-.75.31-1.15.59-.57.4-1.22.86-2.2.86-.04 0-.08-.01-.12-.01h-.1c-.98 0-1.62-.45-2.19-.86-.4-.28-.74-.52-1.14-.59-.21-.03-.42-.05-.62-.05-.36 0-.64.06-.85.1-.14.03-.26.05-.36.05-.25 0-.35-.15-.39-.28-.04-.13-.06-.26-.09-.38s-.07-.33-.11-.38C.89 12.9.2 12.62.04 12.23a.413.413 0 0 1-.036-.15.332.332 0 0 1 .28-.34c2.18-.36 3.16-2.59 3.2-2.684l.01-.02c.12-.23.15-.43.08-.58-.13-.29-.59-.44-.89-.54-.08-.02-.16-.05-.23-.08-.74-.29-.84-.62-.8-.85.06-.32.45-.53.78-.53.097 0 .18.02.256.05.28.13.527.2.737.2a.63.63 0 0 0 .31-.07l-.03-.38c-.065-1.086-.15-2.438.205-3.23C4.94.67 7.175.49 7.835.49l.28-.01h.04z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 17 17" id="icon-star" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M7.544.405l2.305 4.64 5.15.743L11.27 9.4l.88 5.1-4.61-2.407-4.6 2.407.88-5.1L.087 5.79l5.153-.744L7.545.404z">
+      </path>
+    </symbol>
+    <symbol viewBox="19.3 54.3 26.9 33.7" id="icon-thumb-down" xmlns="http://www.w3.org/2000/svg">
+      <title>no</title>
+      <path
+        d="M19.3 84.4c0-4.8 0-9.4.1-14 0-.4 1-1 1.6-1.2 4.2-1.1 7.7-3.2 9.6-7.3.7-1.6.9-3.4 1.5-5 .4-.9 1.2-1.7 1.8-2.5.7.8 2 1.6 2.1 2.5.2 2.2 0 4.5-.2 6.8-.1.9-.4 1.8-.6 3h5.1c1.2 0 2.4 0 3.5.2 1.9.3 2.4 1.3 2.2 3.2-.1 1.2.1 2.4.1 3.6 0 1 0 1.9-.1 2.9-.1 1.1 0 2.2-.3 3.1-1 2.6-2.1 5.2-3.4 7.6-.3.6-1.8.7-2.7.7-2.4.1-4.8.2-7.2 0-1.4-.1-2.9-.5-4-1.3-2.2-1.7-4.4-2.3-7.1-2.1-.6-.1-1.2-.2-2-.2z">
+      </path>
+    </symbol>
+    <symbol viewBox="19.3 54.3 26.9 33.7" id="icon-thumb-up" xmlns="http://www.w3.org/2000/svg">
+      <title>yes</title>
+      <path
+        d="M19.3 84.4c0-4.8 0-9.4.1-14 0-.4 1-1 1.6-1.2 4.2-1.1 7.7-3.2 9.6-7.3.7-1.6.9-3.4 1.5-5 .4-.9 1.2-1.7 1.8-2.5.7.8 2 1.6 2.1 2.5.2 2.2 0 4.5-.2 6.8-.1.9-.4 1.8-.6 3h5.1c1.2 0 2.4 0 3.5.2 1.9.3 2.4 1.3 2.2 3.2-.1 1.2.1 2.4.1 3.6 0 1 0 1.9-.1 2.9-.1 1.1 0 2.2-.3 3.1-1 2.6-2.1 5.2-3.4 7.6-.3.6-1.8.7-2.7.7-2.4.1-4.8.2-7.2 0-1.4-.1-2.9-.5-4-1.3-2.2-1.7-4.4-2.3-7.1-2.1-.6-.1-1.2-.2-2-.2z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 60.7 93.3" id="icon-topics" xmlns="http://www.w3.org/2000/svg">
+      <g xmlns="http://www.w3.org/2000/svg">
+        <path d="M2.5 21.5h55.2v11.8H2.5zM2.5 42.1h55.2v11.8H2.5zM2.5 64.3h55.2v11.8H2.5z"></path>
+      </g>
+    </symbol>
+    <symbol viewBox="0 0 87 60" id="icon-trending" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M1.906 46.826c2.213 1.787 5.466 1.46 7.262-.743v-.006l5.26-6.45 8.378 11.286a5.171 5.171 0 0 0 4.827 2.035 5.128 5.128 0 0 0 4.124-3.215l7.96-20.208L51.26 56.577a5.155 5.155 0 0 0 4.754 3.13c.097 0 .19 0 .286-.007a5.172 5.172 0 0 0 4.66-3.667l10.98-36.787 4.854 9.902c1.234 2.552 4.33 3.613 6.89 2.37 2.56-1.234 3.636-4.314 2.386-6.86L75.42 2.888a5.15 5.15 0 0 0-5.067-2.87 5.135 5.135 0 0 0-4.52 3.653L55.146 39.42 44.28 13.93a5.142 5.142 0 0 0-4.827-3.127 5.157 5.157 0 0 0-4.73 3.263L25.56 37.343l-6.79-9.148a5.197 5.197 0 0 0-4.033-2.08 5.139 5.139 0 0 0-4.124 1.897L1.153 39.6a5.125 5.125 0 0 0 .753 7.226"
+        fill-rule="evenodd"></path>
+    </symbol>
+    <symbol viewBox="0 0 23.62 41.098" id="icon-tumblr" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M21.643 32.826c-.764.364-2.226.682-3.316.71-3.29.088-3.927-2.31-3.955-4.052V16.69h8.252v-6.22h-8.222V0h-6.02c-.1 0-.272.087-.296.307C7.734 3.512 6.234 9.135 0 11.382v5.31h4.16V30.12c0 4.595 3.39 11.126 12.343 10.974 3.02-.053 6.375-1.318 7.117-2.408l-1.977-5.86z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 44.71 36.327" id="icon-twitter" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M44.71 4.295c-1.656.724-3.415 1.242-5.278 1.45A9.146 9.146 0 0 0 43.468.673a18.75 18.75 0 0 1-5.796 2.225C35.965 1.138 33.584 0 30.945 0a9.145 9.145 0 0 0-9.16 9.16c0 .724.052 1.448.208 2.12-7.607-.413-14.335-3.88-18.888-9.417-.777 1.345-1.242 2.742-1.242 4.45 0 3.157 1.604 5.95 4.088 7.607a9.376 9.376 0 0 1-4.14-1.138v.103c0 4.45 3.16 8.176 7.35 9.004-.77.2-1.6.31-2.43.31-.57 0-1.14-.06-1.71-.16 1.14 3.62 4.56 6.31 8.54 6.36-3.1 2.48-7.09 4.34-11.38 4.34-.72 0-1.45-.05-2.17-.16 4.04 2.59 8.9 3.72 14.08 3.72 16.87 0 26.08-13.97 26.08-26.08V9.05c1.76-1.294 3.32-2.9 4.56-4.76">
+      </path>
+    </symbol>
+    <symbol viewBox="-235.8 423.2 35.7 21.3" id="icon-up" xmlns="http://www.w3.org/2000/svg">
+      <path fill="none" d="M-200.5 444.2L-218 424l-17.5 20.2"></path>
+    </symbol>
+    <symbol viewBox="373.3 133.3 533.3 533.3" id="icon-user" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M640 400c73.6 0 133.3-59.7 133.3-133.3S713.6 133.3 640 133.3 506.7 193 506.7 266.7 566.4 400 640 400zm0 66.7c-89 0-266.7 44.7-266.7 133.3v66.7h533.3V600c.1-88.7-177.6-133.3-266.6-133.3z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 1146 1000" id="icon-vimeo" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M0 272q55-65 110-116t95.5-77.5 72.5-43T326 14l17-4q12-2 24-2 19 0 35 6 26 10 42.5 34.5t29 55 21.5 72 15 77.5 13.5 79.5T538 403q32 125 51.5 177.5T631 633q24 0 66.5-55.5T791 426q26-48 26-91 0-13-2-23-9-52-51-65-11-4-24-4-35 0-83 26 22-130 134-209Q876 0 965 0q12 0 24 1 102 8 139 90 18 38 18 88 0 29-6 61-18 102-69.5 208t-113 187.5-132.5 155-123.5 117T611 976q-42 24-78.5 24T463 979t-56-48-38-57q-18-38-97.5-298.5T175 295q-1-2-4-4t-13.5-4.5-24 0-36.5 14T47 333z">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 86.965 87.642" id="icon-whatsapp" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd" clip-rule="evenodd"
+        d="M44.038 13.007c-16.58 0-30.02 13.44-30.02 30.02a29.883 29.883 0 0 0 4.307 15.503l-5.418 16.106 16.62-5.32a29.915 29.915 0 0 0 14.512 3.733c16.58 0 30.02-13.45 30.02-30.03C74.06 26.44 60.61 13 44.03 13zm0 55.013a24.85 24.85 0 0 1-13.75-4.132l-9.604 3.074 3.122-9.28a24.858 24.858 0 0 1-4.76-14.653c0-13.79 11.212-25 24.993-25 13.78 0 24.99 11.21 24.99 24.99 0 13.78-11.22 24.99-25 24.99zm14.075-18.17c-.753-.412-4.45-2.407-5.143-2.69-.693-.28-1.2-.427-1.74.32s-2.072 2.418-2.538 2.913c-.467.495-.916.54-1.668.128-.752-.41-3.19-1.31-6.02-4.03-2.202-2.11-3.646-4.68-4.065-5.46-.42-.78-.01-1.18.39-1.55.35-.33.8-.86 1.2-1.3.4-.43.54-.74.81-1.25.27-.5.16-.95-.02-1.34s-1.57-4.22-2.15-5.77c-.58-1.56-1.23-1.32-1.68-1.34-.45-.01-.96-.1-1.47-.12-.51-.02-1.35.14-2.08.89-.73.74-2.78 2.52-2.92 6.29-.14 3.77 2.47 7.52 2.83 8.04.36.53 4.98 8.7 12.66 12.06 7.67 3.36 7.71 2.34 9.12 2.26 1.41-.07 4.6-1.68 5.31-3.45.7-1.76.76-3.3.58-3.62-.18-.32-.68-.54-1.43-.95z">
+      </path>
+    </symbol>
+    <symbol viewBox="130.35156 177.43359 300 300" overflow="visible" id="icon-yahoo" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M420.926 272.27c-5.2.514-26.85 5.365-34.13 6.925-7.79 2.073-78.983 57.075-83.66 70.58-1.036 4.674-1.556 11.866-1.556 18.624l-.52 10.91c-.002 7.79 2.162 20.35 3.198 27.1 4.68 1.04 38.555.13 44.79 1.17l-.768 13.97c-6.09-.45-49.106-.34-73.68-.34-12.475 0-52.576 1.37-64.897 1l2.33-13.29c6.755-.53 34.728 1.2 40.878-5.29 3.06-3.22 2.09-6.67 2.09-25.38v-8.83c0-4.16 0-11.96-1.04-19.24-2.59-7.8-65.3-86.09-81.41-98.56-4.68-1.56-33.99-4.49-41.26-6.05l-.36-11.97c3.63-1.82 36.22.44 67.85-.73 20.79-.77 68.22 0 74.07.7l-1.5 10.55c-6.23 1.56-36.26 2.14-44.06 4.21 20.27 30.14 52.31 68.94 62.71 84.01 5.72-8.31 55.96-42.87 57.51-54.82-7.79-1.57-33.6-5.28-37.76-5.28l-2.47-13.61c7.08-1.11 44.28 0 62.78 0 15.96 0 50.07 0 59.76.79l-8.86 12.81">
+      </path>
+    </symbol>
+    <symbol viewBox="0 0 462 325" id="icon-youtube" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M234.28 1.691c-53.492 0-132.53 3.24-156.188 4.031C52.396 8.02 42.884 9.366 28.811 21.41 7.368 40.48 2.28 77.954 2.28 135.285v54.562c0 65.439 8.69 98.684 23 110.844 16.517 14.17 27.407 15.302 38.406 17 4.27.646 34.49 6 168.594 6 83.626 0 155.507-3.95 162.937-4.906 11.945-1.508 29.104-3.696 42.063-18.094 19.183-21.803 23-57.999 23-110.437V126.69c0-33.943-1.891-81.916-23-102-15.991-13.536-21.848-17.367-54.938-19.031-9.358-.462-91.02-3.969-148.062-3.969zm-49.5 97l123.5 63.75-123.5 64.25v-128z">
+      </path>
+    </symbol>
+  </svg>
+
+  <div class="l-root l-reskin">
     <div class="l-header">
-      
-<div class="chorus-emc__content" data-emc-slug="UnisonCustomNavCell" data-emc-bucket="372::">
-    
-<header class="c-global-header " data-cid="site/global_header" role="banner" data-analytics-placement="navigation" >
-  <div class="l-wrapper">
-    <div class="c-global-header__logo ">
-      <a href="/" tabindex="1" id="chorus-brand" data-analytics-link="home">
-        
-          <span class="c-global-header__logo-large">
-            
-  <svg fill="#fff" xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2"><path d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3"/><path d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24"/></svg>
 
 
-          </span>
-        
-        
-          <span class="c-global-header__logo-small">
-            
-  <svg fill="#fff" xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2"><path d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3"/><path d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24"/></svg>
+      <div class="chorus-emc__content" data-emc-slug="UnisonCustomNavCell" data-emc-bucket="372::">
+        <header class="c-global-header " data-cid="site/global_header-1615219071_4083_2183" role="banner"
+          data-analytics-placement="navigation" data-cdata="{&quot;nav_items_limit&quot;:0}">
+          <div class="l-wrapper">
+            <div class="c-global-header__logo has-no-sublist">
+              <a href="/" id="chorus-brand" data-analytics-link="home">
+
+                <span class="sr-only">The Verge homepage</span>
+                <span class="c-global-header__logo-large" aria-hidden="true" tabindex="-1">
+
+                  <svg fill="#fff" xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2">
+                    <path
+                      d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3">
+                    </path>
+                    <path
+                      d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24">
+                    </path>
+                  </svg>
 
 
-          </span>
-        
-        
-        
-      </a>
-      
-    </div>
-    
-      <ul class="c-global-header__social">
-      
-        <li><a href="https://www.facebook.com/verge" class="facebook" tabindex="2">
-          <svg class="p-svg-icon"><use xlink:href="#icon-facebook"></use></svg>
-          
-        </a></li>
-      
-        <li><a href="https://twitter.com/verge" class="twitter" tabindex="3">
-          <svg class="p-svg-icon"><use xlink:href="#icon-twitter"></use></svg>
-          
-        </a></li>
-      
-        <li><a href="/rss/index.xml" class="rss" tabindex="4">
-          <svg class="p-svg-icon"><use xlink:href="#icon-rss"></use></svg>
-          
-        </a></li>
-      
-      </ul>
-    
-    
-      <div class="c-global-header__actions">
-    
-    
-      <div class="c-global-header__login">
-        <a class="c-global-header__login-icon" href="https://auth.voxmedia.com/login?return_to=https%3A%2F%2Fwww.theverge.com%2F" data-ui="icon" tabindex="5"><svg class="c-global-header__login-svg"><use xlink:href="#icon-user"></use></svg>
-          <span class="u-hidden-text">Log In or Sign Up</span>
-        </a>
-        <ul class="c-global-header__login-menu" data-ui="menu">
-          <li class="c-global-header__login-menu-item">
-            <a href="https://auth.voxmedia.com/login?return_to=https%3A%2F%2Fwww.theverge.com%2F" data-ui-signin="login" tabindex="6" data-analytics-link="login">Log In</a>
-          </li>
-          <li class="c-global-header__login-menu-item">
-            <a href="https://auth.voxmedia.com/signup?return_to=https%3A%2F%2Fwww.theverge.com%2F" data-ui-signin="signup" tabindex="7" data-analytics-link="signup">Sign Up</a>
-          </li>
-        </ul>
-      </div>
-    
-    
-      <div class="c-global-header__search">
-        <button type="submit" class="c-global-header__search-trigger" tabindex="8">
-          <svg class="c-global-header__login-svg"><use xlink:href="#icon-search"></use></svg>
-        </button>
-      </div>
-    
-    
-      </div>
-    
-    
-    <nav class="c-global-header__links">
-      <ul>
-        
-          
-          
-            <li class="c-global-header__link is-pinned" data-nav-item-id='tech' data-nav-list-trigger='tech'>
-              
-              <a
-              
-                href="/tech"
-              
-              
-                tabindex="9">
-                
-              Tech
-              
-                <span class="c-global-header__link-arrow"><svg><use xlink:href="#icon-norgie-down"></use></svg></span>
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link is-pinned" data-nav-item-id='science' data-nav-list-trigger='science'>
-              
-              <a
-              
-                href="/science"
-              
-              
-                tabindex="10">
-                
-              Science
-              
-                <span class="c-global-header__link-arrow"><svg><use xlink:href="#icon-norgie-down"></use></svg></span>
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link is-pinned" data-nav-item-id='culture' data-nav-list-trigger='culture'>
-              
-              <a
-              
-                href="/culture"
-              
-              
-                tabindex="11">
-                
-              Culture
-              
-                <span class="c-global-header__link-arrow"><svg><use xlink:href="#icon-norgie-down"></use></svg></span>
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='cars' data-nav-list-trigger='cars'>
-              
-              <a
-              
-                href="/transportation"
-              
-              
-                tabindex="12">
-                
-              Cars
-              
-                <span class="c-global-header__link-arrow"><svg><use xlink:href="#icon-norgie-down"></use></svg></span>
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='reviews' data-nav-list-trigger='reviews'>
-              
-              <a
-              
-                href="/reviews"
-              
-              
-                tabindex="13">
-                
-              Reviews
-              
-                <span class="c-global-header__link-arrow"><svg><use xlink:href="#icon-norgie-down"></use></svg></span>
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='longform' >
-              
-              <a
-              
-                href="/longform"
-              
-              
-                tabindex="14">
-                
-              Longform
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='video' >
-              
-              <a
-              
-                href="https://goo.gl/G5RXGs"
-              
-              
-                tabindex="15">
-                
-              Video
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='circuit-breaker' >
-              
-              <a
-              
-                href="/circuitbreaker"
-              
-              
-                tabindex="16">
-                
-              Circuit Breaker
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='forums' >
-              
-              <a
-              
-                href="/forums"
-              
-              
-                tabindex="17">
-                
-              Forums
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='podcasts' >
-              
-              <a
-              
-                href="/podcasts"
-              
-              
-                tabindex="18">
-                
-              Podcasts
-              
-              </a>
-              
-              
-            </li>
-          
-            <li class="c-global-header__link hidden" data-nav-item-id='store' >
-              
-              <a
-              
-                href="/store"
-              
-              
-                tabindex="19">
-                
-              Store
-              
-              </a>
-              
-              
-            </li>
-          
-        
-        <li class="c-global-header__link-more " data-nav-list-trigger="more">
-          <a class="c-global-header__label">
-            More
-            <span class="c-global-header__link-arrow"><svg><use xlink:href="#icon-norgie-down"></use></svg></span>
-            <span class="c-global-header__link-hamburger"><svg><use xlink:href="#icon-hamburger"></use></svg></span>
-          </a>
-        </li>
-      </ul>
-    </nav>
-    
-    
-      <div class="p-input-header c-global-header__search-menu" data-analytics-class="search">
-  <form action="/search" method="GET" data-analytics-class="search">
-    
-    <input class="p-input-header__input" name="q" placeholder="Search">
-    <input type="submit" class="p-input-header__link p-button" value="Search">
-  </form>
-</div>
+                </span>
 
-    
-    
-  </div>
-</header>
-<section class="c-nav-list" data-cid="site/nav_list-1516701511_5938_49185" data-cdata='{"tab_id":"more"}'>
-  <div class="c-nav-list__inner">
-  
-    <ul class="c-nav-list__main" data-nav-list-id="more">
-      
-        <li data-nav-item-id="tech" data-nav-list-id="tech">
-        
-          <a class="c-nav-list__label" href="/tech">
-            Tech
-            
-              <svg><use xlink:href="#icon-norgie-down"></use></svg>
-            
-          </a>
-          
-        
 
-         
-            
-            
-              <ul class="c-nav-list__sub-items">
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+                <span class="c-global-header__logo-small">
+
+                  <svg fill="#fff" xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2">
+                    <path
+                      d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3">
+                    </path>
+                    <path
+                      d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24">
+                    </path>
+                  </svg>
+
+
+                </span>
+
+
+
+              </a>
+
+            </div>
+
+            <h2 class="sr-only" id="global-header__social--label">Follow The Verge online:</h2>
+            <ul class="c-global-header__social" aria-labelledby="global-header__social--label">
+
+              <li class="has-no-sublist"><a href="https://www.facebook.com/verge" class="facebook">
+                  <svg role="img" class="p-svg-icon">
+                    <title>Follow The Verge on Facebook</title>
+                    <use xlink:href="#icon-facebook"></use>
+                  </svg>
+
+                </a></li>
+
+              <li class="has-no-sublist"><a href="https://twitter.com/verge" class="twitter">
+                  <svg role="img" class="p-svg-icon">
+                    <title>Follow The Verge on Twitter</title>
+                    <use xlink:href="#icon-twitter"></use>
+                  </svg>
+
+                </a></li>
+
+              <li class="has-no-sublist"><a href="/rss/index.xml" class="rss">
+                  <svg role="img" class="p-svg-icon">
+                    <title>RSS feed (all stories on The Verge)</title>
+                    <use xlink:href="#icon-rss"></use>
+                  </svg>
+
+                </a></li>
+
+            </ul>
+
+
+            <div class="c-global-header__actions">
+
+
+
+
+
+
+              <div class="c-global-header__login logged_out_menu has-no-sublist">
+                <a class="c-global-header__login-icon"
+                  href="https://auth.voxmedia.com/login?community_id=372&amp;return_to=https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                  data-return-to="" data-ui="icon"><svg role="img" class="c-global-header__login-svg">
+                    <use xlink:href="#icon-user"></use>
+                  </svg>
+                  <span class="sr-only">Log in or sign up</span>
+                </a>
+                <ul class="c-global-header__login-menu" data-ui="menu">
+                  <li class="c-global-header__login-menu-item logged_out_item has-no-sublist">
+                    <a href="https://auth.voxmedia.com/login?community_id=372&amp;return_to=https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      data-return-to="" data-analytics-link="login">Log In</a>
+                  </li>
+
+                  <li class="c-global-header__login-menu-item logged_out_item has-no-sublist">
+                    <a href="https://auth.voxmedia.com/signup?community_id=372&amp;return_to=https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      data-return-to="" data-analytics-link="signup">Sign Up</a>
+                  </li>
+
+                </ul>
+              </div>
+
+
+
+
+            </div>
+
+
+            <nav class="c-global-header__links" aria-labelledby="global-header__links--label">
+              <h2 id="global-header__links--label" class="sr-only">The Verge main menu</h2>
+              <ul>
+
+
+
+                <li class="c-global-header__link is-pinned" data-nav-item-id="tech" data-nav-list-trigger="tech">
+
+                  <a href="/tech">
+                    Tech
+
+                    <span class="c-global-header__link-arrow"><svg role="img">
+                        <use xlink:href="#icon-norgie-down"></use>
+                      </svg></span>
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link" data-nav-item-id="reviews" data-nav-list-trigger="reviews">
+
+                  <a href="/reviews">
+                    Reviews
+
+                    <span class="c-global-header__link-arrow"><svg role="img">
+                        <use xlink:href="#icon-norgie-down"></use>
+                      </svg></span>
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link is-pinned" data-nav-item-id="science" data-nav-list-trigger="science">
+
+                  <a href="/science">
+                    Science
+
+                    <span class="c-global-header__link-arrow"><svg role="img">
+                        <use xlink:href="#icon-norgie-down"></use>
+                      </svg></span>
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link" data-nav-item-id="creators" data-nav-list-trigger="creators">
+
+                  <a href="/creators">
+                    Creators
+
+                    <span class="c-global-header__link-arrow"><svg role="img">
+                        <use xlink:href="#icon-norgie-down"></use>
+                      </svg></span>
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link is-pinned" data-nav-item-id="entertainment"
+                  data-nav-list-trigger="entertainment">
+
+                  <a href="/entertainment">
+                    Entertainment
+
+                    <span class="c-global-header__link-arrow"><svg role="img">
+                        <use xlink:href="#icon-norgie-down"></use>
+                      </svg></span>
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link has-no-sublist" data-nav-item-id="video">
+
+                  <a href="https://goo.gl/G5RXGs">
+                    Video
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link has-no-sublist" data-nav-item-id="features">
+
+                  <a href="/features">
+                    Features
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link hidden has-no-sublist" data-nav-item-id="podcasts">
+
+                  <a href="/podcasts">
+                    Podcasts
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link hidden has-no-sublist" data-nav-item-id="newsletters">
+
+                  <a href="/pages/newsletters">
+                    Newsletters
+
+                  </a>
+
+
+                </li>
+
+                <li class="c-global-header__link hidden has-no-sublist" data-nav-item-id="store">
+
+                  <a href="/store">
+                    Store
+
+                  </a>
+
+
+                </li>
+
+
+                <li class="c-global-header__link-more" data-nav-list-trigger="more">
+                  <a class="c-global-header__label">
+                    More
+                    <span class="c-global-header__link-arrow"><svg role="img">
+                        <use xlink:href="#icon-norgie-down"></use>
+                      </svg></span>
+                    <span class="c-global-header__link-hamburger"><svg role="img">
+                        <use xlink:href="#icon-hamburger"></use>
+                      </svg></span>
+                  </a>
+                </li>
+              </ul>
+            </nav>
+
+
+
+          </div>
+        </header>
+        <section class="c-nav-list" data-cid="site/nav_list-1615219071_8449_2182"
+          data-cdata="{&quot;tab_id&quot;:&quot;more&quot;}">
+          <div class="c-nav-list__inner">
+
+            <ul class="c-nav-list__main" data-nav-list-id="more">
+
+              <li data-nav-item-id="tech" data-nav-list-id="tech" class="hidden">
+
+                <a class="c-nav-list__label" href="/tech">
+                  Tech
+
+                  <span class="c-nav-list__arrow-down"><svg role="img">
+                      <use xlink:href="#icon-norgie-down"></use>
+                    </svg></span>
+
+                </a>
+
+
+
+
+
+
+                <ul class="c-nav-list__sub-items has-columns">
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/apple">Apple</a>
-                      
-                      
+
+                      <a href="https://goo.gl/G5RXGs">
+                        Video
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/google">Google</a>
-                      
-                      
+
+                      <a href="/amazon">
+                        Amazon
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/microsoft">Microsoft</a>
-                      
-                      
+
+                      <a href="/apple">
+                        Apple
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+
                     <li class=" ">
-                      
-                        <a href="/apps">Apps</a>
-                      
-                      
+
+                      <a href="/facebook">
+                        Facebook
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/photography">Photography</a>
-                      
-                      
+
+                      <a href="/google">
+                        Google
+                      </a>
+
+
                     </li>
-                    
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/vr-virtual-reality">Virtual Reality</a>
-                      
-                      
+
+                      <a href="/microsoft">
+                        Microsoft
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+
                     <li class=" ">
-                      
-                        <a href="/business">Business</a>
-                      
-                      
+
+                      <a href="/samsung">
+                        Samsung
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/design">Design</a>
-                      
-                      
+
+                      <a href="/tesla-motors">
+                        Tesla
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                
+
+                    <li class=" ">
+
+                      <a href="/ai-artificial-intelligence">
+                        AI
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/cars">
+                        Cars
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="/cyber-security">
+                        Cybersecurity
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/mobile">
+                        Mobile
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/policy">
+                        Policy
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/privacy">
+                        Privacy
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/scooters">
+                        Scooters
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
                   <li class="c-nav-list__all-link">
                     <a href="/tech">All Tech</a>
                   </li>
-                
-              </ul>
-            
-          
-        </li>
-      
-        <li data-nav-item-id="science" data-nav-list-id="science">
-        
-          <a class="c-nav-list__label" href="/science">
-            Science
-            
-              <svg><use xlink:href="#icon-norgie-down"></use></svg>
-            
-          </a>
-          
-        
 
-         
-            
-            
-              <ul class="c-nav-list__sub-items">
-                
-                  
-                    
+                </ul>
+
+
+              </li>
+
+              <li data-nav-item-id="reviews" data-nav-list-id="reviews" class="hidden">
+
+                <a class="c-nav-list__label" href="/reviews">
+                  Reviews
+
+                  <span class="c-nav-list__arrow-down"><svg role="img">
+                      <use xlink:href="#icon-norgie-down"></use>
+                    </svg></span>
+
+                </a>
+
+
+
+
+
+
+                <ul class="c-nav-list__sub-items has-columns">
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/space">Space</a>
-                      
-                      
+
+                      <a href="/phone-review">
+                        Phones
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/energy">Energy</a>
-                      
-                      
+
+                      <a href="/laptop-review">
+                        Laptops
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/health">Health</a>
-                      
-                      
+
+                      <a href="/headphone-review">
+                        Headphones
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/environment">Environment</a>
-                      
-                      
+
+                      <a href="/camera-review">
+                        Cameras
+                      </a>
+
+
                     </li>
-                    
-                  
-                
-                
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="/tablet-review">
+                        Tablets
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/smartwatch-review">
+                        Smartwatches
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/speaker-review">
+                        Speakers
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/drone-review">
+                        Drones
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="/tech-accessory-review">
+                        Accessories
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/this-is-my-next">
+                        Buying Guides
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/how-to">
+                        How-tos
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/good-deals">
+                        Deals
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
+                  <li class="c-nav-list__all-link">
+                    <a href="/reviews">More from Verge Reviews</a>
+                  </li>
+
+                </ul>
+
+
+              </li>
+
+              <li data-nav-item-id="science" data-nav-list-id="science" class="hidden">
+
+                <a class="c-nav-list__label" href="/science">
+                  Science
+
+                  <span class="c-nav-list__arrow-down"><svg role="img">
+                      <use xlink:href="#icon-norgie-down"></use>
+                    </svg></span>
+
+                </a>
+
+
+
+
+
+
+                <ul class="c-nav-list__sub-items has-columns">
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="http://bit.ly/2FqJZMl">
+                        Video
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/space">
+                        Space
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/nasa">
+                        NASA
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/spacex">
+                        SpaceX
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="/health">
+                        Health
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/energy">
+                        Energy
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/environment">
+                        Environment
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
                   <li class="c-nav-list__all-link">
                     <a href="/science">All Science</a>
                   </li>
-                
-              </ul>
-            
-          
-        </li>
-      
-        <li data-nav-item-id="culture" data-nav-list-id="culture">
-        
-          <a class="c-nav-list__label" href="/culture">
-            Culture
-            
-              <svg><use xlink:href="#icon-norgie-down"></use></svg>
-            
-          </a>
-          
-        
 
-         
-            
-            
-              <ul class="c-nav-list__sub-items">
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+                </ul>
+
+
+              </li>
+
+              <li data-nav-item-id="creators" data-nav-list-id="creators" class="hidden">
+
+                <a class="c-nav-list__label" href="/creators">
+                  Creators
+
+                  <span class="c-nav-list__arrow-down"><svg role="img">
+                      <use xlink:href="#icon-norgie-down"></use>
+                    </svg></span>
+
+                </a>
+
+
+
+
+
+
+                <ul class="c-nav-list__sub-items has-columns">
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/web">Web</a>
-                      
-                      
+
+                      <a href="/youtube">
+                        YouTube
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/tv">TV</a>
-                      
-                      
+
+                      <a href="/instagram">
+                        Instagram
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/film">Film</a>
-                      
-                      
+
+                      <a href="/adobe">
+                        Adobe
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/games">Games</a>
-                      
-                      
+
+                      <a href="/kickstarter">
+                        Kickstarter
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/comics">Comics</a>
-                      
-                      
+
+                      <a href="/tumblr">
+                        Tumblr
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/music">Music</a>
-                      
-                      
+
+                      <a href="art-club">
+                        Art Club
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="/camera-review">
+                        Cameras
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/photography">
+                        Photography
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/whats-in-your-bag">
+                        What’s in your bag?
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
                   <li class="c-nav-list__all-link">
-                    <a href="/culture">All Culture</a>
+                    <a href="/creators">All Creators</a>
                   </li>
-                
-              </ul>
-            
-          
-        </li>
-      
-        <li data-nav-item-id="cars" data-nav-list-id="cars">
-        
-          <a class="c-nav-list__label" href="/transportation">
-            Cars
-            
-              <svg><use xlink:href="#icon-norgie-down"></use></svg>
-            
-          </a>
-          
-        
 
-         
-            
-            
-              <ul class="c-nav-list__sub-items">
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+                </ul>
+
+
+              </li>
+
+              <li data-nav-item-id="entertainment" data-nav-list-id="entertainment" class="hidden">
+
+                <a class="c-nav-list__label" href="/entertainment">
+                  Entertainment
+
+                  <span class="c-nav-list__arrow-down"><svg role="img">
+                      <use xlink:href="#icon-norgie-down"></use>
+                    </svg></span>
+
+                </a>
+
+
+
+
+
+
+                <ul class="c-nav-list__sub-items has-columns">
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/ride-sharing">Ride-Sharing</a>
-                      
-                      
+
+                      <a href="/film">
+                        Film
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/cars">Cars</a>
-                      
-                      
+
+                      <a href="/tv">
+                        TV
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/trains">Mass Transit</a>
-                      
-                      
+
+                      <a href="/games">
+                        Games
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
                     <li class=" ">
-                      
-                        <a href="/planes">Aviation</a>
-                      
-                      
+
+                      <a href="/fortnite">
+                        Fortnite
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/bikes">Rideables</a>
-                      
-                      
+
+                      <a href="/game-of-thrones">
+                        Game of Thrones
+                      </a>
+
+
                     </li>
-                    
+
                     <li class=" ">
-                      
-                        <a href="/autonomous-cars">Autonomy</a>
-                      
-                      
+
+                      <a href="/books">
+                        Books
+                      </a>
+
+
                     </li>
-                    
-                  
-                    </div>
-                  
-                
-                
+
+
+                  </div>
+
+
+
+                  <div class="c-nav-list__col">
+
+
+                    <li class=" ">
+
+                      <a href="/comics">
+                        Comics
+                      </a>
+
+
+                    </li>
+
+                    <li class=" ">
+
+                      <a href="/music">
+                        Music
+                      </a>
+
+
+                    </li>
+
+
+                  </div>
+
+
+
                   <li class="c-nav-list__all-link">
-                    <a href="/transportation">All Transportation</a>
+                    <a href="/entertainment">All Entertainment</a>
                   </li>
-                
-              </ul>
-            
-          
-        </li>
-      
-        <li data-nav-item-id="reviews" data-nav-list-id="reviews">
-        
-          <a class="c-nav-list__label" href="/reviews">
-            Reviews
-            
-              <svg><use xlink:href="#icon-norgie-down"></use></svg>
-            
-          </a>
-          
-        
 
-         
-            
-            
-              <ul class="c-nav-list__sub-items">
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
-                    <li class=" ">
-                      
-                        <a href="/phone-review">Phones</a>
-                      
-                      
-                    </li>
-                    
-                    <li class=" ">
-                      
-                        <a href="/laptop-review">Laptops</a>
-                      
-                      
-                    </li>
-                    
-                    <li class=" ">
-                      
-                        <a href="/camera-review">Cameras</a>
-                      
-                      
-                    </li>
-                    
-                  
-                    </div>
-                  
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
-                    <li class=" ">
-                      
-                        <a href="/tablet-review">Tablets</a>
-                      
-                      
-                    </li>
-                    
-                    <li class=" ">
-                      
-                        <a href="/headphone-review">Headphones</a>
-                      
-                      
-                    </li>
-                    
-                    <li class=" ">
-                      
-                        <a href="/smartwatch-review">Smartwatches</a>
-                      
-                      
-                    </li>
-                    
-                  
-                    </div>
-                  
-                
-                  
-                    <div class="c-nav-list__col">
-                  
-                    
-                    <li class=" ">
-                      
-                        <a href="/vr-headset-review">VR Headsets</a>
-                      
-                      
-                    </li>
-                    
-                    <li class=" ">
-                      
-                        <a href="/this-is-my-next">This is my Next</a>
-                      
-                      
-                    </li>
-                    
-                  
-                    </div>
-                  
-                
-                
-                  <li class="c-nav-list__all-link">
-                    <a href="/reviews">More from Verge Guidebook</a>
-                  </li>
-                
-              </ul>
-            
-          
-        </li>
-      
-        <li data-nav-item-id="longform">
-        
-          <a class="c-nav-list__label" href="/longform">
-            Longform
-            
-          </a>
-          
-        
-
-         
-        </li>
-      
-        <li data-nav-item-id="video">
-        
-          <a class="c-nav-list__label" href="https://goo.gl/G5RXGs">
-            Video
-            
-          </a>
-          
-        
-
-         
-        </li>
-      
-        <li data-nav-item-id="circuit-breaker">
-        
-          <a class="c-nav-list__label" href="/circuitbreaker">
-            Circuit Breaker
-            
-          </a>
-          
-        
-
-         
-        </li>
-      
-        <li data-nav-item-id="forums">
-        
-          <a class="c-nav-list__label" href="/forums">
-            Forums
-            
-          </a>
-          
-        
-
-         
-        </li>
-      
-        <li data-nav-item-id="podcasts">
-        
-          <a class="c-nav-list__label" href="/podcasts">
-            Podcasts
-            
-          </a>
-          
-        
-
-         
-        </li>
-      
-        <li data-nav-item-id="store">
-        
-          <a class="c-nav-list__label" href="/store">
-            Store
-            
-          </a>
-          
-        
-
-         
-        </li>
-      
-      <button data-ui="close-nav" type="button" class="c-nav-list__close">✕</button>
-    </ul>
-  
-  </div>
-</section>
+                </ul>
 
 
-</div>
+              </li>
+
+              <li data-nav-item-id="video" class="hidden">
+
+                <a class="c-nav-list__label" href="https://goo.gl/G5RXGs">
+                  Video
+
+                </a>
 
 
-      
+
+
+              </li>
+
+              <li data-nav-item-id="features" class="hidden">
+
+                <a class="c-nav-list__label" href="/features">
+                  Features
+
+                </a>
+
+
+
+
+              </li>
+
+              <li data-nav-item-id="podcasts">
+
+                <a class="c-nav-list__label" href="/podcasts">
+                  Podcasts
+
+                </a>
+
+
+
+
+              </li>
+
+              <li data-nav-item-id="newsletters">
+
+                <a class="c-nav-list__label" href="/pages/newsletters">
+                  Newsletters
+
+                </a>
+
+
+
+
+              </li>
+
+              <li data-nav-item-id="store">
+
+                <a class="c-nav-list__label" href="/store">
+                  Store
+
+                </a>
+
+
+
+
+              </li>
+
+              <button data-ui="close-nav" type="button" class="c-nav-list__close">✕</button>
+            </ul>
+
+          </div>
+        </section>
+
+
+      </div>
+
+
+      <div class="c-ad-allowlist" data-ui="ad-allowlist" data-cid="site/ad_allowlist-1615219783_1945_5347"
+        data-cdata="{&quot;adblocker_allowlist_prompt_enabled&quot;:true,&quot;messaging_urls&quot;:[&quot;https://cdn.concert.io/lib/adblock/vox_support_understanding.html&quot;,&quot;https://cdn.concert.io/lib/adblock/vox_support_explanatory.html&quot;,&quot;https://cdn.concert.io/lib/adblock/vox_support_explaining.html&quot;,&quot;https://cdn.concert.io/lib/adblock/vox_support_concise.html&quot;],&quot;selector&quot;:&quot;.l-header&quot;}">
+      </div>
+
+
+      <div class="adblock-allowlist-messaging__article-wrapper"><iframe class="adblock-allowlist-messaging__iframe"
+          src="https://cdn.concert.io/lib/adblock/vox_support_explanatory.html" scrolling="no" frameborder="0"
+          title="Adblock Allowlist Instructions"></iframe></div>
     </div>
     <style id="custom-entry-styles" type="text/css">
-  
-</style>
 
-<section class="l-wrapper">
-  <section class="l-segment l-main-content">
-    <span data-content-admin-id="16685133"></span>
-    <div class="l-segment">
-  
-  <div class="c-entry-hero c-entry-hero--default">
-  
-  <div class="c-entry-group-labels c-entry-group-labels--article">
-  
-  
-    
+    </style>
 
-      <ul>
-        
-          <li class="c-entry-group-labels__item">
-            <a href="https://www.theverge.com/tldr">
-              
-              <span>TL;DR</span>
-            </a>
-          </li>
-        
-          <li class="c-entry-group-labels__item">
-            <a href="https://www.theverge.com/science">
-              
-              <span>Science</span>
-            </a>
-          </li>
-        
-          <li class="c-entry-group-labels__item">
-            <a href="https://www.theverge.com/tech">
-              
-              <span>Tech</span>
-            </a>
-          </li>
-        
-      </ul>
-      
-    
-  
-</div>
+    <main id="content" tabindex="-1" class="l-wrapper">
+      <article class="l-segment l-main-content">
+        <span data-content-admin-id="16685133"></span>
+        <div class="l-segment">
 
-  <div class="c-entry-hero__header-wrap">
-    <h1 class="c-page-title">You can visit the Pentagon’s secret nuclear bunker inside Minecraft</h1>
-
-    
-      <div class="c-entry-hero__meta">
-        <div class="c-entry-stat--comment" data-cid="site/entry_stat-1516700709_5175_61286" data-cdata='{"id":16685133,"comment_count":2,"recommended_count":0,"url":"https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"}'>
-  <a href="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model#comments" class="p-comment-notification__unread" data-ui="unread">
-    <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
-    New,
-  </a>
-  <a href="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model#comments" class="p-comment-notification" data-ui="comment">
-    <span class="c-entry-stat__comment-data" data-ui="comment-data">
-      2
-    </span>
-    <span class="u-hidden-text">comments</span>
-  </a>
-</div>
-
-      </div>
-    
-  </div>
-  <h2 class="c-entry-summary p-dek">The zombies are only released on the weekends, the developers promise</h2>
-
-  
-    <div class="c-byline">
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/RachelBecker">Rachel Becker</a><span class="c-byline__item"><a href="https://www.twitter.com/RA_Becks" class="c-byline__twitter-handle">@RA_Becks</a></span>
-      
-    </span>
-    
-    <span class="c-byline__item">
-      
-      <time class="c-byline__item" data-ui="timestamp">
-        Jan 22, 2018,  6:38pm EST
-      </time></span>
-    
-    
-    
-    
-  
-  
-  
-  <a data-entry-admin="16685133" data-cid="tools/entry_admin_button-1516700709_844_61287" data-cdata='{"id":16685133}'></a>
-
-</div>
-
-  
-  
-</div>
+          <div class="c-entry-hero c-entry-hero--default ">
 
 
-  <div class="c-social-buttons--popover main-social" data-cid="site/social_buttons_list/popover-1516700709_7641_61288" data-cdata='{"entry_id":16685133,"services":["facebook","twitter","linkedin","reddit","pocket","flipboard","email"],"base_url":"https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"}'>
-  <div class="c-social-buttons__inline">
-    
-      <a class="facebook" href="https://www.facebook.com/sharer/sharer.php?text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;u=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-analytics-social="facebook">
-        <svg class="p-svg-icon c-social-buttons__svg"><use xlink:href="#icon-facebook"></use></svg> Share
-      </a>
-    
-    
-    <a class="more" href="#" data-ui="more">
-      <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 21 20" class="p-svg-icon c-social-buttons__svg">
-<path d="M18.4,12.9c-0.3,0-0.6,0.3-0.6,0.6V17c0,1-0.8,1.8-1.8,1.8H3c-1,0-1.8-0.8-1.8-1.8V4C1.2,3,2,2.2,3,2.2h8.4
-  c0.3,0,0.6-0.3,0.6-0.6S11.7,1,11.3,1H3C1.3,1,0,2.3,0,4V17c0,1.6,1.3,3,3,3H16c1.6,0,3-1.3,3-3v-3.5C19,13.2,18.7,12.9,18.4,12.9z"></path>
-<path d="M20.9,5.3C20.9,5.3,20.9,5.3,20.9,5.3c0-0.1,0-0.1,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0,0
-  c0,0,0,0,0,0c0,0,0,0,0,0l-4.6-4.6c-0.2-0.2-0.6-0.2-0.8,0s-0.2,0.6,0,0.8l3.3,3.3c-2.1-0.3-5.5-0.3-8.5,1.5
-  C7.6,7.5,5.9,10,5.2,13.5c-0.1,0.3,0.1,0.6,0.5,0.7c0,0,0.1,0,0.1,0c0.3,0,0.5-0.2,0.6-0.5c0.6-3.1,2.1-5.4,4.3-6.8
-  c3-1.8,6.7-1.5,8.5-1.2l-3.8,3.9c-0.2,0.2-0.2,0.6,0,0.8c0.1,0.1,0.3,0.2,0.4,0.2s0.3-0.1,0.4-0.2l4.6-4.6c0,0,0,0,0,0
-  c0,0,0,0,0-0.1c0,0,0,0,0,0c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0-0.1C20.9,5.4,20.9,5.4,20.9,5.3
-  C20.9,5.4,20.9,5.4,20.9,5.3z"></path>
-</svg> More
-    </a>
-  </div>
-  <div class="c-social-buttons__popover" data-ui="popover">
-    <div class="c-social-buttons__popover-header">
-      <strong>Share</strong>
-      <div class="c-social-buttons__popover-title">You can visit the Pentagon’s secret nuclear bunker inside Minecraft</div>
-    </div>
-    <div class="c-social-buttons__popover-body">
-      
-        <a class="facebook" href="https://www.facebook.com/sharer/sharer.php?text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;u=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-analytics-social="facebook">
-          <svg class="p-svg-icon c-social-buttons__svg"><use xlink:href="#icon-facebook"></use></svg>
-          share
-        </a>
-      
-        <a class="twitter" href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;via=Verge" data-analytics-social="twitter">
-          <svg class="p-svg-icon c-social-buttons__svg"><use xlink:href="#icon-twitter"></use></svg>
-          tweet
-        </a>
-      
-        <a class="linkedin" href="http://www.linkedin.com/shareArticle?mini=true&amp;source=The+Verge&amp;summary=The+zombies+are+only+released+on+the+weekends%2C+the+developers+promise&amp;title=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-analytics-social="linkedin">
-          <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 15 16" class="p-svg-icon c-social-buttons__svg">
-<path d="M1.1,0.5h12.6l0,0c0.6,0,1,0.4,1,1v12.6c0,0.6-0.4,1-1,1H1.1c-0.6,0-1-0.4-1-1V1.5l0,0C0.1,1,0.5,0.5,1.1,0.5
-  L1.1,0.5z M8,12.4V8.9C8,8.5,8.1,8.2,8.3,8c0.2-0.2,0.5-0.3,0.8-0.3c0.3,0,0.6,0.1,0.8,0.3c0.2,0.2,0.3,0.6,0.3,1v3.3h2V8.9
-  c0-0.9-0.2-1.5-0.6-2c-0.4-0.5-1-0.7-1.7-0.7C9,6.2,8.5,6.5,8,7.2L7.9,6.4H6l0,1.4v4.7H8z M2.9,12.4h2v-6h-2V12.4z M3.9,5.4
-  c0.4,0,0.6-0.1,0.9-0.3C5,4.9,5.1,4.6,5.1,4.3C5.1,4,5,3.8,4.8,3.6C4.5,3.4,4.3,3.3,3.9,3.3c-0.4,0-0.6,0.1-0.9,0.3
-  C2.8,3.8,2.7,4,2.7,4.3c0,0.3,0.1,0.6,0.3,0.8C3.3,5.3,3.5,5.4,3.9,5.4L3.9,5.4z"></path>
-</svg>
-          Linkedin
-        </a>
-      
-        <a class="reddit" href="https://reddit.com/submit?title=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-analytics-social="reddit">
-          <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 17 17" class="p-svg-icon c-social-buttons__svg">
-<path d="M8.5,0C3.8,0,0,3.8,0,8.5S3.8,17,8.5,17S17,13.2,17,8.5S13.2,0,8.5,0z M14,10.2c0,0.1,0,0.3,0,0.4c0,2.2-2.5,3.9-5.6,3.9
-  s-5.6-1.8-5.6-3.9c0-0.2,0-0.3,0-0.5C2.5,9.9,2.2,9.4,2.2,8.9c0-0.8,0.6-1.5,1.4-1.5c0.4,0,0.7,0.2,0.9,0.4C5.2,7.3,6,6.9,7,6.8
-  c0.3-0.1,0.3-0.1,0.7-0.1l0.7-3.1C8.6,2.9,8.8,2.9,9.3,3C11.1,3.5,12,3.7,12,3.7c0.2-0.3,0.5-0.3,0.8-0.3c0.6,0,1.1,0.5,1.1,1.2
-  s-0.5,1.2-1.1,1.2c-0.5,0-1-0.5-1.1-1c0,0-0.7-0.2-2.2-0.6C9.1,5.9,8.9,6.7,8.9,6.7c1.3,0.1,2.6,0.5,3.5,1.1c0.3-0.3,0.6-0.4,1-0.4
-  c0.8,0,1.4,0.7,1.4,1.5C14.8,9.4,14.5,9.9,14,10.2z"></path>
-<path d="M10.2,12.2c-0.3,0.4-0.9,0.5-1.7,0.5l0,0l0,0c-0.8,0-1.4-0.2-1.7-0.5c-0.1-0.1-0.2-0.1-0.3,0c-0.1,0.1-0.1,0.2,0,0.3
-  c0.4,0.4,1.1,0.7,2,0.7l0,0l0,0c0.9,0,1.6-0.2,2-0.7c0.1-0.1,0.1-0.2,0-0.3C10.4,12.1,10.3,12.1,10.2,12.2z"></path>
-<ellipse cx="6.6" cy="9.9" rx="0.8" ry="0.9"></ellipse>
-<ellipse cx="10.4" cy="9.9" rx="0.8" ry="0.9"></ellipse>
-</svg>
-          Reddit
-        </a>
-      
-        <a class="pocket" href="https://getpocket.com/save?url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-analytics-social="pocket">
-          <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 14" class="p-svg-icon c-social-buttons__svg">
-<path d="M14.4,0.1H2c-0.6,0-1.1,0.5-1.1,1.1v4.6c0,4,3.3,7.3,7.3,7.3c4,0,7.3-3.3,7.3-7.3V1.2C15.5,0.6,15,0.1,14.4,0.1
-  z M12.5,5.4L8.9,9C8.7,9.2,8.4,9.3,8.2,9.3C8,9.3,7.7,9.2,7.5,9L3.9,5.4C3.5,5,3.5,4.4,3.9,4c0.4-0.4,1-0.4,1.3,0l3,3l3-3
-  c0.4-0.4,1-0.4,1.3,0C12.9,4.4,12.9,5,12.5,5.4z"></path>
-</svg>
-          Pocket
-        </a>
-      
-        <a class="flipboard" href="https://share.flipboard.com/bookmarklet/popout?title=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;v=2" data-analytics-social="flipboard">
-          <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 16 16" class="p-svg-icon c-social-buttons__svg">
-  <path d="M0,0v16h16V0H0z M12.9,6.4H9.6v3.2H6.5v3.2H3.2V3.2h9.7V6.4z"></path>
-  <polygon opacity="0.13" points="6.5,3.2 6.5,6.4 9.8,6.4 12.9,6.4 12.9,3.2 "></polygon>
-  <polygon opacity="0.23" points="6.5,9.7 9.7,9.7 9.7,6.4 6.5,6.4 "></polygon>
-</svg>
-          Flipboard
-        </a>
-      
-        <a class="email" href="mailto:?subject=You%20can%20visit%20the%20Pentagon%E2%80%99s%20secret%20nuclear%20bunker%20inside%20Minecraft&amp;body=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model%0A%0AThe%20zombies%20are%20only%20released%20on%20the%20weekends%2C%20the%20developers%20promise" data-analytics-social="email">
-          <svg class="p-svg-icon c-social-buttons__svg"><use xlink:href="#icon-email"></use></svg>
-          Email
-        </a>
-      
-    </div>
-    <span class="c-social-buttons__popover-caret" data-ui="caret"></span>
-  </div>
-</div>
-  
-  
-  
-</div>
-<div class="l-sidebar-fixed l-segment l-article-body-segment">
-  <div class="l-col__main">
-    <figure class="e-image e-image--hero">
-  <span class="e-image__inner">
-    <span class="e-image__image " data-original="https://cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif">
-      
-        <video autoplay muted loop playsinline class="c-gifv" src="https://cdn.vox-cdn.com/thumbor/4l0C-7uGFtTfc6lWibo1ITiE2YU=/0x0:1280x720/320x213/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif" data-cid="site/gifv-1516700709_2103_61290" data-cdata='{"default":{"320":"https://cdn.vox-cdn.com/thumbor/4l0C-7uGFtTfc6lWibo1ITiE2YU=/0x0:1280x720/320x213/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","620":"https://cdn.vox-cdn.com/thumbor/Rfw4SgI-TeL2MQMw2qIZHpxyQqo=/0x0:1280x720/620x413/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","920":"https://cdn.vox-cdn.com/thumbor/FXu3QLVSIPZWhgso7-ZYZizTrm0=/0x0:1280x720/920x613/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","1220":"https://cdn.vox-cdn.com/thumbor/lDY_2Jpe5DB0BWTHN8fpcmkf8Ho=/0x0:1280x720/1220x813/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","1520":"https://cdn.vox-cdn.com/thumbor/4Q3k5QTOIiv6Lo8ePtwOE3gqvTA=/0x0:1280x720/1520x1013/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","1820":"https://cdn.vox-cdn.com/thumbor/Et69lV7aCJj1iGkLvrXHsnImBS4=/0x0:1280x720/1820x1213/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","2120":"https://cdn.vox-cdn.com/thumbor/jNuzvopr11Q4PGrnc_1PB-Vvw9M=/0x0:1280x720/2120x1413/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif","2420":"https://cdn.vox-cdn.com/thumbor/vtnXPiaErd4rZz3gC1WMI7Zn9xc=/0x0:1280x720/2420x1613/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif"},"art_directed":[]}'>
-  <script type="text/template">
-    <picture class="c-picture" data-cid="site/picture_element-1516700709_2998_61289" data-cdata='{"image_id":58416873,"ratio":"*"}'>
-  
-
-
-
-<img srcset="https://cdn.vox-cdn.com/thumbor/9_95hHp_f74MJH97aputXZfrLvs=/0x0:1280x720/320x213/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 320w, https://cdn.vox-cdn.com/thumbor/R23weWVQZECjpQV2C7_3y-6t598=/0x0:1280x720/620x413/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 620w, https://cdn.vox-cdn.com/thumbor/Kztl7vrF-Xf263SdvDicYSihDrs=/0x0:1280x720/920x613/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 920w, https://cdn.vox-cdn.com/thumbor/aYJ-X6VdoWbcnKZowjVNzn_yCKY=/0x0:1280x720/1220x813/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 1220w, https://cdn.vox-cdn.com/thumbor/gnbUvw6QwSt2WzCwygTUwV91xPE=/0x0:1280x720/1520x1013/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 1520w, https://cdn.vox-cdn.com/thumbor/difHASX7jM229LC8PmzgdrWeBig=/0x0:1280x720/1820x1213/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 1820w, https://cdn.vox-cdn.com/thumbor/akj7JOogu6mXy3UaD9CZg1IaHnc=/0x0:1280x720/2120x1413/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 2120w, https://cdn.vox-cdn.com/thumbor/4uJ-oxQqILHawYa0WR7tj399NZ0=/0x0:1280x720/2420x1613/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 2420w" sizes="(min-width: 1221px) 846px, (min-width: 880px) calc(100vw - 334px), 100vw" src="https://cdn.vox-cdn.com/thumbor/vdpwqnqmeOWIqI-GiucnB8Ca3fg=/0x0:1280x720/1200x800/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif">
-
-</picture>
-
-  </script>
-</video>
-      
-    </span>
-    
-  </span>
-  
-    <span class="e-image__meta">
-      
-      
-        <cite><a href="http://www.nti.org/analysis/articles/mineshaft-gap-lavish-bunkers-where-putin-trump-plan-fight-nuclear-war/">Video by the Center for Nonproliferation Studies at MIIS and the Nuclear Threat Initiative</a></cite>
-      
-    </span>
-  
-</figure>
-
-
-
-    
+            <div class="c-entry-group-labels c-entry-group-labels--article">
+              <p class="sr-only c-entry-box--compact__labels-title" id="heading-label--hiynzqns">Filed under:</p>
 
 
 
 
+              <ul aria-labelledby="heading-label--hiynzqns">
 
-<div class="c-entry-content">
-  <p id="zSLJZN">Even if the populations of the US or Russia are annihilated in a nuclear apocalypse, the governments responsible for the devastation plan to fight on from vast, underground bunkers. Now, the public can peer inside the secretive complexes thanks to the efforts of arms control analysts who reconstructed these bunkers inside <em>Minecraft</em>. </p>
-<p id="Hm9zjL">The mistaken missile alert that sent people scurrying for cover in Hawaii last week <a href="https://www.theatlantic.com/international/archive/2018/01/pandemonium-and-rage-in-hawaii/550529/">revealed just how poorly prepared</a> the US government is to protect the public during a nuclear attack. The government’s plans for protecting <em>itself</em> from a rain of thermonuclear fire are much more detailed. Using satellite images, declassified information, and a good amount of guesswork, analysts at the <a href="http://www.miis.edu/academics/researchcenters/nonproliferation">Middlebury Institute of International Studies (or MIIS)</a> reconstructed two underground complexes: the Pentagon’s site in Pennsylvania and a bunker built by the Russian government outside Moscow.</p>
-<p id="epFj7Z">The reconstructions are set in the low-resolution world of <em>Minecraft</em> to lighten the very real, and very depressing, topic of nuclear annihilation, says <a href="http://www.miis.edu/academics/faculty/JLewis/node/23027">Jeffrey Lewis</a>, who led the effort from the <a href="http://www.miis.edu/academics/researchcenters/nonproliferation">James Martin Center for Nonproliferation Studies</a> at MIIS. The aim is to draw attention to the tension between how the government downplays the risk of nuclear war and how it actually prepares for it, Lewis says. “What the bunker model shows you is that the risk of nuclear war is real enough that the United States and Russia spend billions of dollars preparing to stash away their leadership.”  (Players can find an article about the bunkers and instructions for virtually accessing them posted on <a href="http://www.nti.org/analysis/articles/mineshaft-gap-lavish-bunkers-where-putin-trump-plan-fight-nuclear-war/">the Nuclear Threat Initiative’s site</a>.) </p>
-<hr class="p-entry-hr" id="K9e2cN">
-<div id="vozSyf"><div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;"><iframe src="https://www.youtube.com/embed/zzkOaXidWbg?rel=0&amp;" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no"></iframe></div></div>
-<p id="BZG4MC"><small><em>Working with </em></small><a href="https://www.thedailybeast.com/at-last-you-can-build-a-nuclear-command-center-in-minecraft?ref=author"><small><em>defense journalist Adam Rawnsley</em></small></a><small><em>, the CNS team created a trailer video of the bunker reconstructions.</em></small></p>
-<hr class="p-entry-hr" id="misO2s">
-<p id="9KHQXn">The <a href="http://www.simonandschuster.com/books/Raven-Rock/Garrett-M-Graff/9781476735405">650-acre</a> Raven Rock complex is the alternative Pentagon where top defense officials plan to flee during a nuclear attack. Also known as Site R, it’s located on the Pennsylvania side of the border with Maryland — close to the presidential retreat Camp David. Thanks to the Freedom of Information Act, a diagram of the site has been “floating around online,” Lewis says. The team based their reconstruction on that diagram and details in journalist Garrett Graff’s book <a href="http://www.simonandschuster.com/books/Raven-Rock/Garrett-M-Graff/9781476735405"><em>Raven Rock: The Story of the U</em><em>S</em><em> Government’s Secret Plan to Save Itself — While the Rest of Us Die</em></a>. Using satellite images and topography, the team located the entrances to the site and figured out the size of the mountain above it. </p>
-<div id="zuKezc"><div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;"><iframe src="https://sketchfab.com/models/d1e8d568516e4a8aa9c26b9d2ef01fdd/embed?" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no"></iframe></div></div>
-<p id="nmvKyg">The team also modeled the Kosvinsky underground command facility outside of Moscow, Russia. This, too, was based on satellite images and details gleaned from declassified CIA reports. For both complexes — but especially the Russian one — the team had to use their imaginations to fill in the gaps, Lewis says. “There’s an enormous amount of guesswork. In no way, shape, or form did we make anything that we think is perfect,” he says. </p>
-<div id="zwikY9"><div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;"><iframe src="https://sketchfab.com/models/80410e56dc6844d081149720ca744518/embed?" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen="" scrolling="no"></iframe></div></div>
-<p id="yochkF">There are also a few Easter eggs, including an interplanetary wormhole from the science-fiction franchise <em>Stargate</em> in one of the bunkers and a pen of especially virulent zombies. “But the important thing is that we wanted people to get a sense for the scale — and we think that’s probably about right,” Lewis says.  The point is to remind people that as long as nuclear weapons exist, they pose a threat. “It all goes back to focusing on the changing US and Russian nuclear posture,” Lewis says. “We imagine that things are very different from the Cold War, but the bunkers suggest the opposite — they suggest that they’re exactly the same.” </p>
-<p id="VCEFD5"></p>
-</div>
+                <li class="c-entry-group-labels__item">
+                  <a href="https://www.theverge.com/tldr">
+                    <span>TL;DR</span>
+                  </a>
+                </li>
 
+                <li class="c-entry-group-labels__item">
+                  <a href="https://www.theverge.com/science">
+                    <span>Science</span>
+                  </a>
+                </li>
 
+                <li class="c-entry-group-labels__item">
+                  <a href="https://www.theverge.com/tech">
+                    <span>Tech</span>
+                  </a>
+                </li>
 
-<div class="u-hidden-text" id="formatter-datter" data-cid="site/entry_formatter-1516700709_4257_61291" data-cdata='{"svg_hr_illustration":""}'>
-  
-</div>
-
+              </ul>
 
 
 
 
-
-
-
-    <div class="c-related-list" data-cid="site/related_list-1516700709_6476_61293" data-cdata="{}">
-  <h3 class="c-related-list__headline p-alt-head">
-    
-  
-
-
-    <span class="c-related-list__title">Next Up In</span>
-    
-    
-      <a href="https://www.theverge.com/tldr" class="c-related-list__group-name">TL;DR</a>
-    
-  </h3>
-  <ul>
-    
-      <li>
-        
-        <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" href="https://www.theverge.com/tldr/2018/1/22/16920740/facebook-unit-of-time-flicks-frame-rate-ticks-github-nanosecond-second">Facebook announces that it has invented a new unit of time</a>
-        
-      </li>
-    
-      <li>
-        
-        <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" href="https://www.theverge.com/2018/1/22/16919524/pikachu-mascot-suit-help">Someone please help these Pikachu</a>
-        
-      </li>
-    
-      <li>
-        
-        <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" href="https://www.theverge.com/2018/1/22/16919234/pikachu-suit-fail-twitter">How many people does it take to pick up a Pikachu?</a>
-        
-      </li>
-    
-      <li>
-        
-        <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" href="https://www.theverge.com/2018/1/22/16918780/end-of-ze-world-sequel-jason-windsor">End of Ze World gets a sequel more than a decade later</a>
-        
-      </li>
-    
-      <li>
-        
-        <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" href="https://www.theverge.com/tldr/2018/1/22/16918610/super-mario-bros-slow-mo-guys-youtube">This video shows what Super Mario looks like at 380,000 frames per second</a>
-        
-      </li>
-    
-      <li>
-        
-        <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks" href="https://www.theverge.com/2018/1/20/16909808/car-future-design-children-go-compare-uk">A bunch of 11-year-olds designed the cars of the future, and the results are utterly delightful</a>
-        
-      </li>
-    
-    <div data-cid="site/entry_sponsorship/native_ad-rj6CYTbz6gvjgdw1g90DQQ==">
-  <div class="m-native_ad_unit dynamic-native-ad-native_ad_linkset_link"></div>
-</div>
-
-  </ul>
-  
-    
-      
-  <div class="c-video-embed">
-    
-      <div data-cid="site/video_embed/sanitize-1516700709_2156_61292">
-        <!--  ########  BEGIN VOLUME VIDEO  ########  -->
-<div class="volume-video" id="volume-placement-4310" data-volume-placement="linkset" data-analytics-placement="entry:linkset:auto" data-volume-id="30155" data-volume-uuid="7926b0417" data-analytics-label="Why you should be using a password manager | 30155" data-analytics-action="volume:view:entry:linkset:auto" data-analytics-viewport="video" data-volume-player-choice="youtube"></div>
-<!--  ########  END VOLUME VIDEO  ########  -->
-      </div>
-    
-  </div>
-
-
-
-
-    
-  
-</div>
-
-  </div>
-    <div class="l-col__sidebar" data-analytics-placement="sidebar">
-        
-      <div class="u-desktop-only">
-        <aside class="c-rock-list c-rock-list--image c-rock-list--trending" id="rock-trending">
-  <h3 class="p-rock-head c-rock-list__title">
-    
-    
-    <span class="c-rock-list__title-wrapper">
-      
-        
-          Now Trending
-        
-      
-    </span>
-  </h3>
-  <div class="c-rock-list__body">
-    
-    <ol class="c-rock-list__items">
-    
-      
-        <li data-analytics-placement="sidebar:1">
-      
-        <a href="https://www.theverge.com/2018/1/22/16920784/amazon-go-cashier-less-grocery-store-seattle-shoplifting-punishment-detection" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="16684825" data-chorus-optimize-module="entry-list">
-          
-            <div class="c-rock-list__image">
-
-              
-              
-                
-                
-                
-                  <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1516700709_6114_61295" data-cdata='{"image_id":58416029,"ratio":"standard","dynamic_type":"picture","lazy":true}'>
-  <script type="text/template-picture" style="display: none;">
-    
-
-
-  <source
-    srcset="https://cdn.vox-cdn.com/thumbor/PN5tRt27Pj2qlvdEDZlm1Rz5ayg=/0x0:5142x2815/250x167/filters:focal(2160x997:2982x1819):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58416029/908824126.jpg.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/QJWrl0zPiaxnRyDtIsR0oVG3MGM=/0x0:5142x2815/500x333/filters:focal(2160x997:2982x1819):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58416029/908824126.jpg.0.jpg 500w"
-    sizes="250px"
-    type="image/webp"
-  >
-
-
-<img
-  srcset="https://cdn.vox-cdn.com/thumbor/8oiQzxk8LbykVu8EHxyO8CMYRUA=/0x0:5142x2815/250x167/filters:focal(2160x997:2982x1819)/cdn.vox-cdn.com/uploads/chorus_image/image/58416029/908824126.jpg.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/oZnLBOiS6V3wneRSzM5AnQvGMfM=/0x0:5142x2815/500x333/filters:focal(2160x997:2982x1819)/cdn.vox-cdn.com/uploads/chorus_image/image/58416029/908824126.jpg.0.jpg 500w"
-  sizes="250px"
-  src="https://cdn.vox-cdn.com/thumbor/PLLW55jL3LbAfJ8GUsJTbJtxKkI=/0x0:5142x2815/1200x800/filters:focal(2160x997:2982x1819)/cdn.vox-cdn.com/uploads/chorus_image/image/58416029/908824126.jpg.0.jpg"
-  
-  
->
-
-  </script>
-  <script type="text/template-dynamic" style="display: none">
-    
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_7406_61294" data-cdata='{"image_id":58416029,"ratio":"standard"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58416029/908824126.jpg.0.jpg" alt=""></noscript>
-
-  </script>
-</picture>
-
-                
-              
-
-              
             </div>
-          
-          <span class="c-rock-list__entry-title">
-            
-            <span data-chorus-optimize-field="hed">Amazon doesn’t care if you accidentally shoplift from its cashier-less store</span>
-          </span>
-          
-            <span class="c-rock-list__entry-blurb">Amazon has a high level of trust in its unique instant checkout system</span>
-          
-        </a>
-        
-      </li>
-    
-      
-        <li data-analytics-placement="sidebar:2">
-      
-        <a href="https://www.theverge.com/tldr/2018/1/22/16920740/facebook-unit-of-time-flicks-frame-rate-ticks-github-nanosecond-second" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="16684781" data-chorus-optimize-module="entry-list">
-          
-            <div class="c-rock-list__image">
 
-              
-              
-                
-                
-                
-                  <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1516700709_4889_61297" data-cdata='{"image_id":58415393,"ratio":"standard","dynamic_type":"picture","lazy":true}'>
-  <script type="text/template-picture" style="display: none;">
-    
+            <div class="c-entry-hero__header-wrap">
+              <h1 class="c-page-title" style="max-width: 857px;">You can visit the Pentagon’s secret nuclear bunker
+                inside Minecraft</h1>
 
 
-  <source
-    srcset="https://cdn.vox-cdn.com/thumbor/CZhEA4kSnAkNObkspKrB_GMIKSk=/0x0:1020x680/250x167/filters:focal(429x259:591x421):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58415393/fbappicon1_1020.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/CwmtYiqzK1mGx_zL9hZLONm4N2E=/0x0:1020x680/500x333/filters:focal(429x259:591x421):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58415393/fbappicon1_1020.0.jpg 500w"
-    sizes="250px"
-    type="image/webp"
-  >
+              <div class="c-entry-hero__meta">
+                <div class="c-entry-stat--comment" data-cid="site/entry_stat-1615219071_8273_2172"
+                  data-cdata="{&quot;id&quot;:16685133,&quot;comment_count&quot;:2,&quot;recommended_count&quot;:0,&quot;url&quot;:&quot;https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&quot;}">
+                  <a href="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model#comments"
+                    class="p-comment-notification__unread" data-ui="unread">
+                    <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
+                    New,
+                  </a>
+                  <a href="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model#comments"
+                    class="p-comment-notification" data-ui="comment">
+
+                    <span class="c-entry-stat__comment-data" data-ui="comment-data">
+                      2
+                    </span>
+
+                    <span class="u-hidden-text">comments</span>
+                  </a>
+                </div>
+
+              </div>
+
+            </div>
+            <p class="c-entry-summary p-dek" style="max-width: 744px;">The zombies are only released on the weekends,
+              the developers promise</p>
 
 
-<img
-  srcset="https://cdn.vox-cdn.com/thumbor/lruM-1wNc9Lpytblwiuun75Xz5w=/0x0:1020x680/250x167/filters:focal(429x259:591x421)/cdn.vox-cdn.com/uploads/chorus_image/image/58415393/fbappicon1_1020.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/0oo0Y9d9DQRaFud41i0seKp_Xus=/0x0:1020x680/500x333/filters:focal(429x259:591x421)/cdn.vox-cdn.com/uploads/chorus_image/image/58415393/fbappicon1_1020.0.jpg 500w"
-  sizes="250px"
-  src="https://cdn.vox-cdn.com/thumbor/rlwA3HXDBelluHVU_4_8BpwxwP8=/0x0:1020x680/1200x800/filters:focal(429x259:591x421)/cdn.vox-cdn.com/uploads/chorus_image/image/58415393/fbappicon1_1020.0.jpg"
-  
-  
->
+            <div class="c-byline">
+              <span class="c-byline-wrapper">
 
-  </script>
-  <script type="text/template-dynamic" style="display: none">
-    
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_7143_61296" data-cdata='{"image_id":58415393,"ratio":"standard"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58415393/fbappicon1_1020.0.jpg" alt=""></noscript>
+                By
+                <span class="c-byline__item">
 
-  </script>
+
+                  <a href="https://www.theverge.com/authors/rachel-becker" data-analytics-link="author-name"><span
+                      class="c-byline__author-name">Rachel Becker</span></a>
+
+                </span>
+
+                <span class="c-byline__item">
+
+                  <time class="c-byline__item" data-ui="timestamp" datetime="2018-01-22T23:38:17">
+                    Jan 22, 2018, 6:38pm EST
+                  </time>
+                </span>
+
+
+
+
+
+              </span>
+              <span class="c-byline__gear">
+                <a data-entry-admin="16685133" data-cid="tools/entry_admin_button-1615219071_1302_2173"
+                  data-cdata="{&quot;id&quot;:16685133}"></a>
+
+              </span>
+            </div>
+
+
+
+
+          </div>
+
+
+          <div class="c-social-buttons c-social-buttons--popover main-social"
+            data-cid="site/social_buttons_list/popover-1615219071_3645_2174"
+            data-cdata="{&quot;entry_id&quot;:16685133,&quot;services&quot;:[&quot;facebook&quot;,&quot;twitter&quot;,&quot;linkedin&quot;,&quot;reddit&quot;,&quot;pocket&quot;,&quot;flipboard&quot;,&quot;email&quot;],&quot;base_url&quot;:&quot;https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&quot;}">
+            <h2 class="sr-only" id="heading-label--6vic0ld2">Share this story</h2>
+            <ul aria-labelledby="heading-label--6vic0ld2">
+
+              <li>
+                <a class="c-social-buttons__item c-social-buttons__facebook"
+                  href="https://www.facebook.com/sharer/sharer.php?text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;u=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                  data-analytics-social="facebook">
+                  <svg role="img" class="p-svg-icon c-social-buttons__svg">
+                    <use xlink:href="#icon-facebook"></use>
+                  </svg>
+                  <span class="sr-only">Share this on Facebook (opens in new window)</span>
+                </a>
+              </li>
+
+
+              <li>
+                <a class="c-social-buttons__item c-social-buttons__twitter"
+                  href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;via=Verge"
+                  data-analytics-social="twitter">
+                  <svg role="img" class="p-svg-icon c-social-buttons__svg">
+                    <use xlink:href="#icon-twitter"></use>
+                  </svg>
+                  <span class="sr-only">Share this on Twitter (opens in new window)</span>
+                </a>
+              </li>
+
+
+
+              <li data-ui="more">
+                <a class="c-social-buttons__item c-social-buttons__more" href="#" role="button" aria-expanded="false">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 20" class="p-svg-icon c-social-buttons__svg">
+                    <path
+                      d="M18.4,12.9c-0.3,0-0.6,0.3-0.6,0.6V17c0,1-0.8,1.8-1.8,1.8H3c-1,0-1.8-0.8-1.8-1.8V4C1.2,3,2,2.2,3,2.2h8.4
+c0.3,0,0.6-0.3,0.6-0.6S11.7,1,11.3,1H3C1.3,1,0,2.3,0,4V17c0,1.6,1.3,3,3,3H16c1.6,0,3-1.3,3-3v-3.5C19,13.2,18.7,12.9,18.4,12.9z">
+                    </path>
+                    <path d="M20.9,5.3C20.9,5.3,20.9,5.3,20.9,5.3c0-0.1,0-0.1,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0,0
+c0,0,0,0,0,0c0,0,0,0,0,0l-4.6-4.6c-0.2-0.2-0.6-0.2-0.8,0s-0.2,0.6,0,0.8l3.3,3.3c-2.1-0.3-5.5-0.3-8.5,1.5
+C7.6,7.5,5.9,10,5.2,13.5c-0.1,0.3,0.1,0.6,0.5,0.7c0,0,0.1,0,0.1,0c0.3,0,0.5-0.2,0.6-0.5c0.6-3.1,2.1-5.4,4.3-6.8
+c3-1.8,6.7-1.5,8.5-1.2l-3.8,3.9c-0.2,0.2-0.2,0.6,0,0.8c0.1,0.1,0.3,0.2,0.4,0.2s0.3-0.1,0.4-0.2l4.6-4.6c0,0,0,0,0,0
+c0,0,0,0,0-0.1c0,0,0,0,0,0c0,0,0,0,0-0.1c0,0,0,0,0-0.1c0,0,0,0,0,0c0,0,0,0,0,0c0,0,0,0,0-0.1C20.9,5.4,20.9,5.4,20.9,5.3
+C20.9,5.4,20.9,5.4,20.9,5.3z"></path>
+                  </svg>
+                  <span class="c-social-buttons--label" aria-hidden="true">Share</span>
+                  <span class="sr-only">All sharing options</span>
+                </a>
+              </li>
+
+
+            </ul>
+
+            <div class="c-social-buttons__popover" data-ui="popover">
+              <div class="c-social-buttons__popover-header">
+                <h3 tabindex="-1">
+                  <strong aria-hidden="true">Share</strong>
+                  <span class="sr-only">All sharing options for:</span>
+                  <span>You can visit the Pentagon’s secret nuclear bunker inside Minecraft</span>
+                </h3>
+              </div>
+              <div class="c-social-buttons__popover-body">
+                <ul>
+
+                  <li>
+                    <a class="c-social-buttons__item c-social-buttons__linkedin"
+                      href="http://www.linkedin.com/shareArticle?mini=true&amp;source=The+Verge&amp;summary=The+zombies+are+only+released+on+the+weekends%2C+the+developers+promise&amp;title=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      data-analytics-social="linkedin">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 16"
+                        class="p-svg-icon c-social-buttons__svg">
+                        <path d="M1.1,0.5h12.6l0,0c0.6,0,1,0.4,1,1v12.6c0,0.6-0.4,1-1,1H1.1c-0.6,0-1-0.4-1-1V1.5l0,0C0.1,1,0.5,0.5,1.1,0.5
+L1.1,0.5z M8,12.4V8.9C8,8.5,8.1,8.2,8.3,8c0.2-0.2,0.5-0.3,0.8-0.3c0.3,0,0.6,0.1,0.8,0.3c0.2,0.2,0.3,0.6,0.3,1v3.3h2V8.9
+c0-0.9-0.2-1.5-0.6-2c-0.4-0.5-1-0.7-1.7-0.7C9,6.2,8.5,6.5,8,7.2L7.9,6.4H6l0,1.4v4.7H8z M2.9,12.4h2v-6h-2V12.4z M3.9,5.4
+c0.4,0,0.6-0.1,0.9-0.3C5,4.9,5.1,4.6,5.1,4.3C5.1,4,5,3.8,4.8,3.6C4.5,3.4,4.3,3.3,3.9,3.3c-0.4,0-0.6,0.1-0.9,0.3
+C2.8,3.8,2.7,4,2.7,4.3c0,0.3,0.1,0.6,0.3,0.8C3.3,5.3,3.5,5.4,3.9,5.4L3.9,5.4z"></path>
+                      </svg>
+                      <span class="c-social-buttons__text">Linkedin</span>
+                      <span class="sr-only"> (opens in new window)</span></a>
+                  </li>
+
+                  <li>
+                    <a class="c-social-buttons__item c-social-buttons__reddit"
+                      href="https://reddit.com/submit?title=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      data-analytics-social="reddit">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 17"
+                        class="p-svg-icon c-social-buttons__svg">
+                        <path d="M8.5,0C3.8,0,0,3.8,0,8.5S3.8,17,8.5,17S17,13.2,17,8.5S13.2,0,8.5,0z M14,10.2c0,0.1,0,0.3,0,0.4c0,2.2-2.5,3.9-5.6,3.9
+s-5.6-1.8-5.6-3.9c0-0.2,0-0.3,0-0.5C2.5,9.9,2.2,9.4,2.2,8.9c0-0.8,0.6-1.5,1.4-1.5c0.4,0,0.7,0.2,0.9,0.4C5.2,7.3,6,6.9,7,6.8
+c0.3-0.1,0.3-0.1,0.7-0.1l0.7-3.1C8.6,2.9,8.8,2.9,9.3,3C11.1,3.5,12,3.7,12,3.7c0.2-0.3,0.5-0.3,0.8-0.3c0.6,0,1.1,0.5,1.1,1.2
+s-0.5,1.2-1.1,1.2c-0.5,0-1-0.5-1.1-1c0,0-0.7-0.2-2.2-0.6C9.1,5.9,8.9,6.7,8.9,6.7c1.3,0.1,2.6,0.5,3.5,1.1c0.3-0.3,0.6-0.4,1-0.4
+c0.8,0,1.4,0.7,1.4,1.5C14.8,9.4,14.5,9.9,14,10.2z"></path>
+                        <path d="M10.2,12.2c-0.3,0.4-0.9,0.5-1.7,0.5l0,0l0,0c-0.8,0-1.4-0.2-1.7-0.5c-0.1-0.1-0.2-0.1-0.3,0c-0.1,0.1-0.1,0.2,0,0.3
+c0.4,0.4,1.1,0.7,2,0.7l0,0l0,0c0.9,0,1.6-0.2,2-0.7c0.1-0.1,0.1-0.2,0-0.3C10.4,12.1,10.3,12.1,10.2,12.2z"></path>
+                        <ellipse cx="6.6" cy="9.9" rx="0.8" ry="0.9"></ellipse>
+                        <ellipse cx="10.4" cy="9.9" rx="0.8" ry="0.9"></ellipse>
+                      </svg>
+                      <span class="c-social-buttons__text">Reddit</span>
+                      <span class="sr-only"> (opens in new window)</span></a>
+                  </li>
+
+                  <li>
+                    <a class="c-social-buttons__item c-social-buttons__pocket"
+                      href="https://getpocket.com/save?url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      data-analytics-social="pocket">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 14"
+                        class="p-svg-icon c-social-buttons__svg">
+                        <path d="M14.4,0.1H2c-0.6,0-1.1,0.5-1.1,1.1v4.6c0,4,3.3,7.3,7.3,7.3c4,0,7.3-3.3,7.3-7.3V1.2C15.5,0.6,15,0.1,14.4,0.1
+z M12.5,5.4L8.9,9C8.7,9.2,8.4,9.3,8.2,9.3C8,9.3,7.7,9.2,7.5,9L3.9,5.4C3.5,5,3.5,4.4,3.9,4c0.4-0.4,1-0.4,1.3,0l3,3l3-3
+c0.4-0.4,1-0.4,1.3,0C12.9,4.4,12.9,5,12.5,5.4z"></path>
+                      </svg>
+                      <span class="c-social-buttons__text">Pocket</span>
+                      <span class="sr-only"> (opens in new window)</span></a>
+                  </li>
+
+                  <li>
+                    <a class="c-social-buttons__item c-social-buttons__flipboard"
+                      href="https://share.flipboard.com/bookmarklet/popout?title=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;v=2"
+                      data-analytics-social="flipboard">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
+                        class="p-svg-icon c-social-buttons__svg">
+                        <path d="M0,0v16h16V0H0z M12.9,6.4H9.6v3.2H6.5v3.2H3.2V3.2h9.7V6.4z"></path>
+                        <polygon opacity="0.13" points="6.5,3.2 6.5,6.4 9.8,6.4 12.9,6.4 12.9,3.2 "></polygon>
+                        <polygon opacity="0.23" points="6.5,9.7 9.7,9.7 9.7,6.4 6.5,6.4 "></polygon>
+                      </svg>
+                      <span class="c-social-buttons__text">Flipboard</span>
+                      <span class="sr-only"> (opens in new window)</span></a>
+                  </li>
+
+                  <li>
+                    <a class="c-social-buttons__item c-social-buttons__email"
+                      href="mailto:?subject=You%20can%20visit%20the%20Pentagon%E2%80%99s%20secret%20nuclear%20bunker%20inside%20Minecraft&amp;body=The%20zombies%20are%20only%20released%20on%20the%20weekends%2C%20the%20developers%20promise%0A%0Ahttps%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      data-analytics-social="email">
+                      <svg role="img" class="p-svg-icon c-social-buttons__svg">
+                        <use xlink:href="#icon-email"></use>
+                      </svg>
+                      <span class="c-social-buttons__text">Email</span>
+                      <span class="sr-only"> (opens in new window)</span></a>
+                  </li>
+
+                </ul>
+              </div>
+              <span class="c-social-buttons__popover-caret" data-ui="caret"></span>
+            </div>
+
+          </div>
+
+
+
+
+
+        </div>
+        <div class="l-sidebar-fixed l-segment l-article-body-segment">
+          <div class="l-col__main">
+            <figure class="e-image e-image--hero">
+              <span class="e-image__inner">
+
+                <span class="e-image__image "
+                  data-original="https://cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif">
+
+                  <video autoplay="" muted="" loop="" playsinline="" class="c-gifv"
+                    data-cid="site/gifv-1615219071_8574_2176"
+                    data-cdata="{&quot;default&quot;:{&quot;320&quot;:&quot;https://cdn.vox-cdn.com/thumbor/4l0C-7uGFtTfc6lWibo1ITiE2YU=/0x0:1280x720/320x213/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;620&quot;:&quot;https://cdn.vox-cdn.com/thumbor/Rfw4SgI-TeL2MQMw2qIZHpxyQqo=/0x0:1280x720/620x413/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;920&quot;:&quot;https://cdn.vox-cdn.com/thumbor/FXu3QLVSIPZWhgso7-ZYZizTrm0=/0x0:1280x720/920x613/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;1220&quot;:&quot;https://cdn.vox-cdn.com/thumbor/lDY_2Jpe5DB0BWTHN8fpcmkf8Ho=/0x0:1280x720/1220x813/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;1520&quot;:&quot;https://cdn.vox-cdn.com/thumbor/4Q3k5QTOIiv6Lo8ePtwOE3gqvTA=/0x0:1280x720/1520x1013/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;1820&quot;:&quot;https://cdn.vox-cdn.com/thumbor/Et69lV7aCJj1iGkLvrXHsnImBS4=/0x0:1280x720/1820x1213/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;2120&quot;:&quot;https://cdn.vox-cdn.com/thumbor/jNuzvopr11Q4PGrnc_1PB-Vvw9M=/0x0:1280x720/2120x1413/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;,&quot;2420&quot;:&quot;https://cdn.vox-cdn.com/thumbor/vtnXPiaErd4rZz3gC1WMI7Zn9xc=/0x0:1280x720/2420x1613/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif&quot;},&quot;art_directed&quot;:[]}"
+                    src="https://cdn.vox-cdn.com/thumbor/4Q3k5QTOIiv6Lo8ePtwOE3gqvTA=/0x0:1280x720/1520x1013/filters:focal(538x258:742x462):gifv():no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif">
+                    <script type="text/template">
+  <picture class="c-picture" data-cid="site/picture_element-1615219071_704_2175" data-cdata='{"image_id":58416873,"ratio":"*"}'>
+
+
+
+
+<img srcset="https://cdn.vox-cdn.com/thumbor/9_95hHp_f74MJH97aputXZfrLvs=/0x0:1280x720/320x213/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 320w, https://cdn.vox-cdn.com/thumbor/R23weWVQZECjpQV2C7_3y-6t598=/0x0:1280x720/620x413/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 620w, https://cdn.vox-cdn.com/thumbor/Kztl7vrF-Xf263SdvDicYSihDrs=/0x0:1280x720/920x613/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 920w, https://cdn.vox-cdn.com/thumbor/aYJ-X6VdoWbcnKZowjVNzn_yCKY=/0x0:1280x720/1220x813/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 1220w, https://cdn.vox-cdn.com/thumbor/gnbUvw6QwSt2WzCwygTUwV91xPE=/0x0:1280x720/1520x1013/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 1520w, https://cdn.vox-cdn.com/thumbor/difHASX7jM229LC8PmzgdrWeBig=/0x0:1280x720/1820x1213/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 1820w, https://cdn.vox-cdn.com/thumbor/akj7JOogu6mXy3UaD9CZg1IaHnc=/0x0:1280x720/2120x1413/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 2120w, https://cdn.vox-cdn.com/thumbor/4uJ-oxQqILHawYa0WR7tj399NZ0=/0x0:1280x720/2420x1613/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif 2420w" sizes="(min-width: 1221px) 846px, (min-width: 880px) calc(100vw - 334px), 100vw" alt="" data-upload-width="1280" src="https://cdn.vox-cdn.com/thumbor/vdpwqnqmeOWIqI-GiucnB8Ca3fg=/0x0:1280x720/1200x800/filters:focal(538x258:742x462):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416873/2018_01_22_14_19_55.0.gif">
+
 </picture>
 
-                
-              
-
-              
-            </div>
-          
-          <span class="c-rock-list__entry-title">
-            
-            <span data-chorus-optimize-field="hed">Facebook announces that it has invented a new unit of time</span>
-          </span>
-          
-            <span class="c-rock-list__entry-blurb">A ‘Flick’ is 1/705,600,000 of a second and designed to help sync video frame rates</span>
-          
-        </a>
-        
-      </li>
-    
-      
-        <li data-analytics-placement="sidebar:3">
-      
-        <a href="https://www.theverge.com/2018/1/22/16920440/amazon-echo-google-home-nsa-voice-surveillance" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="16684481" data-chorus-optimize-module="entry-list">
-          
-            <div class="c-rock-list__image">
-
-              
-              
-                
-                
-                
-                  <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1516700709_1878_61299" data-cdata='{"image_id":58414357,"ratio":"standard","dynamic_type":"picture","lazy":true}'>
-  <script type="text/template-picture" style="display: none;">
-    
-
-
-  <source
-    srcset="https://cdn.vox-cdn.com/thumbor/W32OjvE3vL7QuLHJLvA1k4ffIvo=/0x0:2040x1360/250x167/filters:focal(721x477:1047x803):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58414357/amazon-echo-verge-9711.0.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/7UzqVOHlbylEsUDk5i8DunZcAfE=/0x0:2040x1360/500x333/filters:focal(721x477:1047x803):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58414357/amazon-echo-verge-9711.0.0.jpg 500w"
-    sizes="250px"
-    type="image/webp"
-  >
-
-
-<img
-  srcset="https://cdn.vox-cdn.com/thumbor/bnfs3R_vjHzT-63rHMd34SbVHw8=/0x0:2040x1360/250x167/filters:focal(721x477:1047x803)/cdn.vox-cdn.com/uploads/chorus_image/image/58414357/amazon-echo-verge-9711.0.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/KfTyoiKmHLKWBupjSWcaeYh0Jww=/0x0:2040x1360/500x333/filters:focal(721x477:1047x803)/cdn.vox-cdn.com/uploads/chorus_image/image/58414357/amazon-echo-verge-9711.0.0.jpg 500w"
-  sizes="250px"
-  src="https://cdn.vox-cdn.com/thumbor/1kLuxz0hwpXydXyIORRkeZNxTJo=/0x0:2040x1360/1200x800/filters:focal(721x477:1047x803)/cdn.vox-cdn.com/uploads/chorus_image/image/58414357/amazon-echo-verge-9711.0.0.jpg"
-  
-  
->
-
-  </script>
-  <script type="text/template-dynamic" style="display: none">
-    
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_1601_61298" data-cdata='{"image_id":58414357,"ratio":"standard"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58414357/amazon-echo-verge-9711.0.0.jpg" alt=""></noscript>
-
-  </script>
-</picture>
-
-                
-              
-
-              
-            </div>
-          
-          <span class="c-rock-list__entry-title">
-            
-            <span data-chorus-optimize-field="hed">The NSA’s voice-recognition system raises hard questions for Echo and Google Home</span>
-          </span>
-          
-            <span class="c-rock-list__entry-blurb">Are Amazon and Google doing enough to keep spies out?</span>
-          
-        </a>
-        
-      </li>
-    
-      
-        <li data-analytics-placement="sidebar:4">
-      
-        <a href="https://www.theverge.com/2018/1/22/16921102/google-breaks-amazon-fire-tv-youtube-workaround" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="16685143" data-chorus-optimize-module="entry-list">
-          
-            <div class="c-rock-list__image">
-
-              
-              
-                
-                
-                
-                  <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1516700709_2767_61301" data-cdata='{"image_id":58416207,"ratio":"standard","dynamic_type":"picture","lazy":true}'>
-  <script type="text/template-picture" style="display: none;">
-    
-
-
-
-<img
-  srcset="https://cdn.vox-cdn.com/thumbor/hSgYqCG65DbXCxF0IhkSpYfnxVg=/0x0:618x376/250x167/filters:focal(260x139:358x237):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416207/verge_example.0.gif 250w, https://cdn.vox-cdn.com/thumbor/mBirzLJooh6jO6kO8aHNHZZ_WoI=/0x0:618x376/500x333/filters:focal(260x139:358x237):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416207/verge_example.0.gif 500w"
-  sizes="250px"
-  src="https://cdn.vox-cdn.com/thumbor/S_rAYjEwPDdUMRaW9GbMMLpNfr4=/0x0:618x376/1200x800/filters:focal(260x139:358x237):no_upscale()/cdn.vox-cdn.com/uploads/chorus_image/image/58416207/verge_example.0.gif"
-  
-  
->
-
-  </script>
-  <script type="text/template-dynamic" style="display: none">
-    
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_5003_61300" data-cdata='{"image_id":58416207,"ratio":"standard"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58416207/verge_example.0.gif" alt=""></noscript>
-
-  </script>
-</picture>
-
-                
-              
-
-              
-            </div>
-          
-          <span class="c-rock-list__entry-title">
-            
-            <span data-chorus-optimize-field="hed">Google briefly broke Amazon’s workaround for YouTube on Fire TV</span>
-          </span>
-          
-            <span class="c-rock-list__entry-blurb">Another petty move in this bitter, user-hostile fight</span>
-          
-        </a>
-        
-      </li>
-    
-      
-        <li data-analytics-placement="sidebar:5">
-      
-        <a href="https://www.theverge.com/2018/1/22/16920078/geoengineering-stratospheric-aerosol-injection-climate-change-biodiversity-global-warming" class="c-rock-list__link" data-analytics-link="trending" data-analytics-viewport="trending" data-chorus-optimize-id="16684119" data-chorus-optimize-module="entry-list">
-          
-            <div class="c-rock-list__image">
-
-              
-              
-                
-                
-                
-                  <picture class="c-picture" data-chorus-optimize-field="main_image" data-cid="site/picture_element-1516700709_4450_61303" data-cdata='{"image_id":58413459,"ratio":"standard","dynamic_type":"picture","lazy":true}'>
-  <script type="text/template-picture" style="display: none;">
-    
-
-
-  <source
-    srcset="https://cdn.vox-cdn.com/thumbor/KhpWX6NL8j2ADFQ7IfLrTkhFIfo=/0x0:936x512/250x167/filters:focal(394x182:542x330):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58413459/Screen_Shot_2015-04-23_at_8.43.10_AM.0.0.png 250w, https://cdn.vox-cdn.com/thumbor/6RGlmef4rJ-v6boiKceeGei77b8=/0x0:936x512/500x333/filters:focal(394x182:542x330):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/58413459/Screen_Shot_2015-04-23_at_8.43.10_AM.0.0.png 500w"
-    sizes="250px"
-    type="image/webp"
-  >
-
-
-<img
-  srcset="https://cdn.vox-cdn.com/thumbor/ill1-zzj_fUuiSjSjWNrO6fzDdA=/0x0:936x512/250x167/filters:focal(394x182:542x330)/cdn.vox-cdn.com/uploads/chorus_image/image/58413459/Screen_Shot_2015-04-23_at_8.43.10_AM.0.0.png 250w, https://cdn.vox-cdn.com/thumbor/mtRMkBjJLDv_F_MW1g8P94c7i7A=/0x0:936x512/500x333/filters:focal(394x182:542x330)/cdn.vox-cdn.com/uploads/chorus_image/image/58413459/Screen_Shot_2015-04-23_at_8.43.10_AM.0.0.png 500w"
-  sizes="250px"
-  src="https://cdn.vox-cdn.com/thumbor/KsGDalraNQkjKRCSMZDRqVFW7BE=/0x0:936x512/1200x800/filters:focal(394x182:542x330)/cdn.vox-cdn.com/uploads/chorus_image/image/58413459/Screen_Shot_2015-04-23_at_8.43.10_AM.0.0.png"
-  
-  
->
-
-  </script>
-  <script type="text/template-dynamic" style="display: none">
-    
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_9879_61302" data-cdata='{"image_id":58413459,"ratio":"standard"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58413459/Screen_Shot_2015-04-23_at_8.43.10_AM.0.0.png" alt=""></noscript>
-
-  </script>
-</picture>
-
-                
-              
-
-              
-            </div>
-          
-          <span class="c-rock-list__entry-title">
-            
-            <span data-chorus-optimize-field="hed">If we start deliberately cooling the Earth, we may not be able to stop</span>
-          </span>
-          
-            <span class="c-rock-list__entry-blurb">Geoengineering isn’t a silver bullet</span>
-          
-        </a>
-        
-      </li>
-    
-    </ol>
-    <div data-cid="site/entry_sponsorship/native_ad-BYrH87S5AMllG0hwU66kKA==">
-  <div class="m-native_ad_unit dynamic-native-ad-native_ad_latest"></div>
-</div>
-
-    
-  </div>
-</aside>
-
-  <script type="text/javascript">ChorusAds.cmd.push(function() {ChorusAds.addVariable("trending_sidebar", ["true"])});</script>
-
-
-      </div>
-      <div class="u-desktop-only">
-        <div class="c-rock-newsletter" id="newsletter-signup-short-form">
-  <div class="c-rock-newsletter__inner">
-  <h3 class="p-rock-head c-rock-list__title">
-    
-    <span class="c-rock-list__title-wrapper">Command Line</span>
-  </h3>
-  
-    <p class="c-rock-newsletter__blurb">Command Line delivers daily updates from the near-future.</p>
-  
-  <form action="https://voxmedia.createsend.com/t/d/s/btyjik/" method="post" id="subForm" class="c-newsletter-signup-form c-newsletter-signup-form__1" data-analytics-class="newsletter" data-analytics-placement="sidebar">
-  
-  
-  <div class="c-newsletter-signup-form__body">
-    
-      <label for="field_email">
-        <span class="p-hidden-label">email address...</span>
-        <input id="field_email" class="p-text-input" name="email" placeholder='email address...' type="email" />
-        
-      </label>
-    
-    <button type="submit" class="p-button">Subscribe</button>
-  </div>
-  <div class="c-newsletter-signup-form__disclaimer">
-    By signing up, you agree to our <a href="https://www.voxmedia.com/pages/privacy-policy">Privacy Policy</a> and European users agree to the data transfer policy.
-    
-  </div>
-</form>
-
-  
-  </div>
-</div>
-
-      </div>
-<div class="chorus-ad-placement ym" id="ym_1199230607295888165"></div><script type="text/javascript">(function(e,t){if(t.innerWidth>727){return;}if(t._ym===void 0){t._ym="";var m=e.createElement("script");m.type="text/javascript",m.async=!0,m.src="//static.yieldmo.com/ym.m3.js",(e.getElementsByTagName("head")[0]||e.getElementsByTagName("body")[0]).appendChild(m)}else t._ym instanceof String||void 0===t._ym.chkPls||t._ym.chkPls()})(document,window);</script>
-
-
-<div id="sidebar-debugger-data" class="u-hidden-text">
-  This Article has a component height of 18. The sidebar size is long.
-</div>
-
-    </div>
-</div>
-
-<div class="l-segment">
-  <div class="OUTBRAIN" data-src="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-widget-id="AR_2" data-ob-template="TheVerge_1" ></div>
-
-<script type="text/javascript" charset="utf-8">
-(function(){
-  // load outbrain js
-  function loadOutbrain(){
-    var ref = document.querySelector("div.OUTBRAIN");
-
-    var script = document.createElement('script');
-    script.setAttribute('type','text/javascript');
-    script.setAttribute('src', 'https://widgets.outbrain.com/outbrain.js');
-    script.setAttribute('async', 'async');
-
-    ref.appendChild(script);
-  }
-
-  // Disable on mobile and tablet screens
-  // 880px is the upper bound for the `medium` breakpoint defined in UserAgent JS lib.
-  var shouldDisable = false && screen.width <= 880;
-
-  if (!shouldDisable) {
-    // first, set a timeout to loadOutbrain, in case no ads load in 5s
-    // (i.e., blocked). once an ad has loaded, create a new timeout that
-    // will load outbrain if openmic doesn't get loaded in 2s
-    //
-    var adBlockerTimeoutId = setTimeout(loadOutbrain, 5000);
-    document.body.addEventListener('first_ad_rendered', function(){
-      clearTimeout(adBlockerTimeoutId);
-      var outbrainTimeoutId = setTimeout(loadOutbrain, 2000);
-      document.body.addEventListener('openmicRendered', function(){
-        clearTimeout(outbrainTimeoutId);
-      });
-    });
-  }
-})();
 </script>
-
-</div>
-
-<div class="l-sidebar-fixed l-segment">
-  <div class="l-col__main">
-      <svg width="0" height="0" style="position:absolute;display:none;"><symbol viewbox="236.9 122.4 318.2 367.2" id="icon-bold" xmlns="http://www.w3.org/2000/svg"><path d="M236.9 422.3h39.8V189.7h-39.8v-67.3h171.4c27.5 0 45.9 0 67.3 9.2 39.8 12.2 64.3 45.9 64.3 88.7 0 30.6-15.3 61.2-42.8 79.6 42.8 12.2 58.1 49 58.1 85.7 0 55.1-39.8 91.8-82.6 104H236.9v-67.3zm177.5-159.1c21.4 0 33.7-15.3 33.7-36.7 0-12.2-6.1-27.5-18.4-30.6-6.1-3.1-12.2-3.1-21.4-3.1h-36.7v70.4h42.8zm9.1 156c6.1 0 12.2 0 18.4-3.1 15.3-6.1 21.4-24.5 21.4-39.8 0-21.4-12.2-36.7-39.8-36.7h-52v82.6h52v-3z"></path></symbol><symbol viewbox="0 0 95.46 95.46" id="icon-comment-flair" xmlns="http://www.w3.org/2000/svg"><path d="M81.48 33.75V14H61.71l-14-14-14 14H14v19.75l-14 14 14 14v19.73h19.75l14 14 14-14h19.73V61.71l14-14zM49.16 58l-7.24 7.24L34.68 58l-9-9 7.24-7.24 9 9 20.63-20.59 7.24 7.24z"></path></symbol><symbol viewbox="191 101 410.1 410.1" id="icon-emoji" xmlns="http://www.w3.org/2000/svg"><path d="M396 101c-113.2 0-205 91.9-205 205s91.9 205 205 205 205-91.9 205-205c0-112.6-91.8-205-205-205zm0 361.8c-86.2 0-156.8-70-156.8-156.8 0-86.2 70-156.8 156.8-156.8 86.2 0 156.8 70 156.8 156.8-.5 86.8-70.5 156.8-156.8 156.8z"></path><ellipse cx="346.3" cy="249.7" rx="28.9" ry="39.1"></ellipse><path d="M445.7 288.3c15.8 0 28.9-17.2 28.9-39.1 0-21.3-12.7-39.1-28.9-39.1-15.8 0-28.9 17.2-28.9 39.1s12.7 39.1 28.9 39.1zm39.1 50.2c-11.1-7.1-25.9-3.5-32.5 7.6 0 .5-17.2 25.9-56.3 25.9-38.6 0-55.3-24.3-56.3-25.9-7.1-11.1-21.3-14.7-32.5-7.6-11.1 6.6-14.7 21.3-8.1 32.5 1 2.1 29.9 48.2 96.9 48.2 66 0 95.4-46.2 96.9-48.2 6.6-11.2 3.1-25.9-8.1-32.5z"></path></symbol><symbol viewbox="0 0 450 324" id="icon-fold" xmlns="http://www.w3.org/2000/svg"><path fill="#231F20" d="M227.3 134.7L95.5 2.9 0 98.4l227.3 222.7L450 98.4 354.5 2.9z"></path></symbol><symbol viewbox="151.2 122.4 489.6 367.2" id="icon-image" xmlns="http://www.w3.org/2000/svg"><path d="M640.8 153v306c0 18.4-12.2 30.6-30.6 30.6H181.8c-18.4 0-30.6-12.2-30.6-30.6V153c0-18.4 12.2-30.6 30.6-30.6h428.4c18.4 0 30.6 12.2 30.6 30.6zM243 244.8c0 33.7 27.5 61.2 61.2 61.2s61.2-27.5 61.2-61.2-27.5-61.2-61.2-61.2-61.2 27.5-61.2 61.2zm214.2 0L344 388.6l-70.4-52-61.2 91.8h367.2L457.2 244.8z"></path></symbol><symbol viewbox="334.8 122.4 122.4 367.2" id="icon-italic" xmlns="http://www.w3.org/2000/svg"><path d="M347 416.2l30.6-149.9h-42.8l9.2-39.8h94.9l-36.7 186.7c0 6.1-3.1 12.2-3.1 15.3 0 18.4 12.2 21.4 24.5 21.4h12.2l-9.2 39.8h-21.4c-24.5 0-58.1-3.1-58.1-49l-.1-24.5zm58.2-293.8h52l-9.2 52h-55.1l12.3-52z"></path></symbol><symbol viewbox="212.4 122.4 367.2 367.2" id="icon-link" xmlns="http://www.w3.org/2000/svg"><path d="M438.8 403.9L380.7 462c-18.4 18.4-42.8 27.5-70.4 27.5s-52-9.2-70.4-27.5c-18.4-21.4-27.5-45.9-27.5-70.4 0-24.5 9.2-52 27.5-70.4l52-52c-3.1 18.4 0 39.8 9.2 58.1l-27.5 24.5c-9.2 9.2-15.3 24.5-15.3 36.7s6.1 27.5 15.3 39.8c9.2 9.2 24.5 15.3 36.7 15.3 15.3 0 27.5-6.1 36.7-15.3l58.1-58.1c9.2-9.2 15.3-24.5 15.3-36.7 0-15.3-6.1-27.5-15.3-36.7-3.1-3.1-6.1-9.2-6.1-15.3s3.1-12.2 6.1-15.3c3.1-3.1 9.2-6.1 15.3-6.1s12.2 3.1 15.3 6.1c18.4 18.4 27.5 42.8 27.5 70.4 6.2 24.5-6 49-24.4 67.3zM549 293.8l-52 52c3.1-18.4 0-39.8-9.2-58.1l30.6-27.5c9.2-9.2 15.3-24.5 15.3-36.7 0-15.3-6.1-27.5-15.3-36.7-9.2-9.2-24.5-15.3-36.7-15.3-15.3 0-27.5 6.1-36.7 15.3l-61.2 55.1c-9.2 9.2-15.3 21.4-15.3 36.7 0 15.3 6.1 27.5 15.3 39.8 3.1 3.1 6.1 9.2 6.1 15.3s-3.1 12.2-6.1 15.3c-3.1 3.1-9.2 6.1-15.3 6.1s-12.2-3.1-15.3-6.1c-18.4-18.4-30.6-42.8-30.6-70.4s9.2-52 27.5-70.4l58.1-55.1c18.4-18.4 42.8-30.6 70.4-30.6s52 9.2 70.4 30.6c18.4 18.4 30.6 42.8 30.6 70.4 0 24.4-9.2 48.8-30.6 70.3z"></path></symbol><symbol viewbox="212.4 153 397.8 306" id="icon-list" xmlns="http://www.w3.org/2000/svg"><path d="M365.4 397.8h244.8v30.6H365.4v-30.6zm0-214.2h244.8v30.6H365.4v-30.6zm-88.7 61.2H243c-18.4 0-30.6-15.3-30.6-30.6v-30.6c0-18.4 12.2-30.6 30.6-30.6h33.7c18.4 0 30.6 12.2 30.6 30.6v30.6c0 15.3-15.3 30.6-30.6 30.6zm0 214.2H243c-18.4 0-30.6-12.2-30.6-30.6v-27.5c0-18.4 12.2-30.6 30.6-30.6h33.7c18.4 0 30.6 12.2 30.6 30.6v27.5c0 18.4-15.3 30.6-30.6 30.6z"></path></symbol><symbol viewbox="212.4 122.4 397.8 367.2" id="icon-orderedlist" xmlns="http://www.w3.org/2000/svg"><path d="M365.4 183.6h244.8v30.6H365.4v-30.6zm0 214.2h244.8v30.6H365.4v-30.6zM215.5 254h36.7v-97.9l-6.1 6.1-18.4 18.4-15.3-18.4 39.8-39.8h24.5V254h36.7v21.4h-97.9V254zM285.8 382.5c0-12.2-9.2-21.4-24.5-21.4-18.4 0-30.6 15.3-30.6 15.3l-15.3-15.3s15.3-24.5 49-24.5c30.6 0 49 18.4 49 42.8 0 49-70.4 52-73.4 88.7h55v-18.4h21.4v39.8h-104v-12.2c0-55 73.4-61.1 73.4-94.8z"></path></symbol><symbol viewbox="181.8 122.4 431.5 370.3" id="icon-quote" xmlns="http://www.w3.org/2000/svg"><path d="M356.2 122.4c-52 0-94.9 18.4-125.5 58.1s-49 88.7-49 153v131.6c0 6.1 3.1 12.2 9.2 18.4 3.1 3.1 9.2 6.1 18.4 6.1h131.6c6.1 0 12.2-3.1 18.4-9.2 3.1-3.1 6.1-9.2 6.1-18.4V358c0-6.1-3.1-12.2-9.2-18.4-6.1-6.1-12.2-9.2-18.4-9.2h-52c0-33.7 6.1-61.2 18.4-82.6 12.2-18.4 30.6-30.6 52-30.6 6.1 0 9.2-3.1 9.2-6.1v-79.6c0-3.1 0-6.1-3.1-6.1 0-3-3-3-6.1-3zM601 220.3c6.1-3.1 9.2-6.1 9.2-9.2v-79.6c0-3.1 0-6.1-3.1-6.1 0-3.1-3.1-3.1-6.1-3.1-52 0-94.9 18.4-125.5 58.1s-49 88.7-49 153V465c0 6.1 3.1 12.2 9.2 18.4 6.1 6.1 12.2 9.2 18.4 9.2h131.6c6.1 0 12.2-3.1 18.4-9.2 6.1-6.1 9.2-12.2 9.2-18.4V361c0-6.1-3.1-12.2-9.2-18.4-6.1-6.1-12.2-9.2-18.4-9.2h-52c0-33.7 6.1-61.2 18.4-82.6 9.1-18.2 27.5-30.5 48.9-30.5z"></path></symbol><symbol viewbox="142.3 -19 787.2 792" id="icon-spoiler" xmlns="http://www.w3.org/2000/svg"><path d="M142.3-19h787.2v792H142.3V-19z"></path></symbol><symbol viewbox="212.4 122.4 367.2 367.2" id="icon-strikeout" xmlns="http://www.w3.org/2000/svg"><path d="M579.6 306H212.4v30.6h208.1c24.5 12.2 42.8 27.5 42.8 55.1 0 36.7-30.6 55.1-70.4 55.1-36.7 0-70.4-15.3-70.4-42.8v-27.5h-49v36.7c0 52 61.2 76.5 116.3 76.5 67.3 0 122.4-36.7 122.4-104 0-21.4-6.1-36.7-15.3-49h82.6V306zm-186.7-30.6c-33.7-12.2-61.2-27.5-61.2-61.2s27.5-49 61.2-49c30.6 0 61.2 12.2 61.2 30.6v24.5H500v-39.8c3.1-36.7-52-58.1-104-58.1-61.2 0-116.3 27.5-116.3 94.9 0 24.5 9.2 42.8 21.4 58.1h91.8z"></path></symbol></svg>
-<section id="comments" class="c-comments" data-cid="apps/comment_forum-1516700709_4100_61304" data-cdata='{"entry_id":16685133}'>
-  <div class="c-comments__header">
-    <h4 class="c-comments__message">Loading comments...</h4>
-  </div>
-</section>
+                  </video>
 
 
-  <div class="c-compact-river">
-  
-    <h2 class="p-breaker-head ">
-      
-      <span class="p-breaker-head__wrapper">The Latest</span>
-    </h2>
-  
-  
-    
-    <div class="c-compact-river__entry ">
-      <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="16686467" data-chorus-optimize-module="entry-box" >
-  
-    <a href="https://www.theverge.com/circuitbreaker/2018/1/23/16922426/acer-chromebook-spin-11-chromebox-cxi3-announcement-specs-price" class="c-entry-box--compact__image-wrapper"  data-analytics-link="article:image">
-      
-        <div class="c-entry-box--compact__image">
-          
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_8966_61305" data-cdata='{"image_id":58420627,"ratio":"*"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58420627/Acer_Chromebook_Spin11_CP311_1H_CP311_1HN_05_with_Stylus.0.jpg" alt=""></noscript>
+                </span>
 
+              </span>
+
+              <span class="e-image__meta">
+
+
+                <cite><a
+                    href="http://www.nti.org/analysis/articles/mineshaft-gap-lavish-bunkers-where-putin-trump-plan-fight-nuclear-war/">Video
+                    by the Center for Nonproliferation Studies at MIIS and the Nuclear Threat Initiative</a></cite>
+
+              </span>
+
+            </figure>
+
+
+
+
+
+
+
+            <div class="c-entry-content ">
+              <p id="zSLJZN">Even if the populations of the US or Russia are annihilated in a nuclear apocalypse, the
+                governments responsible for the devastation plan to fight on from vast, underground bunkers. Now, the
+                public can peer inside the secretive complexes thanks to the efforts of arms control analysts who
+                reconstructed these bunkers inside <em>Minecraft</em>. </p>
+              <p id="Hm9zjL">The mistaken missile alert that sent people scurrying for cover in Hawaii last week <a
+                  href="https://www.theatlantic.com/international/archive/2018/01/pandemonium-and-rage-in-hawaii/550529/">revealed
+                  just how poorly prepared</a> the US government is to protect the public during a nuclear attack. The
+                government’s plans for protecting <em>itself</em> from a rain of thermonuclear fire are much more
+                detailed. Using satellite images, declassified information, and a good amount of guesswork, analysts at
+                the <a href="http://www.miis.edu/academics/researchcenters/nonproliferation">Middlebury Institute of
+                  International Studies (or MIIS)</a> reconstructed two underground complexes: the Pentagon’s site in
+                Pennsylvania and a bunker built by the Russian government outside Moscow.</p>
+              <p id="epFj7Z">The reconstructions are set in the low-resolution world of <em>Minecraft</em> to lighten
+                the very real, and very depressing, topic of nuclear annihilation, says <a
+                  href="http://www.miis.edu/academics/faculty/JLewis/node/23027">Jeffrey Lewis</a>, who led the effort
+                from the <a href="http://www.miis.edu/academics/researchcenters/nonproliferation">James Martin Center
+                  for Nonproliferation Studies</a> at MIIS. The aim is to draw attention to the tension between how the
+                government downplays the risk of nuclear war and how it actually prepares for it, Lewis says. “What the
+                bunker model shows you is that the risk of nuclear war is real enough that the United States and Russia
+                spend billions of dollars preparing to stash away their leadership.” (Players can find an article about
+                the bunkers and instructions for virtually accessing them posted on <a
+                  href="http://www.nti.org/analysis/articles/mineshaft-gap-lavish-bunkers-where-putin-trump-plan-fight-nuclear-war/">the
+                  Nuclear Threat Initiative’s site</a>.) </p>
+              <hr class="p-entry-hr" id="K9e2cN">
+              <div id="vozSyf">
+                <div style="left: 0px; width: 100%; height: auto; position: relative; padding-bottom: 0px;">
+                  <div class="p-scalable-video"><iframe src="https://www.youtube.com/embed/zzkOaXidWbg?rel=0&amp;"
+                      allowfullscreen="" scrolling="no"></iframe></div>
+                </div>
+              </div>
+              <p id="BZG4MC"><small><em>Working with </em></small><a
+                  href="https://www.thedailybeast.com/at-last-you-can-build-a-nuclear-command-center-in-minecraft?ref=author"><small><em>defense
+                      journalist Adam Rawnsley</em></small></a><small><em>, the CNS team created a trailer video of the
+                    bunker reconstructions.</em></small></p>
+              <hr class="p-entry-hr" id="misO2s">
+              <p id="9KHQXn">The <a
+                  href="http://www.simonandschuster.com/books/Raven-Rock/Garrett-M-Graff/9781476735405">650-acre</a>
+                Raven Rock complex is the alternative Pentagon where top defense officials plan to flee during a nuclear
+                attack. Also known as Site R, it’s located on the Pennsylvania side of the border with Maryland — close
+                to the presidential retreat Camp David. Thanks to the Freedom of Information Act, a diagram of the site
+                has been “floating around online,” Lewis says. The team based their reconstruction on that diagram and
+                details in journalist Garrett Graff’s book <a
+                  href="http://www.simonandschuster.com/books/Raven-Rock/Garrett-M-Graff/9781476735405"><em>Raven Rock:
+                    The Story of the U</em><em>S</em><em> Government’s Secret Plan to Save Itself — While the Rest of Us
+                    Die</em></a>. Using satellite images and topography, the team located the entrances to the site and
+                figured out the size of the mountain above it. </p>
+              <div id="zuKezc">
+                <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;"><iframe
+                    src="https://sketchfab.com/models/d1e8d568516e4a8aa9c26b9d2ef01fdd/embed?"
+                    style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;"
+                    allowfullscreen="" scrolling="no"></iframe></div>
+              </div>
+              <p id="nmvKyg">The team also modeled the Kosvinsky underground command facility outside of Moscow, Russia.
+                This, too, was based on satellite images and details gleaned from declassified CIA reports. For both
+                complexes — but especially the Russian one — the team had to use their imaginations to fill in the gaps,
+                Lewis says. “There’s an enormous amount of guesswork. In no way, shape, or form did we make anything
+                that we think is perfect,” he says. </p>
+              <div id="zwikY9">
+                <div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.2493%;"><iframe
+                    src="https://sketchfab.com/models/80410e56dc6844d081149720ca744518/embed?"
+                    style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;"
+                    allowfullscreen="" scrolling="no"></iframe></div>
+              </div>
+              <p id="yochkF">There are also a few Easter eggs, including an interplanetary wormhole from the
+                science-fiction franchise <em>Stargate</em> in one of the bunkers and a pen of especially virulent
+                zombies. “But the important thing is that we wanted people to get a sense for the scale — and we think
+                that’s probably about right,” Lewis says. The point is to remind people that as long as nuclear weapons
+                exist, they pose a threat. “It all goes back to focusing on the changing US and Russian nuclear
+                posture,” Lewis says. “We imagine that things are very different from the Cold War, but the bunkers
+                suggest the opposite — they suggest that they’re exactly the same.” </p>
+              <p id="VCEFD5"></p>
+
+            </div>
+
+
+
+            <div class="u-hidden-text" id="formatter-datter" data-cid="site/entry_formatter-1615219071_6891_2177"
+              data-cdata="{&quot;svg_hr_illustration&quot;:&quot;&quot;}">
+
+            </div>
+
+
+
+
+
+
+            <section class="c-nextclick" data-cid="apps/nextclick-1615219071_3616_2179"
+              data-cdata="{&quot;dynamic_links&quot;:[{&quot;title&quot;:&quot;How to score a COVID-19 vaccine appointment&quot;,&quot;url&quot;:&quot;https://www.theverge.com/22279023/covid-19-vaccine-appointment-how-to&quot;,&quot;data-analytics-link&quot;:&quot;nextclicks&quot;,&quot;data-analytics-viewport&quot;:&quot;nextclicks&quot;,&quot;data-vars-analytics-link-title&quot;:&quot;How to score a COVID-19 vaccine appointment&quot;},{&quot;title&quot;:&quot;How scientists scrambled to stop Donald Trump’s EPA from wiping out climate data&quot;,&quot;url&quot;:&quot;https://www.theverge.com/22313763/scientists-climate-change-data-rescue-donald-trump&quot;,&quot;data-analytics-link&quot;:&quot;nextclicks&quot;,&quot;data-analytics-viewport&quot;:&quot;nextclicks&quot;,&quot;data-vars-analytics-link-title&quot;:&quot;How scientists scrambled to stop Donald Trump’s EPA from wiping out climate data&quot;},{&quot;title&quot;:&quot;OpenAI’s state-of-the-art machine vision AI is fooled by handwritten notes&quot;,&quot;url&quot;:&quot;https://www.theverge.com/2021/3/8/22319173/openai-machine-vision-adversarial-typographic-attacka-clip-multimodal-neuron&quot;,&quot;data-analytics-link&quot;:&quot;nextclicks&quot;,&quot;data-analytics-viewport&quot;:&quot;nextclicks&quot;,&quot;data-vars-analytics-link-title&quot;:&quot;OpenAI’s state-of-the-art machine vision AI is fooled by handwritten notes&quot;},{&quot;title&quot;:&quot;COVID-19 vaccine supplies are on the rise in the US&quot;,&quot;url&quot;:&quot;https://www.theverge.com/2021/3/6/22316094/covid-19-vaccine-supplies-us-antivirus-newsletter&quot;,&quot;data-analytics-link&quot;:&quot;nextclicks&quot;,&quot;data-analytics-viewport&quot;:&quot;nextclicks&quot;,&quot;data-vars-analytics-link-title&quot;:&quot;COVID-19 vaccine supplies are on the rise in the US&quot;},{&quot;title&quot;:&quot;NASA’s Perseverance rover scoots around on Mars for the first time&quot;,&quot;url&quot;:&quot;https://www.theverge.com/2021/3/5/22316093/nasas-perseverance-rover-first-drive-mars&quot;,&quot;data-analytics-link&quot;:&quot;nextclicks&quot;,&quot;data-analytics-viewport&quot;:&quot;nextclicks&quot;,&quot;data-vars-analytics-link-title&quot;:&quot;NASA’s Perseverance rover scoots around on Mars for the first time&quot;},{&quot;title&quot;:&quot;Single-shot&nbsp;COVID-19&nbsp;vaccine&nbsp;is popular at vaccination sites&quot;,&quot;url&quot;:&quot;https://www.theverge.com/2021/3/5/22315138/covid-vaccine-single-shot-johnson-distribution&quot;,&quot;data-analytics-link&quot;:&quot;nextclicks&quot;,&quot;data-analytics-viewport&quot;:&quot;nextclicks&quot;,&quot;data-vars-analytics-link-title&quot;:&quot;Single-shot&nbsp;COVID-19&nbsp;vaccine&nbsp;is popular at vaccination sites&quot;}],&quot;entry_id&quot;:16685133,&quot;experiment_id&quot;:&quot;exp_110&quot;,&quot;experiment_base_url&quot;:&quot;http://vox-datascience.s3.amazonaws.com/recommender/recs/&quot;}">
+              <div class="c-related-list" data-cid="site/related_list-1615219071_1356_2178" data-cdata="{}">
+                <h2 class="c-related-list__head">
+                  Next Up In
+
+                  <a href="https://www.theverge.com/science" class="c-related-list__group-name"><span>Science</span></a>
+
+                </h2>
+                <ul>
+                  <li>
+
+                    <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks"
+                      data-vars-analytics-link-title="How to score a COVID-19 vaccine appointment"
+                      href="https://www.theverge.com/22279023/covid-19-vaccine-appointment-how-to">
+                      How to score a COVID-19 vaccine appointment
+                    </a>
+                  </li>
+
+                  <li>
+
+                    <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks"
+                      data-vars-analytics-link-title="How scientists scrambled to stop Donald Trump’s EPA from wiping out climate data"
+                      href="https://www.theverge.com/22313763/scientists-climate-change-data-rescue-donald-trump">
+                      How scientists scrambled to stop Donald Trump’s EPA from wiping out climate data
+                    </a>
+                  </li>
+
+                  <li>
+
+                    <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks"
+                      data-vars-analytics-link-title="OpenAI’s state-of-the-art machine vision AI is fooled by handwritten notes"
+                      href="https://www.theverge.com/2021/3/8/22319173/openai-machine-vision-adversarial-typographic-attacka-clip-multimodal-neuron">
+                      OpenAI’s state-of-the-art machine vision AI is fooled by handwritten notes
+                    </a>
+                  </li>
+
+                  <li>
+
+                    <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks"
+                      data-vars-analytics-link-title="COVID-19 vaccine supplies are on the rise in the US"
+                      href="https://www.theverge.com/2021/3/6/22316094/covid-19-vaccine-supplies-us-antivirus-newsletter">
+                      COVID-19 vaccine supplies are on the rise in the US
+                    </a>
+                  </li>
+
+                  <li>
+
+                    <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks"
+                      data-vars-analytics-link-title="NASA’s Perseverance rover scoots around on Mars for the first time"
+                      href="https://www.theverge.com/2021/3/5/22316093/nasas-perseverance-rover-first-drive-mars">
+                      NASA’s Perseverance rover scoots around on Mars for the first time
+                    </a>
+                  </li>
+
+                  <li>
+
+                    <a data-analytics-link="nextclicks" data-analytics-viewport="nextclicks"
+                      data-vars-analytics-link-title="Single-shot&nbsp;COVID-19&nbsp;vaccine&nbsp;is popular at vaccination sites"
+                      href="https://www.theverge.com/2021/3/5/22315138/covid-vaccine-single-shot-johnson-distribution">
+                      Single-shot&nbsp;COVID-19&nbsp;vaccine&nbsp;is popular at vaccination sites
+                    </a>
+                  </li>
+
+
+
+                  <div>
+                    <div class="m-native_ad_unit dynamic-native-ad-native_ad_linkset_link"></div>
+                  </div>
+
+                </ul>
+
+              </div>
+
+            </section>
+
+          </div>
+          <div class="l-col__sidebar" data-analytics-placement="sidebar">
+
+            <div class="u-desktop-only">
+              <aside class="c-rock-list c-rock-list--image c-rock-list--hub" id="rock-good-deals">
+                <h3 class="p-rock-head c-rock-list__title">
+
+
+                  <span class="c-rock-list__title-wrapper">
+                    <a href="/good-deals">
+                      <span class="c-rock-list__title-text">
+                        Verge Deals
+                      </span>
+                    </a>
+                  </span>
+                </h3>
+                <div class="c-rock-list__body">
+
+                  <ol class="c-rock-list__items">
+
+
+                    <li class="c-rock-list__item" data-analytics-placement="sidebar:1">
+
+                      <a href="https://www.theverge.com/good-deals/2021/3/8/22319265/sony-whch710n-headphones-target-deal-walmart-nintendo-switch-game-sale"
+                        class="c-rock-list__link" data-analytics-link="hubpage-good-deals"
+                        data-analytics-viewport="hubpage-good-deals" data-chorus-optimize-id="22083306"
+                        data-chorus-optimize-module="entry-list">
+
+                        <div class="c-rock-list__image">
+
+                          <picture class="c-picture" data-chorus-optimize-field="main_image"
+                            data-cid="site/picture_element-1615216180_6277_46131"
+                            data-cdata="{&quot;image_id&quot;:68929356,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+
+
+
+
+                            <source
+                              srcset="https://cdn.vox-cdn.com/thumbor/RSFKTVqAcUDeSfM2UYY0EKHv3VY=/0x0:3000x2000/250x167/filters:focal(1660x654:2140x1134):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68929356/WH_CH710N_B_NC_Concentration_Large.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/uVb_npiw5RWCnxq3HPsEKqhcjC0=/0x0:3000x2000/500x333/filters:focal(1660x654:2140x1134):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68929356/WH_CH710N_B_NC_Concentration_Large.0.jpg 500w"
+                              sizes="250px" type="image/webp">
+
+
+                            <img
+                              srcset="https://cdn.vox-cdn.com/thumbor/ApNV_oFmymYTDdFyBjYFArgZ7LA=/0x0:3000x2000/250x167/filters:focal(1660x654:2140x1134)/cdn.vox-cdn.com/uploads/chorus_image/image/68929356/WH_CH710N_B_NC_Concentration_Large.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/-hBm8X89ODtmkgR8N2yWuoiplCc=/0x0:3000x2000/500x333/filters:focal(1660x654:2140x1134)/cdn.vox-cdn.com/uploads/chorus_image/image/68929356/WH_CH710N_B_NC_Concentration_Large.0.jpg 500w"
+                              sizes="250px" alt="" data-upload-width="3000"
+                              src="https://cdn.vox-cdn.com/thumbor/WAu7dXbG4PmU0P6_jCWdvfSsoG0=/0x0:3000x2000/1200x800/filters:focal(1660x654:2140x1134)/cdn.vox-cdn.com/uploads/chorus_image/image/68929356/WH_CH710N_B_NC_Concentration_Large.0.jpg">
+
+
+                            <script type="text/template-dynamic" style="display: none">
+
+<img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1615216180_4587_46130" data-cdata='{"image_id":68929356,"ratio":"standard"}'>
+<noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/68929356/WH_CH710N_B_NC_Concentration_Large.0.jpg"></noscript>
+
+</script>
+                          </picture>
+
+
+                        </div>
+
+                        <span class="c-rock-list__item--body">
+
+                          <span data-chorus-optimize-field="hed">Sony’s WH-CH710N noise-canceling headphones are half
+                            off</span>
+
+                          <span class="c-rock-list__entry-blurb">They cost $98 at Amazon and Best Buy</span>
+
+                        </span>
+                      </a>
+
+
+                    </li>
+
+
+                    <li class="c-rock-list__item" data-analytics-placement="sidebar:2">
+
+                      <a href="https://www.theverge.com/good-deals/2021/3/6/22315513/video-game-deal-sale-oculus-quest-external-ssd-usb-c-tony-hawk-ps5"
+                        class="c-rock-list__link" data-analytics-link="hubpage-good-deals"
+                        data-analytics-viewport="hubpage-good-deals" data-chorus-optimize-id="22079554"
+                        data-chorus-optimize-module="entry-list">
+
+                        <div class="c-rock-list__image">
+
+                          <picture class="c-picture" data-chorus-optimize-field="main_image"
+                            data-cid="site/picture_element-1615216180_1406_46133"
+                            data-cdata="{&quot;image_id&quot;:68922074,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+
+
+
+
+                            <source
+                              srcset="https://cdn.vox-cdn.com/thumbor/Y_62eV1tjF-XVpYPuL0PhBklJJM=/0x0:2040x1360/250x167/filters:focal(857x517:1183x843):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68922074/akrales_190429_3371_0087.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/kVRIOsRkjLkxOcpt526jgMQtCzU=/0x0:2040x1360/500x333/filters:focal(857x517:1183x843):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68922074/akrales_190429_3371_0087.0.jpg 500w"
+                              sizes="250px" type="image/webp">
+
+
+                            <img
+                              srcset="https://cdn.vox-cdn.com/thumbor/epwZkqRSbiAPE0cM4hZvrpHCdQs=/0x0:2040x1360/250x167/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68922074/akrales_190429_3371_0087.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/EKjrd0boMecIFxSeSPmw_RpHkWM=/0x0:2040x1360/500x333/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68922074/akrales_190429_3371_0087.0.jpg 500w"
+                              sizes="250px" alt="" data-upload-width="2040"
+                              src="https://cdn.vox-cdn.com/thumbor/4_SofrZXVHeG-rCGRO-DmpK839M=/0x0:2040x1360/1200x800/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68922074/akrales_190429_3371_0087.0.jpg">
+
+
+                            <script type="text/template-dynamic" style="display: none">
+
+<img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1615216180_42_46132" data-cdata='{"image_id":68922074,"ratio":"standard"}'>
+<noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/68922074/akrales_190429_3371_0087.0.jpg"></noscript>
+
+</script>
+                          </picture>
+
+
+                        </div>
+
+                        <span class="c-rock-list__item--body">
+
+                          <span data-chorus-optimize-field="hed">Gaming ruled this week’s best deals</span>
+
+                          <span class="c-rock-list__entry-blurb">Recent deals have been fantastic if you’re a gamer, not
+                            so much for everyone else</span>
+
+                        </span>
+                      </a>
+
+
+                    </li>
+
+
+                    <li class="c-rock-list__item" data-analytics-placement="sidebar:3">
+
+                      <a href="https://www.theverge.com/good-deals/2021/3/5/22315118/oculus-quest-refurbished-samsung-galaxy-s21-google-pixel-3-xl-deal-sale"
+                        class="c-rock-list__link" data-analytics-link="hubpage-good-deals"
+                        data-analytics-viewport="hubpage-good-deals" data-chorus-optimize-id="22079159"
+                        data-chorus-optimize-module="entry-list">
+
+                        <div class="c-rock-list__image">
+
+                          <picture class="c-picture" data-chorus-optimize-field="main_image"
+                            data-cid="site/picture_element-1615216180_5875_46135"
+                            data-cdata="{&quot;image_id&quot;:68916907,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+
+
+
+
+                            <source
+                              srcset="https://cdn.vox-cdn.com/thumbor/-xr7NDewN7rsjMa3qHpoT5C6F08=/0x0:2040x1360/250x167/filters:focal(857x517:1183x843):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68916907/akrales_190429_3371_0104.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/NtOKDKphXTVNeSoqbKjhOMTQnWk=/0x0:2040x1360/500x333/filters:focal(857x517:1183x843):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68916907/akrales_190429_3371_0104.0.jpg 500w"
+                              sizes="250px" type="image/webp">
+
+
+                            <img
+                              srcset="https://cdn.vox-cdn.com/thumbor/d5s0rGHlsvKUiF8hqavf4DjMwv4=/0x0:2040x1360/250x167/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68916907/akrales_190429_3371_0104.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/kKTWpk8vBnu6kSFVj-0UglATyzk=/0x0:2040x1360/500x333/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68916907/akrales_190429_3371_0104.0.jpg 500w"
+                              sizes="250px" alt="" data-upload-width="2040"
+                              src="https://cdn.vox-cdn.com/thumbor/0vm1Z3zkQTW80qU1JrDNFATKJss=/0x0:2040x1360/1200x800/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68916907/akrales_190429_3371_0104.0.jpg">
+
+
+                            <script type="text/template-dynamic" style="display: none">
+
+<img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1615216180_1545_46134" data-cdata='{"image_id":68916907,"ratio":"standard"}'>
+<noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/68916907/akrales_190429_3371_0104.0.jpg"></noscript>
+
+</script>
+                          </picture>
+
+
+                        </div>
+
+                        <span class="c-rock-list__item--body">
+
+                          <span data-chorus-optimize-field="hed">Get a refurbished Oculus Quest with a one-year warranty
+                            for under $200 today</span>
+
+                          <span class="c-rock-list__entry-blurb">Plus, grab an unlocked Google Pixel 3 XL for
+                            $280</span>
+
+                        </span>
+                      </a>
+
+
+                    </li>
+
+
+                    <li class="c-rock-list__item" data-analytics-placement="sidebar:4">
+
+                      <a href="https://www.theverge.com/good-deals/2021/3/4/22313178/microsoft-surface-headphones-macbook-pro-m1-fire-tv-cube-deal"
+                        class="c-rock-list__link" data-analytics-link="hubpage-good-deals"
+                        data-analytics-viewport="hubpage-good-deals" data-chorus-optimize-id="22077219"
+                        data-chorus-optimize-module="entry-list">
+
+                        <div class="c-rock-list__image">
+
+                          <picture class="c-picture" data-chorus-optimize-field="main_image"
+                            data-cid="site/picture_element-1615216180_1624_46137"
+                            data-cdata="{&quot;image_id&quot;:68910763,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+
+
+
+
+                            <source
+                              srcset="https://cdn.vox-cdn.com/thumbor/EyRGK5nMLWZhQfQ3Ku2N8_If9JI=/0x0:2040x1360/250x167/filters:focal(857x517:1183x843):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68910763/jbareham_181114_3083_0085.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/JBRLjg1lxDnEa6A0Owjor7RQTw0=/0x0:2040x1360/500x333/filters:focal(857x517:1183x843):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68910763/jbareham_181114_3083_0085.0.jpg 500w"
+                              sizes="250px" type="image/webp">
+
+
+                            <img
+                              srcset="https://cdn.vox-cdn.com/thumbor/rtwc-L1_WpELFen7E0MTKPOBj0E=/0x0:2040x1360/250x167/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68910763/jbareham_181114_3083_0085.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/NqJrnDeO-1UlYNGCZ58EMiUO0pw=/0x0:2040x1360/500x333/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68910763/jbareham_181114_3083_0085.0.jpg 500w"
+                              sizes="250px" alt="" data-upload-width="2040"
+                              src="https://cdn.vox-cdn.com/thumbor/qGBC_9eYY_y__uGaJAUBuzpFPDc=/0x0:2040x1360/1200x800/filters:focal(857x517:1183x843)/cdn.vox-cdn.com/uploads/chorus_image/image/68910763/jbareham_181114_3083_0085.0.jpg">
+
+
+                            <script type="text/template-dynamic" style="display: none">
+
+<img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1615216180_1074_46136" data-cdata='{"image_id":68910763,"ratio":"standard"}'>
+<noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/68910763/jbareham_181114_3083_0085.0.jpg"></noscript>
+
+</script>
+                          </picture>
+
+
+                        </div>
+
+                        <span class="c-rock-list__item--body">
+
+                          <span data-chorus-optimize-field="hed">Microsoft’s first-gen Surface Headphones are down to
+                            their lowest price yet</span>
+
+                          <span class="c-rock-list__entry-blurb">Plus, a 44mm Apple Watch Series 6 is $380 at
+                            Amazon</span>
+
+                        </span>
+                      </a>
+
+
+                    </li>
+
+
+                    <li class="c-rock-list__item" data-analytics-placement="sidebar:5">
+
+                      <a href="https://www.theverge.com/good-deals/2021/3/3/22310975/western-digital-portable-ssd-usb-c-tony-hawk-pro-skater-ps5-deal-sale"
+                        class="c-rock-list__link" data-analytics-link="hubpage-good-deals"
+                        data-analytics-viewport="hubpage-good-deals" data-chorus-optimize-id="22075016"
+                        data-chorus-optimize-module="entry-list">
+
+                        <div class="c-rock-list__image">
+
+                          <picture class="c-picture" data-chorus-optimize-field="main_image"
+                            data-cid="site/picture_element-1615216180_5734_46139"
+                            data-cdata="{&quot;image_id&quot;:68903201,&quot;ratio&quot;:&quot;standard&quot;,&quot;dynamic_type&quot;:&quot;picture&quot;,&quot;lazy&quot;:true}">
+
+
+
+
+                            <source
+                              srcset="https://cdn.vox-cdn.com/thumbor/PNva1xmvCXM9ptiZfwVD2vBTaL8=/0x0:4128x2752/250x167/filters:focal(1562x1160:2222x1820):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68903201/en_us_WD_MyPassportSSD_ProdIMG_Computer_Plugin_HR.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/5fKcc8RV7wagfJJBEgJCGeiMi6c=/0x0:4128x2752/500x333/filters:focal(1562x1160:2222x1820):format(webp)/cdn.vox-cdn.com/uploads/chorus_image/image/68903201/en_us_WD_MyPassportSSD_ProdIMG_Computer_Plugin_HR.0.jpg 500w"
+                              sizes="250px" type="image/webp">
+
+
+                            <img
+                              srcset="https://cdn.vox-cdn.com/thumbor/zQvSrBCg952mNR6YFNmqB-r-x6I=/0x0:4128x2752/250x167/filters:focal(1562x1160:2222x1820)/cdn.vox-cdn.com/uploads/chorus_image/image/68903201/en_us_WD_MyPassportSSD_ProdIMG_Computer_Plugin_HR.0.jpg 250w, https://cdn.vox-cdn.com/thumbor/OsgBZQpxiOcgZ00EmfpZeGzP4mE=/0x0:4128x2752/500x333/filters:focal(1562x1160:2222x1820)/cdn.vox-cdn.com/uploads/chorus_image/image/68903201/en_us_WD_MyPassportSSD_ProdIMG_Computer_Plugin_HR.0.jpg 500w"
+                              sizes="250px" alt="" data-upload-width="4128"
+                              src="https://cdn.vox-cdn.com/thumbor/wnLQcDMXHaJZ8G76cVNU4TtcUqk=/0x0:4128x2752/1200x800/filters:focal(1562x1160:2222x1820)/cdn.vox-cdn.com/uploads/chorus_image/image/68903201/en_us_WD_MyPassportSSD_ProdIMG_Computer_Plugin_HR.0.jpg">
+
+
+                            <script type="text/template-dynamic" style="display: none">
+
+<img class="c-dynamic-image " alt="" data-chorus-optimize-field="main_image" src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" data-cid="site/dynamic_size_image-1615216180_7874_46138" data-cdata='{"image_id":68903201,"ratio":"standard"}'>
+<noscript><img alt="" src="https://cdn.vox-cdn.com/uploads/chorus_image/image/68903201/en_us_WD_MyPassportSSD_ProdIMG_Computer_Plugin_HR.0.jpg"></noscript>
+
+</script>
+                          </picture>
+
+
+                        </div>
+
+                        <span class="c-rock-list__item--body">
+
+                          <span data-chorus-optimize-field="hed">Western Digital’s fast 1TB portable SSD costs less than
+                            usual today</span>
+
+                          <span class="c-rock-list__entry-blurb">Ideal for your PC or game console</span>
+
+                        </span>
+                      </a>
+
+
+                    </li>
+
+                  </ol>
+                  <div>
+                    <div class="m-native_ad_unit dynamic-native-ad-native_ad_latest"></div>
+                  </div>
+
+                </div>
+
+                <div class="c-rock-list__cta">
+                  <a class="c-rock-list__more" href="/good-deals">More in Verge Deals</a>
+                </div>
+
+              </aside>
+
+
+            </div>
+            <div class="u-desktop-only">
+              <div class="c-newsletter_signup_box c-newsletter_signup_box--breaker" id="newsletter-signup-short-form"
+                data-newsletter-slug="processor">
+                <div class="c-newsletter_signup_box__main">
+
+                  <span class="c-newsletter_signup_box__icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54.47 53.1">
+                      <line fill="#ffffff" stroke-miterlimit="10" stroke-width="5px" stroke="#000000" x1="1.77"
+                        y1="49.98" x2="27.93" y2="23.82"></line>
+                      <line fill="#ffffff" stroke-miterlimit="10" stroke-width="5px" stroke="#000000" x1="33.82"
+                        y1="17.93" x2="49.43" y2="2.32"></line>
+                      <line fill="#ffffff" stroke-miterlimit="10" stroke-width="5px" stroke="#ff7f00" x1="10.32"
+                        y1="41.43" x2="21.32" y2="30.43"></line>
+                      <line fill="#ffffff" stroke-miterlimit="10" stroke-width="5px" stroke="#000000" x1="2.42"
+                        y1="21.87" x2="22.31" y2="1.76"></line>
+                      <line fill="#ffffff" stroke-miterlimit="10" stroke-width="5px" stroke="#000000" x1="27.97"
+                        y1="51.33" x2="41.2" y2="38.1"></line>
+                      <line fill="#ffffff" stroke-miterlimit="10" stroke-width="5px" stroke="#ff7f00" x1="46.47"
+                        y1="32.83" x2="52.7" y2="26.6"></line>
+                    </svg>
+                  </span>
+
+                  <h2 class="c-newsletter_signup_box__title">
+                    <span class="sr-only">
+                      Sign up for the
+
+                      newsletter
+
+                    </span>
+                    Processor
+                  </h2>
+
+                  <p class="c-newsletter_signup_box__blurb">A newsletter about computers</p>
+
+                  <form action="https://voxmedia.createsend.com/t/d/s/btyjik/" method="post" id="subForm"
+                    data-analytics-class="newsletter"
+                    class="c-newsletter_signup_box--form c-newsletter_signup_box--form__1"
+                    data-analytics-placement="sidebar" data-cid="site/newsletter_signup_form-1615219071_4441_2180"
+                    data-cdata="{}">
+
+                    <input id="field_source" name="source"
+                      value="Presto::Site::NewsletterSignupBox__/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+                      type="hidden">
+
+                    <input id="field_cm-f-buydlt" name="cm-f-buydlt" value="0" type="hidden">
+
+
+                    <div class="c-newsletter_signup_box--form__body">
+
+                      <div class="c-newsletter_signup_box--form__field">
+                        <label for="field_email" class="c-newsletter_signup_box--form__email">
+
+                          <span>Email <strong
+                              class="c-newsletter_signup_box--form__required-field">(required)</strong></span>
+
+
+                        </label>
+                        <div class="c-newsletter_signup_box--form__input">
+                          <input id="field_email" class="p-text-input" name="email" type="email" required=""
+                            placeholder="">
+                        </div>
+                      </div>
+
+
+
+                      <div class="c-newsletter_signup_box--form__disclaimer">
+                        By signing up, you agree to our <a href="https://www.voxmedia.com/legal/privacy-notice">Privacy
+                          Notice</a> and European users agree to the data transfer policy.
+
+                      </div>
+
+                      <button type="submit" class="p-button">Subscribe</button>
+                    </div>
+                  </form>
+
+
+                </div>
+              </div>
+
+            </div>
+
+
+          </div>
         </div>
-      
-      
-      
-    </a>
-  
-  <div class="c-entry-box--compact__body">
-    
-    
-    
-    <h2 class="c-entry-box--compact__title"><a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.theverge.com/circuitbreaker/2018/1/23/16922426/acer-chromebook-spin-11-chromebox-cxi3-announcement-specs-price">Acer announces $349 Chromebook Spin 11 with 360-degree hinge and USB-C</a></h2>
-    
-    
-      
-        <div class="c-byline" data-cid="site/byline-1516700709_5413_61308" data-cdata='{"timestamp":null}'>
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/Sam%20Byford">Sam Byford</a>
-      
-    </span>
-    
-    
-    
-    
-  
-  
-    <span class="c-byline__item">
-      <div class="c-entry-stat--words" data-cid="site/entry_stat-1516700709_7489_61306" data-cdata='{"id":16686467,"comment_count":1,"recommended_count":0,"url":"https://www.theverge.com/circuitbreaker/2018/1/23/16922426/acer-chromebook-spin-11-chromebox-cxi3-announcement-specs-price"}'>
-  <a href="https://www.theverge.com/circuitbreaker/2018/1/23/16922426/acer-chromebook-spin-11-chromebox-cxi3-announcement-specs-price#comments" data-ui="comment">
-    <span data-ui="comment-data">1</span>
-    <span class="c-entry-stat--words__word">comment</span>
-    <span class="c-entry-stat--words__unread" data-ui="unread">
-      / <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
-      <span class="c-entry-stat--words__word">new</span>
-    </span>
-  </a>
-</div>
 
-    </span>
-  
-  
-  <a data-entry-admin="16686467" data-cid="tools/entry_admin_button-1516700709_4487_61307" data-cdata='{"id":16686467}'></a>
 
-</div>
-
-      
-    
-    
-    
-
-    
-    
-  </div>
-
-  
-
-  
-</div>
-
-    </div>
-    
-    <div class="c-compact-river__entry ">
-      <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="16686421" data-chorus-optimize-module="entry-box" >
-  
-    <a href="https://www.theverge.com/2018/1/23/16922380/facebook-esl-one-dota-2-csgo-exclusive-live-streaming" class="c-entry-box--compact__image-wrapper"  data-analytics-link="article:image">
-      
-        <div class="c-entry-box--compact__image">
-          
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_3552_61309" data-cdata='{"image_id":58420611,"ratio":"*"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58420611/3.0.png" alt=""></noscript>
-
-        </div>
-      
-      
-      
-    </a>
-  
-  <div class="c-entry-box--compact__body">
-    
-    
-    
-    <h2 class="c-entry-box--compact__title"><a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.theverge.com/2018/1/23/16922380/facebook-esl-one-dota-2-csgo-exclusive-live-streaming">Facebook’s new game streaming exclusive is a direct challenge to Twitch and YouTube</a></h2>
-    
-    
-      
-        <div class="c-byline" data-cid="site/byline-1516700709_8554_61312" data-cdata='{"timestamp":null}'>
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/vladsavov">Vlad Savov</a>
-      
-    </span>
-    
-    
-    
-    
-  
-  
-    <span class="c-byline__item">
-      <div class="c-entry-stat--words" data-cid="site/entry_stat-1516700709_8086_61310" data-cdata='{"id":16686421,"comment_count":1,"recommended_count":0,"url":"https://www.theverge.com/2018/1/23/16922380/facebook-esl-one-dota-2-csgo-exclusive-live-streaming"}'>
-  <a href="https://www.theverge.com/2018/1/23/16922380/facebook-esl-one-dota-2-csgo-exclusive-live-streaming#comments" data-ui="comment">
-    <span data-ui="comment-data">1</span>
-    <span class="c-entry-stat--words__word">comment</span>
-    <span class="c-entry-stat--words__unread" data-ui="unread">
-      / <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
-      <span class="c-entry-stat--words__word">new</span>
-    </span>
-  </a>
-</div>
-
-    </span>
-  
-  
-  <a data-entry-admin="16686421" data-cid="tools/entry_admin_button-1516700709_8500_61311" data-cdata='{"id":16686421}'></a>
-
-</div>
-
-      
-    
-    
-    
-
-    
-    
-  </div>
-
-  
-
-  
-</div>
-
-    </div>
-    
-    <div class="c-compact-river__entry ">
-      <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="16685815" data-chorus-optimize-module="entry-box" >
-  
-    <a href="https://www.theverge.com/2018/1/22/16921774/air-force-spacex-zuma-satellite-disappearance-northrop-grumman" class="c-entry-box--compact__image-wrapper"  data-analytics-link="article:image">
-      
-        <div class="c-entry-box--compact__image">
-          
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_92_61313" data-cdata='{"image_id":58418523,"ratio":"*"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58418523/39585575631_216cc035f4_o.0.0.jpg" alt=""></noscript>
-
-        </div>
-      
-      
-      
-    </a>
-  
-  <div class="c-entry-box--compact__body">
-    
-    
-    
-    <h2 class="c-entry-box--compact__title"><a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.theverge.com/2018/1/22/16921774/air-force-spacex-zuma-satellite-disappearance-northrop-grumman">The Air Force is sticking by SpaceX after the Zuma mission</a></h2>
-    
-    
-      
-        <div class="c-byline" data-cid="site/byline-1516700709_9128_61315" data-cdata='{"timestamp":null}'>
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/RachelBecker">Rachel Becker</a>
-      
-    </span>
-    
-    
-    
-    
-  
-  
-  
-  <a data-entry-admin="16685815" data-cid="tools/entry_admin_button-1516700709_4256_61314" data-cdata='{"id":16685815}'></a>
-
-</div>
-
-      
-    
-    
-    
-
-    
-    
-  </div>
-
-  
-
-  
-</div>
-
-    </div>
-    
-    <div class="c-compact-river__entry ">
-      <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="16685491" data-chorus-optimize-module="entry-box" >
-  
-    <a href="https://www.theverge.com/2018/1/22/16921450/trump-tariffs-solar-cells-panels-jobs-clean-energy-imports-china-suniva-solarworld" class="c-entry-box--compact__image-wrapper"  data-analytics-link="article:image">
-      
-        <div class="c-entry-box--compact__image">
-          
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_291_61316" data-cdata='{"image_id":58417695,"ratio":"*"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58417695/shutterstock_1006818448.0.jpg" alt=""></noscript>
-
-        </div>
-      
-      
-      
-    </a>
-  
-  <div class="c-entry-box--compact__body">
-    
-    
-    
-    <h2 class="c-entry-box--compact__title"><a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.theverge.com/2018/1/22/16921450/trump-tariffs-solar-cells-panels-jobs-clean-energy-imports-china-suniva-solarworld">Trump’s latest blow to clean energy is a tariff on solar panels</a></h2>
-    
-    
-      
-        <div class="c-byline" data-cid="site/byline-1516700709_4038_61319" data-cdata='{"timestamp":null}'>
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/RachelBecker">Rachel Becker</a>
-      
-    </span>
-    
-    
-    
-    
-  
-  
-    <span class="c-byline__item">
-      <div class="c-entry-stat--words" data-cid="site/entry_stat-1516700709_8771_61317" data-cdata='{"id":16685491,"comment_count":34,"recommended_count":0,"url":"https://www.theverge.com/2018/1/22/16921450/trump-tariffs-solar-cells-panels-jobs-clean-energy-imports-china-suniva-solarworld"}'>
-  <a href="https://www.theverge.com/2018/1/22/16921450/trump-tariffs-solar-cells-panels-jobs-clean-energy-imports-china-suniva-solarworld#comments" data-ui="comment">
-    <span data-ui="comment-data">34</span>
-    <span class="c-entry-stat--words__word">comments</span>
-    <span class="c-entry-stat--words__unread" data-ui="unread">
-      / <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
-      <span class="c-entry-stat--words__word">new</span>
-    </span>
-  </a>
-</div>
-
-    </span>
-  
-  
-  <a data-entry-admin="16685491" data-cid="tools/entry_admin_button-1516700709_3792_61318" data-cdata='{"id":16685491}'></a>
-
-</div>
-
-      
-    
-    
-    
-
-    
-    
-  </div>
-
-  
-
-  
-</div>
-
-    </div>
-    
-    <div class="c-compact-river__entry ">
-      <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="16684553" data-chorus-optimize-module="entry-box" >
-  
-    <a href="https://www.theverge.com/2018/1/22/16920512/facebook-democracy-effects-social-media" class="c-entry-box--compact__image-wrapper"  data-analytics-link="article:image">
-      
-        <div class="c-entry-box--compact__image">
-          
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_1669_61320" data-cdata='{"image_id":58417297,"ratio":"*"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58417297/facebook-stock-1099.0.0.jpg" alt=""></noscript>
-
-        </div>
-      
-      
-      
-    </a>
-  
-  <div class="c-entry-box--compact__body">
-    
-    
-    
-    <h2 class="c-entry-box--compact__title"><a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.theverge.com/2018/1/22/16920512/facebook-democracy-effects-social-media">The more Facebook examines itself, the more fault it finds</a></h2>
-    
-    
-      
-        <div class="c-byline" data-cid="site/byline-1516700709_4338_61323" data-cdata='{"timestamp":null}'>
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/CaseyNewton">Casey Newton</a>
-      
-    </span>
-    
-    
-    
-    
-  
-  
-    <span class="c-byline__item">
-      <div class="c-entry-stat--words" data-cid="site/entry_stat-1516700709_9254_61321" data-cdata='{"id":16684553,"comment_count":3,"recommended_count":0,"url":"https://www.theverge.com/2018/1/22/16920512/facebook-democracy-effects-social-media"}'>
-  <a href="https://www.theverge.com/2018/1/22/16920512/facebook-democracy-effects-social-media#comments" data-ui="comment">
-    <span data-ui="comment-data">3</span>
-    <span class="c-entry-stat--words__word">comments</span>
-    <span class="c-entry-stat--words__unread" data-ui="unread">
-      / <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
-      <span class="c-entry-stat--words__word">new</span>
-    </span>
-  </a>
-</div>
-
-    </span>
-  
-  
-  <a data-entry-admin="16684553" data-cid="tools/entry_admin_button-1516700709_5190_61322" data-cdata='{"id":16684553}'></a>
-
-</div>
-
-      
-    
-    
-    
-
-    
-    
-  </div>
-
-  
-
-  
-</div>
-
-    </div>
-    
-    <div class="c-compact-river__entry ">
-      <div class="c-entry-box--compact c-entry-box--compact--article" data-chorus-optimize-id="16685143" data-chorus-optimize-module="entry-box" >
-  
-    <a href="https://www.theverge.com/2018/1/22/16921102/google-breaks-amazon-fire-tv-youtube-workaround" class="c-entry-box--compact__image-wrapper"  data-analytics-link="article:image">
-      
-        <div class="c-entry-box--compact__image">
-          
-<img class="c-dynamic-image " src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs" alt="" data-chorus-optimize-field="main_image" data-cid="site/dynamic_size_image-1516700709_1232_61324" data-cdata='{"image_id":58416207,"ratio":"*"}'>
-<noscript><img src="https://cdn.vox-cdn.com/uploads/chorus_image/image/58416207/verge_example.0.gif" alt=""></noscript>
-
-        </div>
-      
-      
-      
-    </a>
-  
-  <div class="c-entry-box--compact__body">
-    
-    
-    
-    <h2 class="c-entry-box--compact__title"><a data-chorus-optimize-field="hed" data-analytics-link="article" href="https://www.theverge.com/2018/1/22/16921102/google-breaks-amazon-fire-tv-youtube-workaround">Google briefly broke Amazon’s workaround for YouTube on Fire TV</a></h2>
-    
-    
-      
-        <div class="c-byline" data-cid="site/byline-1516700709_5658_61327" data-cdata='{"timestamp":null}'>
-  
-    By
-    <span class="c-byline__item">
-      
-        
-        <a href="https://www.theverge.com/users/ChrisWelch">Chris Welch</a>
-      
-    </span>
-    
-    
-    
-    
-  
-  
-    <span class="c-byline__item">
-      <div class="c-entry-stat--words" data-cid="site/entry_stat-1516700709_207_61325" data-cdata='{"id":16685143,"comment_count":53,"recommended_count":0,"url":"https://www.theverge.com/2018/1/22/16921102/google-breaks-amazon-fire-tv-youtube-workaround"}'>
-  <a href="https://www.theverge.com/2018/1/22/16921102/google-breaks-amazon-fire-tv-youtube-workaround#comments" data-ui="comment">
-    <span data-ui="comment-data">53</span>
-    <span class="c-entry-stat--words__word">comments</span>
-    <span class="c-entry-stat--words__unread" data-ui="unread">
-      / <span class="c-entry-stat__comment-data" data-ui="unread-data"></span>
-      <span class="c-entry-stat--words__word">new</span>
-    </span>
-  </a>
-</div>
-
-    </span>
-  
-  
-  <a data-entry-admin="16685143" data-cid="tools/entry_admin_button-1516700709_6039_61326" data-cdata='{"id":16685143}'></a>
-
-</div>
-
-      
-    
-    
-    
-
-    
-    
-  </div>
-
-  
-
-  
-</div>
-
-    </div>
-    
-  
-  <div data-cid="site/entry_sponsorship/native_ad-Hp3gwyU8tcjCSUTkI+1MWA==">
-  <div class="m-native_ad_unit dynamic-native-ad-native_ad_ymal_link"></div>
-</div>
-
-</div>
-
-
-  </div>
-    <div class="l-col__sidebar" id="comments-sidebar" data-analytics-placement="sidebar">
-      
-    </div>
-</div>
-
-  </section>
-</section>
-
-
-
-    <footer class="c-footer" role="contentinfo">
-  <div class="l-wrapper c-footer__wrapper">
-    <div class="c-footer__section c-footer__section-logo">
-      <a rel="nofollow" href="/" class="c-footer__logo-link">
-        
-          
-  <svg fill="#fff" xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2"><path d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3"/><path d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24"/></svg>
-
-
-        
-        <span class="u-hidden-text">Chorus</span>
-      </a>
-    </div>
-
-    <div class="c-footer__section c-footer__section-links">
-      <ul class="u-list-dot-sep">
-        
-          <li><a rel="nofollow" href="https://www.voxmedia.com/terms-of-use">Terms of Use</a></li>
-        
-          <li><a rel="nofollow" href="https://www.voxmedia.com/privacy-policy">Privacy Policy</a></li>
-        
-          <li><a rel="nofollow" href="https://www.voxmedia.com/communications-preferences">Communications Preferences</a></li>
-        
-      </ul>
-      <ul class="u-list-dot-sep">
-        
-          <li><a rel="nofollow" href="/contact-the-verge">Contact</a></li>
-        
-          <li><a rel="nofollow" href="https://apps.voxmedia.com/verge-tips/">Tip Us</a></li>
-        
-          <li><a rel="nofollow" href="/community-guidelines">Community Guidelines</a></li>
-        
-          <li><a rel="nofollow" href="/about-the-verge">About</a></li>
-        
-          <li><a rel="nofollow" href="/ethics-statement">Ethics Statement</a></li>
-        
-      </ul>
-
-      
-
-      <div class="c-footer__status">
-        <span id="status_io" class="m-footer__bottom__status">
-  All Systems Operational
-  <a href="http://status.voxmedia.com" rel="nofollow" target="_blank">Check out our status page for more details.</a>
-</span>
-
-      </div>
-    </div>
-
-    <div class="c-footer__section c-footer__section-vox">
-      <a rel="nofollow" class="u-block" href="http://www.voxmedia.com"><span class="u-hidden-text">Vox Media</span><svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewbox="-147 464.2 484 79.5" class="c-footer__vox-logo"><g><path fill="#4E4E50" class="vox-media-logo-text" d="M-133.2 498l9.9 29 6.4-19.2c1.1-3.3 2.1-6.6 3-9.4h13.3l-13.2 32.4c-2.1 5.3-3.4 8.4-4.6 12l-10 .6-13.2-32c-1.6-4-3.6-9-5.4-12.9l13.8-.5zm38.8 23.6c0-14 9.3-24.4 23.2-24.4 13.3 0 22.1 9.8 22.1 22.1 0 14-9.4 24.4-23.2 24.4-13.4.1-22.1-9.8-22.1-22.1zm33-.9c0-8.4-4.3-13.6-10.3-13.6-6.4 0-10.5 6-10.5 13.2 0 8.4 4.3 13.6 10.3 13.6 6.4 0 10.5-6 10.5-13.2zm19.2 21.9l15.3-22.7-6-8.8-8.6-12.7 13.9-.5 9.1 14.2 3.1-5.3c1.6-2.6 3.8-6.1 5.4-8.6H3.7l-14.6 21.9 5.4 7.9c2.5 3.8 6.8 10.3 9.6 14.4l-14 .5-9.3-15.1-2.9 4.7c-1.4 2.3-4.4 7.2-6.1 9.8h-14v.3zm79.4-15.2l1.9-13.9c.6-4 1.6-12 1.8-15.3l9.6-.4c1.1 2.5 2.7 6.1 4 8.9l8.2 18.2 8-18.5c1.2-2.7 2.6-6 3.7-8.5h9.3c.4 3.7 1.4 11.5 2 15.6l2 13.9c.6 4.1 1.8 11.9 2.5 15.2l-12.4.5c-.1-1.8-.7-7.1-1.1-9.6l-1.8-14c-3.1 7.7-8.6 21.4-9.4 23.6l-6.6.3-9.5-23.3-1.5 13.5c-.3 2.5-.8 7.3-.8 9.1H34.7c.7-3.3 1.9-11.2 2.5-15.3zm96.1 15.5c-4.2-.3-9.3-.3-14.2-.3-5.5 0-11.5.1-16.2.3.3-3 .4-11.3.4-15.4v-14c0-4-.1-12.5-.4-15.6 4.6.2 9.6.3 15.3.3 5.2 0 10-.1 14.3-.3-.3 3.1-.5 6.2-.5 10-3.2-.1-6.4-.1-10.3-.1-1.9 0-4 0-5.8.1-.1.9-.1 2.2-.1 2.8v4.9l13.7-.1c-.1 2.6-.2 5.5-.2 8.8h-13.5v5.7c0 .7 0 2 .1 2.9 1.8 0 3.9.1 5.8.1 4.5 0 8.3-.1 12-.2-.2 3.2-.4 6.2-.4 10.1zm30-.3h-16.6c.3-3 .4-11.1.4-15.2v-13.9c0-4-.1-12-.4-15.1 2.3 0 7.9-.4 14.9-.4 16.7 0 26 8 26 21.5 0 14.2-9.5 23.1-24.3 23.1zm-.2-35c-1.3 0-2.1.1-3.1.2-.1.8-.1 2.1-.1 2.8v19.6c0 .8 0 1.7.1 2.6 1 .1 1.8.2 3.3.2 8.4 0 12-5.5 12-13-.1-7.9-4.7-12.4-12.2-12.4zm37.2 35c.3-3 .4-11.1.4-15.2v-13.9c0-4-.1-12.2-.4-15.2 2.5 0 11.3-.1 13.4-.3-.2 1.8-.3 6.9-.3 9.3v26.2c0 2.4.1 7.3.3 9.1h-13.4zm38.1-32.2c2.2-5.2 3.7-8.5 4.9-12l10.1-.6 13.8 32c1.6 3.9 4 9 5.8 12.9l-13.4.5-3.4-8.4h-15.4c-.8 2.1-2.6 7.1-3 7.9h-13.1l13.7-32.3zm4.9 16.5h10.1l-5.1-13.7-5 13.7z"></path><path fill="#F6A01A" d="M337 464.2V498l-30-16.9 30-16.9z"></path><path fill="#FBE346" d="M276.9 464.2V498l30.1-16.9-30.1-16.9z"></path><path fill="#F47B20" d="M307 481.1V515l30-17-30-16.9z"></path><path fill="#F8CC15" d="M307 481.1V515l-30.1-17 30.1-16.9z"></path></g></svg></a>
-      
-        <a rel="nofollow" class="u-block c-footer__corporate-link" href="https://www.voxmedia.com/vox-advertising">Advertise with us</a>
-      
-        <a rel="nofollow" class="u-block c-footer__corporate-link" href="https://jobs.voxmedia.com">Jobs @ Vox Media</a>
-      
-      &copy; 2018 <a rel="nofollow" href="http://www.voxmedia.com">Vox Media</a>, Inc. All Rights Reserved
-      
-      
-    </div>
-  </div>
-</footer>
-
-    <div class="c-tab-bar " data-cid="site/tab_bar/index-1516700709_8582_61329" data-cdata="{}">
-  <a href="/" class="c-tab-bar__logo">
-    
-      
-  <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 291.4 1280 217.2"><path d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3"></path><path d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24"></path></svg>
-
-
-    
-    
-  </a>
-  <ul class="c-social-buttons " data-analytics-placement="sticky" data-cid="site/social_buttons_list-1516700709_696_61328" data-cdata='{"entry_id":16685133,"services":["twitter","facebook"],"base_url":"https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"}'>
-  
-  
-    <li class="c-social-buttons__item">
-      <a class="c-social-buttons__item-link c-social-buttons__twitter" href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;via=Verge" data-analytics-social="twitter">
-        <svg class="p-svg-icon c-social-buttons__svg"><use xlink:href="#icon-twitter"></use></svg>
-        <span class="c-social-buttons__text">
-          tweet
-        </span>
-      </a>
-    </li>
-  
-    <li class="c-social-buttons__item">
-      <a class="c-social-buttons__item-link c-social-buttons__facebook" href="https://www.facebook.com/sharer/sharer.php?text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;u=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model" data-analytics-social="facebook">
-        <svg class="p-svg-icon c-social-buttons__svg"><use xlink:href="#icon-facebook"></use></svg>
-        <span class="c-social-buttons__text">
-          share
-        </span>
-      </a>
-    </li>
-  
-  
-</ul>
-
-  <span class="c-tab-bar__sponsorship"></span>
-  
-</div>
-
-  </div>
-
-    <script src="https://cdn.vox-cdn.com/javascripts/unison_body.v0a5a23e7b4e0e6c2.js"></script>
-      <script src="https://cdn.vox-cdn.com/presto/chorus.b2354601d5ac9f15bd38.js"></script>
-  
-
-      <!-- Phonograph -->
-  <script src="https://phonograph2.voxmedia.com/pickup.js" async="async" defer="defer"></script>
-  <script>
-//<![CDATA[
-
-          var phonographEvents = phonographEvents || [];
-          if (window.dataLayer && window.Context) {
-            Context.fetch().then(function() {
-              var data = {'Page Title': document.title, 'GA Track Prefix': 't1.', 'User ID': Context.currentUser.get('id') || null};
-              for (var i=0; i < dataLayer.length; i++) {
-                if (dataLayer[i]['Network']) {
-                  Object.keys(dataLayer[i]).forEach(function(k) { data[k] = dataLayer[i][k]; });
-                  break;
-                }
+        <div class="l-segment outbrain-container">
+          <div class="OUTBRAIN"
+            data-src="https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+            data-widget-id="AR_2" data-ob-template="TheVerge_1">
+            <script type="text/javascript" src="https://widgets.outbrain.com/outbrain.js" async="async"></script>
+          </div>
+
+          <script type="text/javascript" charset="utf-8">
+            (function () {
+              // load outbrain js
+              function loadOutbrain() {
+                var ref = document.querySelector("div.OUTBRAIN");
+
+                var script = document.createElement('script');
+                script.setAttribute('type', 'text/javascript');
+                script.setAttribute('src', 'https://widgets.outbrain.com/outbrain.js');
+                script.setAttribute('async', 'async');
+
+                ref.appendChild(script);
               }
-              phonographEvents.push(['pageload', data]);
-            });
-          } else {
-            phonographEvents.push(['pageload', {'Page Title': document.title}]);
-          }
-        
-//]]>
-</script>
+
+              // Disable on mobile and tablet screens
+              // 880px is the upper bound for the `medium` breakpoint defined in UserAgent JS lib.
+              var shouldDisable = false && screen.width <= 880;
+              var scrollSubscriber = document.cookie.indexOf("scroll0=") > -1;
+              var hymnalPreviewContent = !!(window.location.href.indexOf("concert_preview") > -1);
+
+              if (!shouldDisable && !scrollSubscriber && !hymnalPreviewContent) {
+                // first, set a timeout to loadOutbrain, in case no ads load in 5s
+                // (i.e., blocked). once an ad has loaded, create a new timeout that
+                // will load outbrain if openmic doesn't get loaded in 2s
+                //
+                var adBlockerTimeoutId = setTimeout(loadOutbrain, 5000);
+                document.body.addEventListener('first_ad_rendered', function () {
+                  clearTimeout(adBlockerTimeoutId);
+                  var outbrainTimeoutId = setTimeout(loadOutbrain, 2000);
+                  document.body.addEventListener('playlistRendered', function () {
+                    clearTimeout(outbrainTimeoutId);
+                  });
+                });
+              }
+            })();
+          </script>
+
+        </div>
+
+        <div class="l-sidebar-fixed l-segment">
+          <div class="l-col__main">
+            <svg width="0" height="0" style="position:absolute;display:none;">
+              <symbol viewBox="236.9 122.4 318.2 367.2" id="icon-bold" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M236.9 422.3h39.8V189.7h-39.8v-67.3h171.4c27.5 0 45.9 0 67.3 9.2 39.8 12.2 64.3 45.9 64.3 88.7 0 30.6-15.3 61.2-42.8 79.6 42.8 12.2 58.1 49 58.1 85.7 0 55.1-39.8 91.8-82.6 104H236.9v-67.3zm177.5-159.1c21.4 0 33.7-15.3 33.7-36.7 0-12.2-6.1-27.5-18.4-30.6-6.1-3.1-12.2-3.1-21.4-3.1h-36.7v70.4h42.8zm9.1 156c6.1 0 12.2 0 18.4-3.1 15.3-6.1 21.4-24.5 21.4-39.8 0-21.4-12.2-36.7-39.8-36.7h-52v82.6h52v-3z">
+                </path>
+              </symbol>
+              <symbol viewBox="0 0 95.46 95.46" id="icon-comment-flair" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M81.48 33.75V14H61.71l-14-14-14 14H14v19.75l-14 14 14 14v19.73h19.75l14 14 14-14h19.73V61.71l14-14zM49.16 58l-7.24 7.24L34.68 58l-9-9 7.24-7.24 9 9 20.63-20.59 7.24 7.24z">
+                </path>
+              </symbol>
+              <symbol viewBox="191 101 410.1 410.1" id="icon-emoji" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M396 101c-113.2 0-205 91.9-205 205s91.9 205 205 205 205-91.9 205-205c0-112.6-91.8-205-205-205zm0 361.8c-86.2 0-156.8-70-156.8-156.8 0-86.2 70-156.8 156.8-156.8 86.2 0 156.8 70 156.8 156.8-.5 86.8-70.5 156.8-156.8 156.8z">
+                </path>
+                <ellipse cx="346.3" cy="249.7" rx="28.9" ry="39.1"></ellipse>
+                <path
+                  d="M445.7 288.3c15.8 0 28.9-17.2 28.9-39.1 0-21.3-12.7-39.1-28.9-39.1-15.8 0-28.9 17.2-28.9 39.1s12.7 39.1 28.9 39.1zm39.1 50.2c-11.1-7.1-25.9-3.5-32.5 7.6 0 .5-17.2 25.9-56.3 25.9-38.6 0-55.3-24.3-56.3-25.9-7.1-11.1-21.3-14.7-32.5-7.6-11.1 6.6-14.7 21.3-8.1 32.5 1 2.1 29.9 48.2 96.9 48.2 66 0 95.4-46.2 96.9-48.2 6.6-11.2 3.1-25.9-8.1-32.5z">
+                </path>
+              </symbol>
+              <symbol viewBox="0 0 450 324" id="icon-fold" xmlns="http://www.w3.org/2000/svg">
+                <path fill="#231F20" d="M227.3 134.7L95.5 2.9 0 98.4l227.3 222.7L450 98.4 354.5 2.9z"></path>
+              </symbol>
+              <symbol viewBox="151.2 122.4 489.6 367.2" id="icon-image" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M640.8 153v306c0 18.4-12.2 30.6-30.6 30.6H181.8c-18.4 0-30.6-12.2-30.6-30.6V153c0-18.4 12.2-30.6 30.6-30.6h428.4c18.4 0 30.6 12.2 30.6 30.6zM243 244.8c0 33.7 27.5 61.2 61.2 61.2s61.2-27.5 61.2-61.2-27.5-61.2-61.2-61.2-61.2 27.5-61.2 61.2zm214.2 0L344 388.6l-70.4-52-61.2 91.8h367.2L457.2 244.8z">
+                </path>
+              </symbol>
+              <symbol viewBox="334.8 122.4 122.4 367.2" id="icon-italic" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M347 416.2l30.6-149.9h-42.8l9.2-39.8h94.9l-36.7 186.7c0 6.1-3.1 12.2-3.1 15.3 0 18.4 12.2 21.4 24.5 21.4h12.2l-9.2 39.8h-21.4c-24.5 0-58.1-3.1-58.1-49l-.1-24.5zm58.2-293.8h52l-9.2 52h-55.1l12.3-52z">
+                </path>
+              </symbol>
+              <symbol viewBox="212.4 122.4 367.2 367.2" id="icon-link" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M438.8 403.9L380.7 462c-18.4 18.4-42.8 27.5-70.4 27.5s-52-9.2-70.4-27.5c-18.4-21.4-27.5-45.9-27.5-70.4 0-24.5 9.2-52 27.5-70.4l52-52c-3.1 18.4 0 39.8 9.2 58.1l-27.5 24.5c-9.2 9.2-15.3 24.5-15.3 36.7s6.1 27.5 15.3 39.8c9.2 9.2 24.5 15.3 36.7 15.3 15.3 0 27.5-6.1 36.7-15.3l58.1-58.1c9.2-9.2 15.3-24.5 15.3-36.7 0-15.3-6.1-27.5-15.3-36.7-3.1-3.1-6.1-9.2-6.1-15.3s3.1-12.2 6.1-15.3c3.1-3.1 9.2-6.1 15.3-6.1s12.2 3.1 15.3 6.1c18.4 18.4 27.5 42.8 27.5 70.4 6.2 24.5-6 49-24.4 67.3zM549 293.8l-52 52c3.1-18.4 0-39.8-9.2-58.1l30.6-27.5c9.2-9.2 15.3-24.5 15.3-36.7 0-15.3-6.1-27.5-15.3-36.7-9.2-9.2-24.5-15.3-36.7-15.3-15.3 0-27.5 6.1-36.7 15.3l-61.2 55.1c-9.2 9.2-15.3 21.4-15.3 36.7 0 15.3 6.1 27.5 15.3 39.8 3.1 3.1 6.1 9.2 6.1 15.3s-3.1 12.2-6.1 15.3c-3.1 3.1-9.2 6.1-15.3 6.1s-12.2-3.1-15.3-6.1c-18.4-18.4-30.6-42.8-30.6-70.4s9.2-52 27.5-70.4l58.1-55.1c18.4-18.4 42.8-30.6 70.4-30.6s52 9.2 70.4 30.6c18.4 18.4 30.6 42.8 30.6 70.4 0 24.4-9.2 48.8-30.6 70.3z">
+                </path>
+              </symbol>
+              <symbol viewBox="212.4 153 397.8 306" id="icon-list" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M365.4 397.8h244.8v30.6H365.4v-30.6zm0-214.2h244.8v30.6H365.4v-30.6zm-88.7 61.2H243c-18.4 0-30.6-15.3-30.6-30.6v-30.6c0-18.4 12.2-30.6 30.6-30.6h33.7c18.4 0 30.6 12.2 30.6 30.6v30.6c0 15.3-15.3 30.6-30.6 30.6zm0 214.2H243c-18.4 0-30.6-12.2-30.6-30.6v-27.5c0-18.4 12.2-30.6 30.6-30.6h33.7c18.4 0 30.6 12.2 30.6 30.6v27.5c0 18.4-15.3 30.6-30.6 30.6z">
+                </path>
+              </symbol>
+              <symbol viewBox="212.4 122.4 397.8 367.2" id="icon-orderedlist" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M365.4 183.6h244.8v30.6H365.4v-30.6zm0 214.2h244.8v30.6H365.4v-30.6zM215.5 254h36.7v-97.9l-6.1 6.1-18.4 18.4-15.3-18.4 39.8-39.8h24.5V254h36.7v21.4h-97.9V254zM285.8 382.5c0-12.2-9.2-21.4-24.5-21.4-18.4 0-30.6 15.3-30.6 15.3l-15.3-15.3s15.3-24.5 49-24.5c30.6 0 49 18.4 49 42.8 0 49-70.4 52-73.4 88.7h55v-18.4h21.4v39.8h-104v-12.2c0-55 73.4-61.1 73.4-94.8z">
+                </path>
+              </symbol>
+              <symbol viewBox="181.8 122.4 431.5 370.3" id="icon-quote" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M356.2 122.4c-52 0-94.9 18.4-125.5 58.1s-49 88.7-49 153v131.6c0 6.1 3.1 12.2 9.2 18.4 3.1 3.1 9.2 6.1 18.4 6.1h131.6c6.1 0 12.2-3.1 18.4-9.2 3.1-3.1 6.1-9.2 6.1-18.4V358c0-6.1-3.1-12.2-9.2-18.4-6.1-6.1-12.2-9.2-18.4-9.2h-52c0-33.7 6.1-61.2 18.4-82.6 12.2-18.4 30.6-30.6 52-30.6 6.1 0 9.2-3.1 9.2-6.1v-79.6c0-3.1 0-6.1-3.1-6.1 0-3-3-3-6.1-3zM601 220.3c6.1-3.1 9.2-6.1 9.2-9.2v-79.6c0-3.1 0-6.1-3.1-6.1 0-3.1-3.1-3.1-6.1-3.1-52 0-94.9 18.4-125.5 58.1s-49 88.7-49 153V465c0 6.1 3.1 12.2 9.2 18.4 6.1 6.1 12.2 9.2 18.4 9.2h131.6c6.1 0 12.2-3.1 18.4-9.2 6.1-6.1 9.2-12.2 9.2-18.4V361c0-6.1-3.1-12.2-9.2-18.4-6.1-6.1-12.2-9.2-18.4-9.2h-52c0-33.7 6.1-61.2 18.4-82.6 9.1-18.2 27.5-30.5 48.9-30.5z">
+                </path>
+              </symbol>
+              <symbol viewBox="142.3 -19 787.2 792" id="icon-spoiler" xmlns="http://www.w3.org/2000/svg">
+                <path d="M142.3-19h787.2v792H142.3V-19z"></path>
+              </symbol>
+              <symbol viewBox="212.4 122.4 367.2 367.2" id="icon-strikeout" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M579.6 306H212.4v30.6h208.1c24.5 12.2 42.8 27.5 42.8 55.1 0 36.7-30.6 55.1-70.4 55.1-36.7 0-70.4-15.3-70.4-42.8v-27.5h-49v36.7c0 52 61.2 76.5 116.3 76.5 67.3 0 122.4-36.7 122.4-104 0-21.4-6.1-36.7-15.3-49h82.6V306zm-186.7-30.6c-33.7-12.2-61.2-27.5-61.2-61.2s27.5-49 61.2-49c30.6 0 61.2 12.2 61.2 30.6v24.5H500v-39.8c3.1-36.7-52-58.1-104-58.1-61.2 0-116.3 27.5-116.3 94.9 0 24.5 9.2 42.8 21.4 58.1h91.8z">
+                </path>
+              </symbol>
+            </svg>
+            <section id="comments" class="c-comments" data-cid="apps/comment_forum-1615219071_4421_2181"
+              data-cdata="{&quot;entry_id&quot;:16685133}">
+              <div class="c-comments__header">
+                <h4 class="c-comments__message">Loading comments...</h4>
+              </div>
+            </section>
+
+
+
+
+          </div>
+          <div class="l-col__sidebar" id="comments-sidebar" data-analytics-placement="sidebar">
+
+          </div>
+        </div>
+
+      </article>
+    </main>
+
+
+
+
+
+    <footer class="c-footer" role="contentinfo" data-cid="site/global_footer-1615220420_8473_8640" data-cdata="{}">
+      <div class="l-wrapper c-footer__wrapper">
+        <div class="c-footer__section c-footer__section-logo">
+          <a rel="nofollow" href="/" class="c-footer__logo-link">
+
+
+            <svg fill="#fff" xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2">
+              <path
+                d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3">
+              </path>
+              <path
+                d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24">
+              </path>
+            </svg>
+
+
+
+            <span class="u-hidden-text">Chorus</span>
+          </a>
+        </div>
+
+        <div class="c-footer__section c-footer__section-links">
+          <ul class="u-list-dot-sep">
+
+            <li><a rel="nofollow" href="https://www.voxmedia.com/legal/terms-of-use">Terms of Use</a></li>
+
+            <li><a rel="nofollow" href="https://www.voxmedia.com/legal/privacy-notice">Privacy Notice</a></li>
+
+            <li><a rel="nofollow" href="https://www.voxmedia.com/legal/cookie-policy">Cookie Policy</a></li>
+
+            <li><a rel="nofollow" href="/contact#donotsell">Do Not Sell My Personal Info</a></li>
+
+            <li><a rel="nofollow" href="https://www.voxmedia.com/pages/licensing">Licensing FAQ</a></li>
+
+            <li><a rel="nofollow" href="https://www.voxmedia.com/legal/accessibility">Accessibility</a></li>
+
+            <li><a rel="nofollow" href="https://status.voxmedia.com">Platform Status</a></li>
+
+
+          </ul>
+          <ul class="u-list-dot-sep">
+
+            <li><a rel="nofollow" href="/contact-the-verge">Contact</a></li>
+
+            <li><a rel="nofollow" href="https://www.theverge.com/a/tip-us-secure-contact-email">Tip Us</a></li>
+
+            <li><a rel="nofollow" href="/community-guidelines">Community Guidelines</a></li>
+
+            <li><a rel="nofollow" href="/about-the-verge">About</a></li>
+
+            <li><a rel="nofollow" href="/ethics-statement">Ethics Statement</a></li>
+
+          </ul>
+
+
+        </div>
+
+        <div class="c-footer__section c-footer__section-vox">
+          <a rel="nofollow" class="u-block" href="https://www.voxmedia.com"><span class="u-hidden-text">Vox
+              Media</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 254.42 33.54" aria-labelledby="title"
+              aria-describedby="description" role="img" class="c-footer__vox-logo">
+              <title id="title">Vox Media</title>
+              <desc id="description">Vox Media logo.</desc>
+              <path
+                d="M229.88,262.35a16.77,16.77,0,1,0,16.77,16.77,16.77,16.77,0,0,0-16.77-16.77m0,25.08a8.32,8.32,0,1,1,7.92-8.31,8.12,8.12,0,0,1-7.92,8.31"
+                transform="translate(-179.16 -262.35)"></path>
+              <polygon points="0 0.66 16.97 33.38 33.95 0.66 24.05 0.66 17.07 14.31 10.09 0.66 0 0.66"></polygon>
+              <rect x="208.65" y="0.66" width="9" height="32.26"></rect>
+              <polygon
+                points="170.15 8.74 170.15 0.66 145.41 0.66 145.41 32.92 170.15 32.92 170.15 24.84 154.82 24.84 154.82 20.68 169.01 20.68 169.01 12.91 154.82 12.91 154.82 8.74 170.15 8.74">
+              </polygon>
+              <path
+                d="M367.39,263H353.84v32.27h13.55a16.14,16.14,0,1,0,0-32.27m-.71,24.09h-3.74V271.19h3.74a8,8,0,1,1,0,15.91"
+                transform="translate(-179.16 -262.35)"></path>
+              <polygon
+                points="131.07 14.94 131.07 32.92 140.17 32.92 140.17 0.66 128.9 0.66 121.92 14.12 114.94 0.66 103.67 0.66 103.67 32.92 112.57 32.92 112.57 14.94 121.82 32.77 131.07 14.94">
+              </polygon>
+              <polygon
+                points="83.11 24.43 88.78 32.93 99.44 32.93 88.44 16.79 99.34 0.66 88.88 0.66 83.21 9.16 83.31 9.16 77.63 0.66 67.08 0.66 77.98 16.79 66.98 32.93 77.43 32.93 83.11 24.43">
+              </polygon>
+              <path d="M412.55,284.07l4-11.53,4,11.53ZM422,263H411.38l-11.62,32.27h9l1.41-4.15H423l1.4,4.15h9.21Z"
+                transform="translate(-179.16 -262.35)"></path>
+            </svg></a>
+
+
+          <a rel="nofollow" class="u-block c-footer__corporate-link"
+            href="https://www.voxmedia.com/vox-advertising">Advertise with us</a>
+
+          <a rel="nofollow" class="u-block c-footer__corporate-link" href="https://jobs.voxmedia.com">Jobs @ Vox
+            Media</a>
+
+          © 2021 <a rel="nofollow" href="https://www.voxmedia.com">Vox Media</a>, LLC. All Rights Reserved
+
+
+        </div>
+      </div>
+    </footer>
+
+    <div class="c-tab-bar" data-cid="site/tab_bar/index-1615219071_0_2185" data-cdata="{}">
+      <a href="/" class="c-tab-bar__logo">
+
+
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 291.4 1280 217.2">
+          <path
+            d="M0 292.1v58.1h39.7v153.2h67.1V292.1M220.1 372.4h-31.4v-22.3h15.8v-58h-82.8v211.3h67v-79.9h31.4v79.9h67.2V292.1h-67.2M302 503.4h124.3v-58.2h-60.2v-24.6h38.3v-48.2h-38.3v-22.2h60.2v-58.1H302M954.8 363.6c0-45.6-33.7-71.5-81.5-71.5h-74.7v211.2h67.1v-54.1l38.4 54.1h75.7l-54.4-81c19.6-10.7 29.4-30.2 29.4-58.7M865.5 387v-39.3c9.3 0 20.7 2.8 24.1 13 .3.9.5 1.9.8 2.9 0 .1 0 .3.1.4.1 1 .3 2.2.3 3.4 0 15.7-14.3 19.6-25.3 19.6M559.2 420.8h-.6l-4.8-17.4-15-53.1h26.4l17.4-58.2h-134l76.8 211.2h68.8l8.3-22.6s36.8-99.8 56.9-154.2v176.8h124.3v-58.2h-60.2v-24.6h38.2v-48.1h-38.2v-22.2h60.2V292H598l-38.8 128.8zM1280 350.3v-58.1h-124.3v211.2H1280v-58.2h-60.3v-24.6h38.3v-48h-38.3v-22.3">
+          </path>
+          <path
+            d="M1142.8 459.1V373H1048v48h35.3v17.1c-2.7 2.4-8.5 3.7-14.5 3.7-24.6 0-42.8-19.4-42.8-43.1s17.7-44.7 42.3-44.7c14.9 0 50.2.1 50.2.1v-62.6h-16.1c-30 0-59.9-2.4-87.4 11.8-21.7 11.2-38.9 30.2-48 52.8-5.3 13.3-8 27.7-8 42 0 59.9 47 110.4 107.9 110.4 30.2 0 59.7-11.3 75.8-25.4.1-14.6.1-16.8.1-24">
+          </path>
+        </svg>
+
+
+
+
+      </a>
+
+
+      <div class="c-social-buttons" data-analytics-placement="sticky" aria-labelledby="heading-label--k8azsqut"
+        data-cid="site/social_buttons_list-1615219071_1278_2184"
+        data-cdata="{&quot;entry_id&quot;:16685133,&quot;services&quot;:[&quot;twitter&quot;,&quot;facebook&quot;],&quot;base_url&quot;:&quot;https://www.theverge.com/2018/1/22/16921092/pentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&quot;}">
+        <h2 class="sr-only" id="heading-label--k8azsqut">Share this story</h2>
+
+        <ul>
+
+          <li>
+            <a class="c-social-buttons__item c-social-buttons__twitter"
+              href="https://twitter.com/intent/tweet?counturl=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;url=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model&amp;via=Verge"
+              data-analytics-social="twitter">
+              <svg role="img" class="p-svg-icon c-social-buttons__svg">
+                <use xlink:href="#icon-twitter"></use>
+              </svg>
+              <span class="c-social-buttons__text">
+                Twitter
+              </span>
+              <span class="sr-only"> (opens in new window)</span></a>
+          </li>
+
+          <li>
+            <a class="c-social-buttons__item c-social-buttons__facebook"
+              href="https://www.facebook.com/sharer/sharer.php?text=You+can+visit+the+Pentagon%E2%80%99s+secret+nuclear+bunker+inside+Minecraft&amp;u=https%3A%2F%2Fwww.theverge.com%2F2018%2F1%2F22%2F16921092%2Fpentagon-secret-nuclear-bunker-reconstruction-minecraft-cns-miis-model"
+              data-analytics-social="facebook">
+              <svg role="img" class="p-svg-icon c-social-buttons__svg">
+                <use xlink:href="#icon-facebook"></use>
+              </svg>
+              <span class="c-social-buttons__text">
+                Facebook
+              </span>
+              <span class="sr-only"> (opens in new window)</span></a>
+          </li>
+
+
+        </ul>
+
+      </div>
+
+
+      <span class="c-tab-bar__sponsorship"></span>
+
+
+    </div>
+
+  </div>
+
+  <script src="https://cdn.vox-cdn.com/packs/js/chorus-45a5379b6bb9fb7c7e01.js" async="async"
+    data-privacy-no-concern="true"
+    integrity="sha256-OzKNm/WpXqEw7FuNQXdjeqAklFnddphVXgaQHrBmAS0= sha384-ro4nDugXT9dcx60K4Ia27MJrr34i1/T0+HfU0zckD7+rJ0UzTZ9Dg8eJhFihNugj"
+    crossorigin="anonymous"></script>
+
+
+  <div id="amzn-assoc-ad-c86ecff2-0781-48c9-a698-200b0643c35a"></div>
+  <script defer=""
+    src="https://z-na.associates-amazon.com/onetag/v2?MarketPlace=US&amp;instanceId=c86ecff2-0781-48c9-a698-200b0643c35a"></script>
+
+  <!-- Phonograph -->
+
+  <script src="https://phonograph2.voxmedia.com/pickup.js?v=1529075019264" id="phonograph-pickup" async="async"
+    defer="defer"></script>
+
+  <script>
+    var phonographEvents = phonographEvents || [];
+    (function () {
+      var continent = document.cookie.match(/_chorus_geoip_continent=([^;]+)/i) || [];
+      var data = { 'Page Title': document.title, 'GA Track Prefix': 't1.', 'geoip_continent': continent[1] };
+      var dataLayer = window.dataLayer || [];
+      dataLayer
+        .filter(function (m) { return !!m['Network'] })
+        .forEach(function (m) {
+          Object.keys(m).forEach(function (k) { data[k] = m[k] });
+        });
+
+      var userid = data['Logged in Status'];
+      data['User ID'] = (typeof userid === 'number') ? userid : null;
+      phonographEvents.push(['pageload', data]);
+    })();
+  </script>
   <!-- End Phonograph -->
 
-    
-  </body>
-</html>
+  <script id="parsely-cfg" src="//cdn.parsely.com/keys/theverge.com/p.js" defer=""></script>
 
+
+
+  <!--[if !IE]> -->
+  <script>
+    (function (a, c, d, e) { if (!a[c]) { var b = a[c] = {}; b[d] = []; b[e] = function (a) { b[d].push(a) } } })(window, 'Scroll', '_q', 'do');
+    Scroll.config = {
+      detected: false
+    };
+  </script>
+  <script src="https://static.scroll.com/js/scroll.js" async="async"></script>
+  <!-- <![endif]-->
+
+
+
+
+
+  <script type="text/javascript">
+    window.onload = function () {
+      var links = document.querySelector('.c-entry-content').querySelectorAll('p [has-subtag="true"], li [has-subtag="true"], div [has-subtag="true"');
+      links.forEach(link => {
+        var subtagData = link.getAttribute('data-cdata');
+        if (subtagData) {
+          window.Subtags(link, JSON.parse(subtagData));
+        }
+      });
+    }
+  </script>
+</body>
+
+</html>

--- a/packages/metascraper/test/integration/medium/input.html
+++ b/packages/metascraper/test/integration/medium/input.html
@@ -1,241 +1,3672 @@
-<!DOCTYPE html><html xmlns:cc="http://creativecommons.org/ns#"><head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# medium-com: http://ogp.me/ns/fb/medium-com#"><meta http-equiv="Content-Type" content="text/html; charset=utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>🍾🚀 webpack 3: Official Release!! 🚀🍾 – webpack – Medium</title><link rel="canonical" href="https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b"><meta name="title" content="🍾🚀 webpack 3: Official Release!! 🚀🍾 – webpack – Medium"><meta name="referrer" content="unsafe-url"><meta name="description" content="After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Today, we’ve fulfilled these promises."><meta name="theme-color" content="#000000"><meta property="reveal
-  " content="🍾🚀 webpack 3: Official Release!! 🚀🍾 – webpack – Medium"><meta property="og:url" content="https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b"><meta property="og:image" content="https://cdn-images-1.medium.com/max/1200/1*Ac4K68j43uSbvHnKZKfXPw.jpeg"><meta property="fb:app_id" content="542599432471018"><meta property="og:description" content="Now with Scope Hoisting, “magic comments”, and more!"><meta name="twitter:description" content="Now with Scope Hoisting, “magic comments”, and more!"><meta name="twitter:image:src" content="https://cdn-images-1.medium.com/max/1200/1*Ac4K68j43uSbvHnKZKfXPw.jpeg"><link rel="publisher" href="https://plus.google.com/103654360130207659246"><link rel="author" href="https://medium.com/@TheLarkInn"><meta property="author" content="Sean T. Larkin"><meta property="og:type" content="article"><meta name="twitter:card" content="summary_large_image"><meta property="article:publisher" content="https://www.facebook.com/medium"><meta property="article:author" content="https://medium.com/@TheLarkInn"><meta name="robots" content="index, follow"><meta property="article:published_time" content="2017-06-19T17:23:28.613Z"><meta name="twitter:creator" content="@TheLarkInn"><meta name="twitter:site" content="@Medium"><meta property="og:site_name" content="Medium"><meta name="twitter:label1" value="Reading time"><meta name="twitter:data1" value="3 min read"><meta name="twitter:app:name:iphone" content="Medium"><meta name="twitter:app:id:iphone" content="828256236"><meta name="twitter:app:url:iphone" content="medium://p/15fd2dd8f07b"><meta property="al:ios:app_name" content="Medium"><meta property="al:ios:app_store_id" content="828256236"><meta property="al:android:package" content="com.medium.reader"><meta property="al:android:app_name" content="Medium"><meta property="al:ios:url" content="medium://p/15fd2dd8f07b"><meta property="al:android:url" content="medium://p/15fd2dd8f07b"><meta property="al:web:url" content="https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b"><link rel="search" type="application/opensearchdescription+xml" title="Medium" href="/osd.xml" /><link rel="alternate" href="android-app://com.medium.reader/https/medium.com/p/15fd2dd8f07b" /><script type="application/ld+json">{"@context":"http://schema.org","@type":"NewsArticle","image":{"@type":"ImageObject","width":1920,"height":1280,"url":"https://cdn-images-1.medium.com/max/2000/1*Ac4K68j43uSbvHnKZKfXPw.jpeg"},"datePublished":"2017-06-19T17:23:28.613Z","dateModified":"2017-07-05T11:54:14.175Z","headline":"🍾🚀 webpack 3: Official Release!! 🚀🍾","name":"🍾🚀 webpack 3: Official Release!! 🚀🍾","keywords":["JavaScript","Webpack","Tech","Technology","Web Development"],"author":{"@type":"Person","name":"Sean T. Larkin","url":"https://medium.com/@TheLarkInn"},"creator":["Sean T. Larkin"],"publisher":{"@type":"Organization","name":"webpack","url":"https://medium.com/webpack","logo":{"@type":"ImageObject","width":154,"height":60,"url":"https://cdn-images-1.medium.com/max/308/1*gdoQ1_5OID90wf1eLTFvWw.png"}},"mainEntityOfPage":"https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b"}</script><link rel="stylesheet" type="text/css" href="https://cdn-static-1.medium.com/_/fp/css/fonts-base.by5Oi_VbnwEIvhnWIsuUjA.css" /><link rel="stylesheet" href="https://cdn-static-1.medium.com/_/fp/css/main-base.q2NIP0snUkh8aJPmi5ocaQ.css"><script>if (window.top !== window.self) window.top.location = window.self.location.href;var OB_startTime = new Date().getTime(); var OB_loadErrors = []; function _onerror(e) { OB_loadErrors.push(e) }; if (document.addEventListener) document.addEventListener("error", _onerror, true); else if (document.attachEvent) document.attachEvent("onerror", _onerror); function _asyncScript(u) {var d = document, f = d.getElementsByTagName("script")[0], s = d.createElement("script"); s.type = "text/javascript"; s.async = true; s.src = u; f.parentNode.insertBefore(s, f);}function _asyncStyles(u) {var d = document, f = d.getElementsByTagName("script")[0], s = d.createElement("link"); s.rel = "stylesheet"; s.href = u; f.parentNode.insertBefore(s, f); return s}(new Image()).src = "/_/stat?event=pixel.load&origin=" + encodeURIComponent(location.origin);</script><script>window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date; ga("create", "UA-24232453-2", "auto", {"allowLinker": true, "legacyCookieDomain": window.location.hostname}); ga("send", "pageview");</script><script async src="https://www.google-analytics.com/analytics.js"></script><!--[if lt IE 9]><script charset="UTF-8" src="https://cdn-static-1.medium.com/_/fp/js/shiv.RI2ePTZ5gFmMgLzG5bEVAA.js"></script><![endif]--><link rel="icon" href="https://cdn-static-1.medium.com/_/fp/icons/favicon-medium.TAS6uQ-Y7kcKgi0xjcYHXw.ico" class="js-favicon"><link rel="apple-touch-icon" sizes="152x152" href="https://cdn-images-1.medium.com/fit/c/304/304/1*Wx82vEGrMfW4AdSLodZXgQ.png"><link rel="apple-touch-icon" sizes="120x120" href="https://cdn-images-1.medium.com/fit/c/240/240/1*Wx82vEGrMfW4AdSLodZXgQ.png"><link rel="apple-touch-icon" sizes="76x76" href="https://cdn-images-1.medium.com/fit/c/152/152/1*Wx82vEGrMfW4AdSLodZXgQ.png"><link rel="apple-touch-icon" sizes="60x60" href="https://cdn-images-1.medium.com/fit/c/120/120/1*Wx82vEGrMfW4AdSLodZXgQ.png"><link rel="mask-icon" href="https://cdn-static-1.medium.com/_/fp/icons/favicon.KjTfUJo7yJH_fCoUzzH3cg.svg" color="#171717"></head><body itemscope class=" postShowScreen browser-chrome os-mac is-withMagicUnderlines is-noJs"><script>document.body.className = document.body.className.replace(/(^|\s)is-noJs(\s|$)/, "$1is-js$2")</script><div class="site-main" id="container"><div class="butterBar butterBar--error"></div><div class="surface"><div id="prerendered" class="screenContent"><canvas class="canvas-renderer"></canvas><div class="container u-maxWidth740 u-xs-margin0 notesPositionContainer js-notesPositionContainer"></div><div class="metabar u-clearfix js-metabar"><div class="metabar-inner u-marginAuto u-maxWidth1000 u-paddingLeft20 u-paddingRight20 js-metabarMiddle"><div class="metabar-block metabar-block--left u-floatLeft u-height65 u-xs-height56"><a href="https://medium.com/" class="siteNav-logo" data-log-event="home"><span class="svgIcon svgIcon--logoNewRainbow svgIcon--45px is-flushLeft"><svg class="svgIcon-use" width="45" height="45" viewBox="0 0 45 45" ><g fill="none" fill-rule="evenodd"><path d="M36.283 34.741c.948.46 1.717.14 1.717-.7v-19.3a.22.22 0 0 0-.124-.19l-3.865-1.829v20.943l2.272 1.076z" fill="#663091"/><path fill="#4F51A2" d="M31 32.22l3.647 1.74V13.01L31 11.272V32.22z"/><path d="M28.284 10a.898.898 0 0 1 .241.078l.001.003v.01l2.621 1.25V32.29l-3.48-1.661V10.584c0-.328.164-.54.409-.584h.208z" fill="#0271B9"/><path d="M34.32 12.837l3.567 1.702a.121.121 0 0 1 .033.024l-3.678 5.858-6.576 10.209-3.475-1.659 10.13-16.134z" fill="#00ADDD"/><path fill="#7DCCBA" d="M34.538 12.94l-10.13 16.135-3.603-1.72 10.13-16.134z"/><path d="M28.523 10.069c-.47-.22-1.082-.05-1.36.38l-9.83 15.247 3.536 1.69L31 11.25l-2.476-1.182z" fill="#00A750"/><path d="M21.674 27.768l5.863 2.799-1.895-3.078-8.286-12.854a.156.156 0 0 0-.06-.054l-5.299-2.528 9.677 15.715z" fill="#CADB2D"/><path d="M17.333 25.696L7.838 10.97c-.461-.716-.194-.995.592-.62l3.766 1.798 9.677 15.715-4.54-2.167z" fill="#F9EF24"/><path d="M14 33.969l1.903.908c.787.376 1.43-.004 1.43-.844V14.659a.092.092 0 0 0-.055-.084L14 13.01v20.96z" fill="#F99132"/><path fill="#F7722F" d="M10.066 32.122V11.108L14 13.01v20.96z"/><path d="M10.5 32.298l-2.642-1.261c-.472-.224-.858-.82-.858-1.325V10.89c0-.672.515-.976 1.145-.675l2.355 1.124V32.3z" fill="#E51E25"/></g></svg></span><span class="u-textScreenReader">Homepage</span></a><div class="u-alignMiddle u-inlineBlock u-verticalAlignTop u-height65 u-xs-height56"><div class="u-alignBlock"><span class="u-inlineBlock u-height28 u-xs-height24 u-verticalAlignTop u-marginRight20 u-borderRightLighter"></span></div></div><div class="u-alignMiddle u-inlineBlock u-verticalAlignTop u-height65 u-xs-height56 u-marginRight18"><div class="u-alignBlock"><a class="js-logCollection" href="https://medium.com/webpack?source=logo-c9ef5404fa69---b2f039622545"><img height="36" width="93" class="u-paddingTop5" src="https://cdn-images-1.medium.com/letterbox/186/72/50/50/1*gdoQ1_5OID90wf1eLTFvWw.png?source=logoAvatar-c9ef5404fa69---b2f039622545" alt="webpack" /></a></div></div><div class="u-alignMiddle u-inlineBlock u-verticalAlignTop u-height65 u-xs-height56 u-xs-hide"><div class="u-alignBlock"><div class="buttonSet u-lineHeightInherit u-marginLeft0"><div class="buttonSet-inner"><button class="button button--primary u-paddingLeft10 u-paddingRight10 u-height19 u-lineHeight13 u-verticalAlignMiddle u-fontSize12 u-uiTextMedium button--small u-noUserSelect button--withChrome u-accentColor--buttonNormal js-relationshipButton is-smallPill"  data-action="toggle-follow-collection" data-collection-id="b2f039622545"><span class="button-label  js-buttonLabel">Follow</span></button></div></div></div></div></div><div class="metabar-block u-floatRight u-xs-absolute u-xs-textAlignRight u-xs-right0 u-xs-marginRight20 u-height65 u-xs-height56"><div class="u-alignMiddle u-inlineBlock u-verticalAlignTop u-height65 u-xs-height56"><div class="u-alignBlock"><div class="buttonSet u-lineHeightInherit"><label class="button button--chromeless button--small button--circle button--withIcon button--withSvgIcon inputGroup u-sm-hide metabar-predictiveSearch u-widthAuto u-baseColor--placeholderNormal  u-lineHeight30 u-height32 u-verticalAlignMiddle" title="Search webpack"><span class="svgIcon svgIcon--search svgIcon--25px u-top0 u-baseColor--iconLight"><svg class="svgIcon-use" width="25" height="25"  viewBox="0 0 25 25"><path d="M20.067 18.933l-4.157-4.157a6 6 0 1 0-.884.884l4.157 4.157a.624.624 0 1 0 .884-.884zM6.5 11c0-2.62 2.13-4.75 4.75-4.75S16 8.38 16 11s-2.13 4.75-4.75 4.75S6.5 13.62 6.5 11z"/></svg></span><input class="js-predictiveSearchInput textInput textInput--rounded textInput--darkText u-baseColor--textNormal textInput--transparent  u-lineHeight30 u-height32 u-verticalAlignMiddle" type="search" placeholder="Search webpack" required="true" data-collection-id="b2f039622545" /></label><a class="button button--small button--chromeless u-sm-show is-inSiteNavBar u-baseColor--buttonNormal button--withIcon button--withSvgIcon u-xs-top2"   href="https://medium.com/webpack/search" title="Search" aria-label="Search"><span class="button-defaultState"><span class="svgIcon svgIcon--search svgIcon--25px"><svg class="svgIcon-use" width="25" height="25"  viewBox="0 0 25 25"><path d="M20.067 18.933l-4.157-4.157a6 6 0 1 0-.884.884l4.157 4.157a.624.624 0 1 0 .884-.884zM6.5 11c0-2.62 2.13-4.75 4.75-4.75S16 8.38 16 11s-2.13 4.75-4.75 4.75S6.5 13.62 6.5 11z"/></svg></span></span></a><button class="button button--small button--circle button--chromeless is-touchIconBlackPulse is-inSiteNavBar u-baseColor--buttonNormal button--withIcon button--withSvgIcon button--activity js-notificationsButton u-marginRight10"  title="Notifications" aria-label="Notifications" data-action="open-notifications"><span class="svgIcon svgIcon--bell svgIcon--25px"><svg class="svgIcon-use" width="25" height="25"  viewBox="-293 409 25 25"><path d="M-273.327 423.67l-1.673-1.52v-3.646a5.5 5.5 0 0 0-6.04-5.474c-2.86.273-4.96 2.838-4.96 5.71v3.41l-1.68 1.553c-.204.19-.32.456-.32.734V427a1 1 0 0 0 1 1h3.49a3.079 3.079 0 0 0 3.01 2.45 3.08 3.08 0 0 0 3.01-2.45h3.49a1 1 0 0 0 1-1v-2.59c0-.28-.12-.55-.327-.74zm-7.173 5.63c-.842 0-1.55-.546-1.812-1.3h3.624a1.92 1.92 0 0 1-1.812 1.3zm6.35-2.45h-12.7v-2.347l1.63-1.51c.236-.216.37-.522.37-.843v-3.41c0-2.35 1.72-4.356 3.92-4.565a4.353 4.353 0 0 1 4.78 4.33v3.645c0 .324.137.633.376.85l1.624 1.477v2.373z"/></svg></span></button><button class="button button--chromeless u-baseColor--buttonNormal is-inSiteNavBar js-userActions"  aria-haspopup="true" data-action="open-userActions"><div class="avatar"><img  src="https://cdn-images-1.medium.com/fit/c/64/64/1*j31ieu3b9LqPTf3tj_mhcw.jpeg" class="avatar-image avatar-image--icon" alt="Kiko Beats"></div></button></div></div></div></div></div><div class="metabar-inner u-marginAuto u-maxWidth1000 js-metabarBottom"><nav role="navigation" class="metabar-block metabar-block--below u-overflowHiddenY u-height40"><ul class="u-textAlignLeft u-noWrap u-overflowX js-collectionNavItems u-sm-paddingLeft20 u-sm-paddingRight20 u-paddingBottom100"><li class="metabar-navItem js-collectionNavItem u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darken u-accentColor--textDarken js-homeNav u-baseColor--link"   href="https://medium.com/webpack">Home</a></li><li class="metabar-navItem js-collectionNavItem  u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darken u-accentColor--textDarken link--noUnderline js-navItemLink u-baseColor--link"   href="https://medium.com/webpack/announcements/home">Announcments</a></li><li class="metabar-navItem js-collectionNavItem  u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darken u-accentColor--textDarken link--noUnderline js-navItemLink u-baseColor--link"   href="https://medium.com/webpack/freelancing-log-book/home">Freelance Log Book</a></li><li class="metabar-navItem js-collectionNavItem  u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darken u-accentColor--textDarken link--noUnderline js-navItemLink u-baseColor--link"   href="https://medium.com/webpack/contributors-guide/home">Contributors Guide</a></li><li class="metabar-navItem js-collectionNavItem  u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darken u-accentColor--textDarken link--noUnderline js-navItemLink u-baseColor--link"   href="https://medium.com/webpack/tips-and-tricks/home">Tips and Tricks</a></li><li class="metabar-navItem js-collectionNavItem  u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darken u-accentColor--textDarken link--noUnderline js-navItemLink u-baseColor--link"   href="https://medium.com/webpack/about">About Us</a></li><span class="u-borderLeft1 u-paddingLeft22 u-xs-paddingLeft12 u-baseColor--borderLight"></span><li class="metabar-navItem js-collectionNavItem  is-external u-uiTextMedium u-fontSize14 u-inlineBlock u-textUppercase u-letterSpacing003 u-textColorNormal u-xs-paddingRight12 u-xs-marginRight0 u-paddingTop5 u-xs-paddingTop10"><a class="link link--darkenOnHover u-accentColor--textDarken link--noUnderline js-navItemLink u-baseColor--link"   href="http://webpack.js.org" rel="nofollow noopener" target="_blank">Official Documentation</a></li></ul></nav></div></div><div class="metabar metabar--spacer js-metabarSpacer  u-height105 u-xs-height95"></div><main role="main"><article class=" u-sizeViewHeightMin100 u-overflowHidden postArticle postArticle--full is-withAccentColors"  lang="en"><header class="container u-maxWidth740"><div class="postMetaHeader u-paddingBottom10 row"><div class="postMetaHeader-socialProof2 col u-size12of12 u-paddingBottom20"><div class="postMetaInline">Recommended by <a class="link link--darken u-accentColor--textDarken u-baseColor--link"   href="https://medium.com/@chriscoyier" data-action="show-user-card" data-action-value="a789923b5cad" data-action-type="hover" data-user-id="a789923b5cad" dir="auto">Chris Coyier</a>, <a class="link link--darken u-accentColor--textDarken u-baseColor--link"   href="https://medium.com/@firstdoit" data-action="show-user-card" data-action-value="b26b29e32f86" data-action-type="hover" data-user-id="b26b29e32f86" dir="auto">Guilherme Rodrigues</a>, <span class="u-noWrap">and <button class="button button--chromeless u-baseColor--buttonNormal"  data-action="show-recommends" data-action-value="15fd2dd8f07b">1,350 others</button></span></div></div><div class="col u-size12of12 js-postMetaLockup"><div class="postMetaLockup postMetaLockup--authorWithBio u-flex js-postMetaLockup"><div class="u-flex0"><a class="link avatar u-baseColor--link"   href="https://medium.com/@TheLarkInn?source=post_header_lockup" data-action="show-user-card" data-action-source="post_header_lockup" data-action-value="393110b0b9e4" data-action-type="hover" data-user-id="393110b0b9e4" dir="auto"><img  src="https://cdn-images-1.medium.com/fit/c/120/120/1*64H5DfQ6_WwZ0WbsY430dA.jpeg" class="avatar-image avatar-image--small" alt="Go to the profile of Sean T. Larkin"></a></div><div class="u-flex1 u-paddingLeft15 u-overflowHidden"><a class="link link link--darken link--darker u-baseColor--link"   href="https://medium.com/@TheLarkInn?source=post_header_lockup" data-action="show-user-card" data-action-source="post_header_lockup" data-action-value="393110b0b9e4" data-action-type="hover" data-user-id="393110b0b9e4" dir="auto">Sean T. Larkin</a><span class="followState js-followState buttonSet-inner" data-user-id="393110b0b9e4"><button class="button u-paddingLeft10 u-paddingRight10 u-height19 u-lineHeight13 u-verticalAlignMiddle u-fontSize12 u-uiTextMedium u-noUserSelect button--withChrome u-baseColor--buttonNormal button--withHover button--unblock js-unblockButton u-marginLeft10 u-marginTopNegative2 u-xs-hide"  data-action="toggle-block-user" data-action-value="393110b0b9e4" data-action-source="post_header_lockup"><span class="button-label  button-defaultState">Blocked</span><span class="button-label button-hoverState">Unblock</span></button><button class="button button--primary u-paddingLeft10 u-paddingRight10 u-height19 u-lineHeight13 u-verticalAlignMiddle u-fontSize12 u-uiTextMedium u-noUserSelect button--withChrome u-accentColor--buttonNormal button--follow js-followButton u-marginLeft10 u-marginTopNegative2 u-xs-hide"  data-action="toggle-subscribe-user" data-action-value="393110b0b9e4" data-action-source="post_header_lockup_follow" data-subscribe-source="post_header_lockup" data-follow-context-entity-id="15fd2dd8f07b"><span class="button-label  button-defaultState js-buttonLabel">Follow</span><span class="button-label button-activeState">Following</span></button></span><div class="postMetaInline u-noWrapWithEllipsis u-xs-normalWrap u-xs-lineClamp2 u-xs-maxHeight2LineHeightBase">@Webpack Core team &amp; AngularCLI team. User Experience Developer @ Mutual of Omaha, Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and Gardener!</div><div class="postMetaInline js-testPostMetaInlineSupplemental"><time datetime="2017-06-19T17:23:28.613Z">Jun 19</time><span class="middotDivider u-fontSize12"></span><span class="readingTime" title="3 min read"></span></div></div></div></div></div></header><div class="postArticle-content js-postField js-notesSource js-trackedPost"  data-post-id="15fd2dd8f07b" data-source="post_page" data-collection-id="b2f039622545" data-tracking-context="postPage"><section name="33b6" class="section section--body section--first"><div class="section-divider"><hr class="section-divider"></div><div class="section-content"><div class="section-inner sectionLayout--outsetColumn"><figure name="821e" id="821e" class="graf graf--figure graf--layoutOutsetCenter graf--leading"><div class="aspectRatioPlaceholder is-locked" style="max-width: 1000px; max-height: 667px;"><div class="aspectRatioPlaceholder-fill" style="padding-bottom: 66.7%;"></div><div class="progressiveMedia js-progressiveMedia graf-image" data-image-id="1*Ac4K68j43uSbvHnKZKfXPw.jpeg" data-width="4896" data-height="3264" data-action="zoom" data-action-value="1*Ac4K68j43uSbvHnKZKfXPw.jpeg"><img src="https://cdn-images-1.medium.com/freeze/max/60/1*Ac4K68j43uSbvHnKZKfXPw.jpeg?q=20" crossorigin="anonymous" class="progressiveMedia-thumbnail js-progressiveMedia-thumbnail"><canvas class="progressiveMedia-canvas js-progressiveMedia-canvas"></canvas><img class="progressiveMedia-image js-progressiveMedia-image" data-src="https://cdn-images-1.medium.com/max/2000/1*Ac4K68j43uSbvHnKZKfXPw.jpeg"><noscript class="js-progressiveMedia-inner"><img class="progressiveMedia-noscript js-progressiveMedia-inner" src="https://cdn-images-1.medium.com/max/2000/1*Ac4K68j43uSbvHnKZKfXPw.jpeg"></noscript></div></div><figcaption class="imageCaption">It’s finally here. And it’s beautiful.</figcaption></figure></div><div class="section-inner sectionLayout--insetColumn"><h1 name="ea51" id="ea51" class="graf graf--h3 graf-after--figure graf--title">🍾🚀 webpack 3: Official Release!! 🚀🍾</h1><h2 name="8fe8" id="8fe8" class="graf graf--h4 graf-after--h3 graf--subtitle">Scope Hoisting, “magic comments”, and more!</h2><p name="927b" id="927b" class="graf graf--p graf-after--h4">After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Moreover, we promised to deliver them in a <strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">faster</em></strong>, <strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">more stable</em></strong> release cycle.</p><p name="efac" id="efac" class="graf graf--p graf-after--p">No more year-long betas, no breaking changes between release candidates. We promised to do you right by<em class="markup--em markup--p-em"> </em><strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">you,</em></strong><em class="markup--em markup--p-em"> the community that makes webpack thrive.</em></p><p name="ca2d" id="ca2d" class="graf graf--p graf-after--p">The webpack team is proud to announce that today we have released webpack 3.0.0!!! You can download or upgrade to it today!!</p><p name="549b" id="549b" class="graf graf--p graf-after--p"><code class="markup--code markup--p-code">npm install webpack@3.0.0 --save-dev</code></p><p name="69df" id="69df" class="graf graf--p graf-after--p">or with</p><p name="4ef7" id="4ef7" class="graf graf--p graf-after--p graf--trailing"><code class="markup--code markup--p-code">yarn add webpack@3.0.0 --dev</code></p></div></div></section><section name="33f3" class="section section--body"><div class="section-divider"><hr class="section-divider"></div><div class="section-content"><div class="section-inner sectionLayout--insetColumn"><p name="17f8" id="17f8" class="graf graf--p graf--leading">Migrating from webpack 2 to 3, should involve <strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">no effort beyond running the upgrade commands in your terminal.</em></strong> We marked this as a Major change because of internal breaking changes that could affect some plugins.</p><p name="2878" id="2878" class="graf graf--p graf-after--p"><strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">So far we’ve seen 98% of users upgrade with no breaking functionality at all!!!</em></strong></p><h3 name="3750" id="3750" class="graf graf--h3 graf-after--p">What’s new?</h3><p name="3c03" id="3c03" class="graf graf--p graf-after--h3">As we mentioned, we aimed to deliver the features that you <a href="https://webpack.js.org/vote" data-href="https://webpack.js.org/vote" class="markup--anchor markup--p-anchor" rel="noopener nofollow" target="_blank">voted for</a>! Because of the overwhelming GitHub contributions, <a href="http://opencollective.com/webpack" data-href="http://opencollective.com/webpack" class="markup--anchor markup--p-anchor" rel="nofollow noopener" target="_blank">support from our backers and sponsors</a>, we have been able to hit each one. 😍</p><h4 name="c11e" id="c11e" class="graf graf--h4 graf-after--p">🔬 Scope Hoisting 🔬</h4><p name="0014" id="0014" class="graf graf--p graf-after--h4">Scope Hoisting is the flagship feature of webpack 3. One of webpack’s trade-offs when bundling was that each module in your bundle would be wrapped in individual function closures. These wrapper functions made it slower for your JavaScript to execute in the browser. In comparison, tools like Closure Compiler and RollupJS ‘hoist’ or concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser.</p><figure name="d5a2" id="d5a2" class="graf graf--figure graf--iframe graf-after--p"><div class="aspectRatioPlaceholder is-locked"><div class="aspectRatioPlaceholder-fill" style="padding-bottom: 37%;"></div><div class="progressiveMedia js-progressiveMedia"><img src="https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDCih0NiWAAAAtZl.jpg%3Alarge&amp;key=a19fcc184b9711e1b4764040d3dc5c07&amp;width=40" crossorigin="anonymous" class="progressiveMedia-thumbnail js-progressiveMedia-thumbnail"><canvas class="progressiveMedia-canvas js-progressiveMedia-canvas"></canvas><div class="iframeContainer"><IFRAME data-width="500" data-height="185" width="500" height="185" data-src="/media/4533845503a873853b93e6aaf0833c57?postId=15fd2dd8f07b" data-media-id="4533845503a873853b93e6aaf0833c57" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDCih0NiWAAAAtZl.jpg%3Alarge&amp;key=a19fcc184b9711e1b4764040d3dc5c07" class="progressiveMedia-iframe js-progressiveMedia-iframe" allowfullscreen frameborder="0"></IFRAME></div><noscript class="js-progressiveMedia-inner"><div class="iframeContainer"><IFRAME data-width="500" data-height="185" width="500" height="185" src="/media/4533845503a873853b93e6aaf0833c57?postId=15fd2dd8f07b" data-media-id="4533845503a873853b93e6aaf0833c57" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDCih0NiWAAAAtZl.jpg%3Alarge&amp;key=a19fcc184b9711e1b4764040d3dc5c07" allowfullscreen frameborder="0"></IFRAME></div></noscript></div></div></figure><p name="4965" id="4965" class="graf graf--p graf-after--figure">As of today, with webpack 3, you can <strong class="markup--strong markup--p-strong">now add the following plugin to your configuration to enable scope hoisting:</strong></p><pre name="7078" id="7078" class="graf graf--pre graf-after--p">module.exports = {  <br>  plugins: [<br>    new webpack.optimize.ModuleConcatenationPlugin()<br>  ]<br>};</pre><p name="95b8" id="95b8" class="graf graf--p graf-after--pre">Scope Hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and <a href="https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5" data-href="https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5" class="markup--anchor markup--p-anchor" target="_blank">other conditions</a>.</p><p name="40b6" id="40b6" class="graf graf--p graf-after--p">To stay informed on what triggers these fallbacks, we’ve added a <code class="markup--code markup--p-code">--display-optimization-bailout</code> cli flag that will tell you what caused the fallback.</p><figure name="6a0e" id="6a0e" class="graf graf--figure graf--iframe graf-after--p"><div class="aspectRatioPlaceholder is-locked"><div class="aspectRatioPlaceholder-fill" style="padding-bottom: 37%;"></div><div class="progressiveMedia js-progressiveMedia"><img src="https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F838369206907387904%2FPNdDKe77_400x400.jpg&amp;key=a19fcc184b9711e1b4764040d3dc5c07&amp;width=40" crossorigin="anonymous" class="progressiveMedia-thumbnail js-progressiveMedia-thumbnail"><canvas class="progressiveMedia-canvas js-progressiveMedia-canvas"></canvas><div class="iframeContainer"><IFRAME data-width="500" data-height="185" width="500" height="185" data-src="/media/6663aed6525e9200886db81c9415337c?postId=15fd2dd8f07b" data-media-id="6663aed6525e9200886db81c9415337c" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F838369206907387904%2FPNdDKe77_400x400.jpg&amp;key=a19fcc184b9711e1b4764040d3dc5c07" class="progressiveMedia-iframe js-progressiveMedia-iframe" allowfullscreen frameborder="0"></IFRAME></div><noscript class="js-progressiveMedia-inner"><div class="iframeContainer"><IFRAME data-width="500" data-height="185" width="500" height="185" src="/media/6663aed6525e9200886db81c9415337c?postId=15fd2dd8f07b" data-media-id="6663aed6525e9200886db81c9415337c" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F838369206907387904%2FPNdDKe77_400x400.jpg&amp;key=a19fcc184b9711e1b4764040d3dc5c07" allowfullscreen frameborder="0"></IFRAME></div></noscript></div></div></figure><p name="f203" id="f203" class="graf graf--p graf-after--figure">Because scope hoisting will remove function wrappers around your modules, you may see some small size improvements. However, the significant improvement will be how fast the JavaScript loads in the browser. If you have awesome before and after comparisons, feel free to respond with some data as we’d be honored to share it!</p><h4 name="ea65" id="ea65" class="graf graf--h4 graf-after--p">🔮 ”Magic Comments” 🔮</h4><p name="b50c" id="b50c" class="graf graf--p graf-after--h4">When we introduced in webpack 2 the ability to use the dynamic import syntax ( <code class="markup--code markup--p-code">import()</code> ), users expressed their concerns that they could not create named chunks like they were able to with <code class="markup--code markup--p-code">require.ensure</code>.</p><p name="b465" id="b465" class="graf graf--p graf-after--p">We have now introduced what the community has coined “magic comments”, the ability to pass chunk name, <a href="https://medium.com/webpack/how-to-use-webpacks-new-magic-comment-feature-with-react-universal-component-ssr-a38fd3e296a" data-href="https://medium.com/webpack/how-to-use-webpacks-new-magic-comment-feature-with-react-universal-component-ssr-a38fd3e296a" class="markup--anchor markup--p-anchor" target="_blank">and more</a> as an inline comment to your <code class="markup--code markup--p-code">import()</code> statements.</p><figure name="1049" id="1049" class="graf graf--figure graf--iframe graf-after--p"><div class="aspectRatioPlaceholder is-locked"><div class="aspectRatioPlaceholder-fill" style="padding-bottom: 35.699999999999996%;"></div><div class="progressiveMedia js-progressiveMedia"><img src="https://i.embed.ly/1/display/resize?url=https%3A%2F%2Favatars3.githubusercontent.com%2Fu%2F3408176%3Fv%3D3%26s%3D400&amp;key=a19fcc184b9711e1b4764040d3dc5c07&amp;width=40" crossorigin="anonymous" class="progressiveMedia-thumbnail js-progressiveMedia-thumbnail"><canvas class="progressiveMedia-canvas js-progressiveMedia-canvas"></canvas><div class="iframeContainer"><IFRAME width="700" height="250" data-src="/media/1de84d98f7926e813eccd95ddac64e1b?postId=15fd2dd8f07b" data-media-id="1de84d98f7926e813eccd95ddac64e1b" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Favatars3.githubusercontent.com%2Fu%2F3408176%3Fv%3D3%26s%3D400&amp;key=a19fcc184b9711e1b4764040d3dc5c07" class="progressiveMedia-iframe js-progressiveMedia-iframe" allowfullscreen frameborder="0"></IFRAME></div><noscript class="js-progressiveMedia-inner"><div class="iframeContainer"><IFRAME width="700" height="250" src="/media/1de84d98f7926e813eccd95ddac64e1b?postId=15fd2dd8f07b" data-media-id="1de84d98f7926e813eccd95ddac64e1b" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Favatars3.githubusercontent.com%2Fu%2F3408176%3Fv%3D3%26s%3D400&amp;key=a19fcc184b9711e1b4764040d3dc5c07" allowfullscreen frameborder="0"></IFRAME></div></noscript></div></div><figcaption class="imageCaption">By using comments, we are able to stay true to the load specification, and still give you the great chunk naming features you love.</figcaption></figure><p name="f813" id="f813" class="graf graf--p graf-after--figure">Although these are technically features we released in v2.4 and v2.6, we worked to stabilize and fix bugs for these features that have landed in v3. This now allows the dynamic import syntax to have the same flexibility as <code class="markup--code markup--p-code">require.ensure</code>.</p><figure name="e1b1" id="e1b1" class="graf graf--figure graf--iframe graf-after--p"><div class="aspectRatioPlaceholder is-locked"><div class="aspectRatioPlaceholder-fill" style="padding-bottom: 37%;"></div><div class="progressiveMedia js-progressiveMedia"><img src="https://i.embed.ly/1/display/resize?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDBwao-MVwAAnydG.jpg%3Alarge&amp;key=a19fcc184b9711e1b4764040d3dc5c07&amp;width=40" crossorigin="anonymous" class="progressiveMedia-thumbnail js-progressiveMedia-thumbnail"><canvas class="progressiveMedia-canvas js-progressiveMedia-canvas"></canvas><div class="iframeContainer"><IFRAME data-width="500" data-height="185" width="500" height="185" data-src="/media/fd3c12141eb0e7363d3e33feb528480c?postId=15fd2dd8f07b" data-media-id="fd3c12141eb0e7363d3e33feb528480c" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDBwao-MVwAAnydG.jpg%3Alarge&amp;key=a19fcc184b9711e1b4764040d3dc5c07" class="progressiveMedia-iframe js-progressiveMedia-iframe" allowfullscreen frameborder="0"></IFRAME></div><noscript class="js-progressiveMedia-inner"><div class="iframeContainer"><IFRAME data-width="500" data-height="185" width="500" height="185" src="/media/fd3c12141eb0e7363d3e33feb528480c?postId=15fd2dd8f07b" data-media-id="fd3c12141eb0e7363d3e33feb528480c" data-thumbnail="https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDBwao-MVwAAnydG.jpg%3Alarge&amp;key=a19fcc184b9711e1b4764040d3dc5c07" allowfullscreen frameborder="0"></IFRAME></div></noscript></div></div></figure><p name="a2af" id="a2af" class="graf graf--p graf-after--figure">To learn more information, see our <a href="https://webpack.js.org/guides/code-splitting-async" data-href="https://webpack.js.org/guides/code-splitting-async" class="markup--anchor markup--p-anchor" rel="nofollow noopener" target="_blank">newest documentation guide on code-splitting</a> that highlights these features!!!</p><h3 name="5371" id="5371" class="graf graf--h3 graf-after--p">😍 What’s next? 😍</h3><p name="4f06" id="4f06" class="graf graf--p graf-after--h3">We have quite a few features and enhancements that we are hoping to bring you!!! But to take control of the ones we should be working one, stop by our<a href="http://webpack.js.org/vote" data-href="http://webpack.js.org/vote" class="markup--anchor markup--p-anchor" rel="nofollow noopener" target="_blank"><em class="markup--em markup--p-em"> vote page, and upvote the features you would like to see!</em></a></p><p name="92e2" id="92e2" class="graf graf--p graf-after--p">Here are some of those things we are hoping to bring you still:</p><ul class="postList"><li name="b1a0" id="b1a0" class="graf graf--li graf-after--p">Better Build Caching</li><li name="e784" id="e784" class="graf graf--li graf-after--li">Faster initial and incremental builds</li><li name="9ec9" id="9ec9" class="graf graf--li graf-after--li">Better TypeScript experience</li><li name="98e6" id="98e6" class="graf graf--li graf-after--li">Revamped Long term caching</li><li name="8e9d" id="8e9d" class="graf graf--li graf-after--li">WASM Module Support</li><li name="8948" id="8948" class="graf graf--li graf-after--li">Improve User Experience</li></ul><h3 name="f87b" id="f87b" class="graf graf--h3 graf-after--li">🙇Thank you 🙇</h3><p name="48ea" id="48ea" class="graf graf--p graf-after--h3">All of our users, contributors, documentation writers, bloggers, sponsors, backers, and maintainers are all shareholders in helping us ensure webpack is successful for years to come.</p><p name="9f50" id="9f50" class="graf graf--p graf-after--p graf--trailing">For this, we thank you all. It is not possible without you and we can’t wait to share what is in store for the future!!</p></div></div></section><section name="f349" class="section section--body section--last"><div class="section-divider"><hr class="section-divider"></div><div class="section-content"><div class="section-inner sectionLayout--insetColumn"><p name="d2ed" id="d2ed" class="graf graf--p graf--leading graf--trailing"><em class="markup--em markup--p-em">No time to help contribute? Want to give back in other ways? </em><strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">Become a Backer or Sponsor to webpack by donating to our </em></strong><a href="http://opencollective.com/webpack" data-href="http://opencollective.com/webpack" class="markup--anchor markup--p-anchor" rel="nofollow noopener" target="_blank"><strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">open collective</em></strong></a><strong class="markup--strong markup--p-strong"><em class="markup--em markup--p-em">.</em></strong><em class="markup--em markup--p-em"> Open Collective not only helps support the Core Team, but also supports contributors who have spent significant time improving our organization on their free time! ❤</em></p></div></div></section></div><footer class="u-paddingTop10"><div class="container u-maxWidth740"><div class="row"><div class="col u-size12of12"></div></div><div class="row"><div class="col u-size12of12 js-postTags"><div class="u-paddingBottom10"><ul class="tags tags--postTags tags--borderless"><li><a class="link u-baseColor--link"   href="https://medium.com/tag/javascript?source=post" data-action-source="post">JavaScript</a></li><li><a class="link u-baseColor--link"   href="https://medium.com/tag/webpack?source=post" data-action-source="post">Webpack</a></li><li><a class="link u-baseColor--link"   href="https://medium.com/tag/tech?source=post" data-action-source="post">Tech</a></li><li><a class="link u-baseColor--link"   href="https://medium.com/tag/technology?source=post" data-action-source="post">Technology</a></li><li><a class="link u-baseColor--link"   href="https://medium.com/tag/web-development?source=post" data-action-source="post">Web Development</a></li></ul></div></div></div><div class="row js-postActionsFooter"><div class="postActions col u-size12of12"><div class="u-floatLeft buttonSet buttonSet--withLabels"><div class="buttonSet-inner"><div class="js-actionRecommend" data-post-id="15fd2dd8f07b" data-is-icon-29px="true" data-has-recommend-list="true" data-source="post_actions_footer"><button class="button button--primary button--large button--chromeless is-touchIconFadeInPulse u-accentColor--buttonNormal button--withIcon button--withSvgIcon u-accentColor--iconLight js-actionRecommendButton"  title="Recommend to share this article with your followers and let the author know you liked it" aria-label="Recommend to share this article with your followers and let the author know you liked it" data-action="upvote" data-action-value="15fd2dd8f07b" data-action-source="post_actions_footer"><span class="button-defaultState"><span class="svgIcon svgIcon--heart svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M16.215 23.716c-.348.288-.984.826-1.376 1.158a.526.526 0 0 1-.68 0c-.36-.307-.92-.78-1.22-1.03C9.22 20.734 3 15.527 3 10.734 3 7.02 5.916 4 9.5 4c1.948 0 3.77.898 5 2.434C15.73 4.898 17.552 4 19.5 4c3.584 0 6.5 3.02 6.5 6.734 0 4.9-6.125 9.96-9.785 12.982zM19.5 5.2c-1.774 0-3.423.923-4.41 2.468a.699.699 0 0 1-.59.323.706.706 0 0 1-.59-.32c-.988-1.54-2.637-2.47-4.41-2.47-2.922 0-5.3 2.49-5.3 5.54 0 4.23 6.19 9.41 9.517 12.19.217.18.566.48.783.66l.952-.79c3.496-2.88 9.348-7.72 9.348-12.05 0-3.05-2.378-5.53-5.3-5.53z"/></svg></span></span><span class="button-activeState"><span class="svgIcon svgIcon--heartFilled svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.5 4c-1.948 0-3.77.898-5 2.434C13.27 4.898 11.448 4 9.5 4 5.916 4 3 7.02 3 10.734c0 4.793 6.227 10 9.95 13.11.296.25.853.723 1.212 1.03.196.166.48.166.677 0 .39-.332 1.02-.87 1.37-1.158 3.66-3.022 9.79-8.08 9.79-12.982C26 7.02 23.08 4 19.5 4z" fill-rule="evenodd"/></svg></span></span></button><button class="button button--chromeless u-baseColor--buttonNormal"  data-action="show-recommends" data-action-value="15fd2dd8f07b">1.3K</button></div></div><div class="buttonSet-inner"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  data-action="respond" data-action-source="post_actions_footer"><span class="svgIcon svgIcon--response svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M21.27 20.058c1.89-1.826 2.754-4.17 2.754-6.674C24.024 8.21 19.67 4 14.1 4 8.53 4 4 8.21 4 13.384c0 5.175 4.53 9.385 10.1 9.385 1.007 0 2-.14 2.95-.41.285.25.592.49.918.7 1.306.87 2.716 1.31 4.19 1.31.276-.01.494-.14.6-.36a.625.625 0 0 0-.052-.65c-.61-.84-1.042-1.71-1.282-2.58a5.417 5.417 0 0 1-.154-.75zm-3.85 1.324l-.083-.28-.388.12a9.72 9.72 0 0 1-2.85.424c-4.96 0-8.99-3.706-8.99-8.262 0-4.556 4.03-8.263 8.99-8.263 4.95 0 8.77 3.71 8.77 8.27 0 2.25-.75 4.35-2.5 5.92l-.24.21v.32c0 .07 0 .19.02.37.03.29.1.6.19.92.19.7.49 1.4.89 2.08-.93-.14-1.83-.49-2.67-1.06-.34-.22-.88-.48-1.16-.74z"/></svg></span></button><button class="button button--chromeless u-baseColor--buttonNormal"  data-action="scroll-to-responses">37</button></div></div><div class="u-floatRight buttonSet buttonSet--narrow"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  title="Share on Twitter" aria-label="Share on Twitter" data-action="share-on-twitter" data-action-source="post_actions_footer"><span class="svgIcon svgIcon--twitter svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M21.967 11.8c.018 5.93-4.607 11.18-11.177 11.18-2.172 0-4.25-.62-6.047-1.76l-.268.422-.038.5.186.013.168.012c.3.02.44.032.6.046 2.06-.026 3.95-.686 5.49-1.86l1.12-.85-1.4-.048c-1.57-.055-2.92-1.08-3.36-2.51l-.48.146-.05.5c.22.03.48.05.75.08.48-.02.87-.07 1.25-.15l2.33-.49-2.32-.49c-1.68-.35-2.91-1.83-2.91-3.55 0-.05 0-.01-.01.03l-.49-.1-.25.44c.63.36 1.35.57 2.07.58l1.7.04L7.4 13c-.978-.662-1.59-1.79-1.618-3.047a4.08 4.08 0 0 1 .524-1.8l-.825.07a12.188 12.188 0 0 0 8.81 4.515l.59.033-.06-.59v-.02c-.05-.43-.06-.63-.06-.87a3.617 3.617 0 0 1 6.27-2.45l.2.21.28-.06c1.01-.22 1.94-.59 2.73-1.09l-.75-.56c-.1.36-.04.89.12 1.36.23.68.58 1.13 1.17.85l-.21-.45-.42-.27c-.52.8-1.17 1.48-1.92 2L22 11l.016.28c.013.2.014.35 0 .52v.04zm.998.038c.018-.22.017-.417 0-.66l-.498.034.284.41a8.183 8.183 0 0 0 2.2-2.267l.97-1.48-1.6.755c.17-.08.3-.02.34.03a.914.914 0 0 1-.13-.292c-.1-.297-.13-.64-.1-.766l.36-1.254-1.1.695c-.69.438-1.51.764-2.41.963l.48.15a4.574 4.574 0 0 0-3.38-1.484 4.616 4.616 0 0 0-4.61 4.613c0 .29.02.51.08.984l.01.02.5-.06.03-.5c-3.17-.18-6.1-1.7-8.08-4.15l-.48-.56-.36.64c-.39.69-.62 1.48-.65 2.28.04 1.61.81 3.04 2.06 3.88l.3-.92c-.55-.02-1.11-.17-1.6-.45l-.59-.34-.14.67c-.02.08-.02.16 0 .24-.01 2.12 1.55 4.01 3.69 4.46l.1-.49-.1-.49c-.33.07-.67.12-1.03.14-.18-.02-.43-.05-.64-.07l-.76-.09.23.73c.57 1.84 2.29 3.14 4.28 3.21l-.28-.89a8.252 8.252 0 0 1-4.85 1.66c-.12-.01-.26-.02-.56-.05l-.17-.01-.18-.01L2.53 21l1.694 1.07a12.233 12.233 0 0 0 6.58 1.917c7.156 0 12.2-5.73 12.18-12.18l-.002.04z"/></svg></span></button><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  title="Share on Facebook" aria-label="Share on Facebook" data-action="share-on-facebook" data-action-source="post_actions_footer"><span class="svgIcon svgIcon--facebook svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M16.39 23.61v-5.808h1.846a.55.55 0 0 0 .546-.48l.36-2.797a.551.551 0 0 0-.547-.62H16.39V12.67c0-.67.12-.813.828-.813h1.474a.55.55 0 0 0 .55-.55V8.803a.55.55 0 0 0-.477-.545c-.436-.06-1.36-.116-2.22-.116-2.5 0-4.13 1.62-4.13 4.248v1.513H10.56a.551.551 0 0 0-.55.55v2.797c0 .304.248.55.55.55h1.855v5.76c-4.172-.96-7.215-4.7-7.215-9.1 0-5.17 4.17-9.36 9.31-9.36 5.14 0 9.31 4.19 9.31 9.36 0 4.48-3.155 8.27-7.43 9.15M14.51 4C8.76 4 4.1 8.684 4.1 14.46c0 5.162 3.75 9.523 8.778 10.32a.55.55 0 0 0 .637-.543v-6.985a.551.551 0 0 0-.55-.55H11.11v-1.697h1.855a.55.55 0 0 0 .55-.55v-2.063c0-2.02 1.136-3.148 3.03-3.148.567 0 1.156.027 1.597.06v1.453h-.924c-1.363 0-1.93.675-1.93 1.912v1.78c0 .3.247.55.55.55h2.132l-.218 1.69H15.84c-.305 0-.55.24-.55.55v7.02c0 .33.293.59.623.54 5.135-.7 9.007-5.11 9.007-10.36C24.92 8.68 20.26 4 14.51 4"/></svg></span></button><button class="button button--large button--dark button--chromeless is-touchIconFadeInPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon button--bookmark js-bookmarkButton"  title="Bookmark this story to read later" aria-label="Bookmark this story to read later" data-action="add-to-bookmarks" data-action-value="15fd2dd8f07b"><span class="button-defaultState"><span class="svgIcon svgIcon--bookmark svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.385 4h-9.77A2.623 2.623 0 0 0 7 6.615V23.01a1.022 1.022 0 0 0 1.595.847l5.905-4.004 5.905 4.004A1.022 1.022 0 0 0 22 23.011V6.62A2.625 2.625 0 0 0 19.385 4zM21 23l-5.91-3.955-.148-.107a.751.751 0 0 0-.884 0l-.147.107L8 23V6.615C8 5.725 8.725 5 9.615 5h9.77C20.275 5 21 5.725 21 6.615V23z" fill-rule="evenodd"/></svg></span></span><span class="button-activeState"><span class="svgIcon svgIcon--bookmarkFilled svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.385 4h-9.77A2.623 2.623 0 0 0 7 6.615V23.01a1.022 1.022 0 0 0 1.595.847l5.905-4.004 5.905 4.004A1.022 1.022 0 0 0 22 23.011V6.62A2.625 2.625 0 0 0 19.385 4z" fill-rule="evenodd"/></svg></span></span></button><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon js-moreActionsButton"  title="More actions" aria-label="More actions" data-action="more-actions" data-action-source="post_actions_footer"><span class="svgIcon svgIcon--more svgIcon--25px"><svg class="svgIcon-use" width="25" height="25"  viewBox="-480.5 272.5 21 21"><path d="M-463 284.6c.9 0 1.6-.7 1.6-1.6s-.7-1.6-1.6-1.6-1.6.7-1.6 1.6.7 1.6 1.6 1.6zm0 .9c-1.4 0-2.5-1.1-2.5-2.5s1.1-2.5 2.5-2.5 2.5 1.1 2.5 2.5-1.1 2.5-2.5 2.5zm-7-.9c.9 0 1.6-.7 1.6-1.6s-.7-1.6-1.6-1.6-1.6.7-1.6 1.6.7 1.6 1.6 1.6zm0 .9c-1.4 0-2.5-1.1-2.5-2.5s1.1-2.5 2.5-2.5 2.5 1.1 2.5 2.5-1.1 2.5-2.5 2.5zm-7-.9c.9 0 1.6-.7 1.6-1.6s-.7-1.6-1.6-1.6-1.6.7-1.6 1.6.7 1.6 1.6 1.6zm0 .9c-1.4 0-2.5-1.1-2.5-2.5s1.1-2.5 2.5-2.5 2.5 1.1 2.5 2.5-1.1 2.5-2.5 2.5z"/></svg></span></button></div></div></div></div><div class="js-postPromotionWrapper postPromotionWrapper" data-location-id="footer_above_post_attribution"></div><div class="u-maxWidth740 u-paddingTop20 u-marginTop10 u-borderTopLightest container u-paddingBottom20 js-postAttributionFooterContainer u-xs-paddingTop10 u-xs-paddingBottom10"><div class="row js-postFooterInfo"><div class="col u-size6of12 u-xs-size12of12"><li class="u-block u-paddingBottom18 js-cardUser"><div class="u-marginLeft20 u-floatRight"><span class="followState js-followState buttonSet-inner" data-user-id="393110b0b9e4"><button class="button button--small u-noUserSelect button--withChrome u-baseColor--buttonNormal button--withHover button--unblock js-unblockButton"  data-action="toggle-block-user" data-action-value="393110b0b9e4" data-action-source="footer_card"><span class="button-label  button-defaultState">Blocked</span><span class="button-label button-hoverState">Unblock</span></button><button class="button button--primary button--small u-noUserSelect button--withChrome u-accentColor--buttonNormal button--follow js-followButton"  data-action="toggle-subscribe-user" data-action-value="393110b0b9e4" data-action-source="footer_card_follow" data-subscribe-source="footer_card" data-follow-context-entity-id="15fd2dd8f07b"><span class="button-label  button-defaultState js-buttonLabel">Follow</span><span class="button-label button-activeState">Following</span></button></span></div><div class="u-tableCell "><a class="link avatar u-baseColor--link"   href="https://medium.com/@TheLarkInn?source=footer_card" title="Go to the profile of Sean T. Larkin" aria-label="Go to the profile of Sean T. Larkin" data-action-source="footer_card" data-user-id="393110b0b9e4" dir="auto"><img  src="https://cdn-images-1.medium.com/fit/c/120/120/1*64H5DfQ6_WwZ0WbsY430dA.jpeg" class="avatar-image avatar-image--small" alt="Go to the profile of Sean T. Larkin"></a></div><div class="u-tableCell u-verticalAlignMiddle u-breakWord u-paddingLeft15"><h3 class="u-fontSize18 u-lineHeightTighter u-marginBottom4"><a class="link link--primary u-accentColor--hoverTextNormal"   href="https://medium.com/@TheLarkInn" property="cc:attributionName" title="Go to the profile of Sean T. Larkin" aria-label="Go to the profile of Sean T. Larkin" rel="author cc:attributionUrl" data-user-id="393110b0b9e4" dir="auto">Sean T. Larkin</a></h3><p class="u-fontSize14 u-lineHeightBaseSans u-textColorDark u-marginBottom4"><a href="http://twitter.com/Webpack" target="_blank" title="Twitter profile for @Webpack">@Webpack</a> Core team &amp; AngularCLI team. User Experience Developer @ Mutual of Omaha, Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and Gardener!</p></div></li></div><div class="col u-size6of12 u-xs-size12of12 u-xs-marginTop30"><li class="u-block u-paddingBottom18 js-cardCollection"><div class="u-marginLeft20 u-floatRight"><button class="button button--primary button--small u-noUserSelect button--withChrome u-accentColor--buttonNormal js-relationshipButton"  data-action="toggle-follow-collection" data-collection-id="b2f039622545"><span class="button-label  js-buttonLabel">Follow</span></button></div><div class="u-tableCell "><a class="link avatar avatar--roundedRectangle u-baseColor--link"   href="https://medium.com/webpack?source=footer_card" title="Go to webpack" aria-label="Go to webpack" data-action-source="footer_card"><img src="https://cdn-images-1.medium.com/fit/c/120/120/1*Wx82vEGrMfW4AdSLodZXgQ.png" class="avatar-image u-size60x60" alt="webpack"></a></div><div class="u-tableCell u-verticalAlignMiddle u-breakWord u-paddingLeft15"><h3 class="u-fontSize18 u-lineHeightTighter u-marginBottom4"><a class="link link--primary u-accentColor--hoverTextNormal"   href="https://medium.com/webpack?source=footer_card" rel="collection" data-action-source="footer_card">webpack</a></h3><p class="u-fontSize14 u-lineHeightBaseSans u-textColorDark u-marginBottom4">The official Medium publication for the webpack opensource project!</p><div class="buttonSet"></div></div></li></div></div></div><div class="js-postFooterPlacements"></div><div class="u-padding0 u-clearfix u-backgroundGrayLightest u-print-hide supplementalPostContent js-responsesWrapper"></div><div class="supplementalPostContent js-readNext"></div><div class="supplementalPostContent js-heroPromo"></div></footer></article></main><div class="u-marginAuto u-maxWidth1000"><div class="js-postShareWidget u-foreground u-sm-hide u-transition--fadeOut300 u-fixed"><ul><li class="u-uiTextSemibold u-textAlignCenter u-textColorNormal u-fontSize12 u-textUppercase">Share</li><li class="u-textAlignCenter"><div class="js-actionRecommend" data-post-id="15fd2dd8f07b" data-is-icon-29px="true" data-is-vertical="true" data-has-recommend-list="true" data-source="post_share_widget"><button class="button button--primary button--large button--chromeless is-touchIconFadeInPulse u-accentColor--buttonNormal button--withIcon button--withSvgIcon u-accentColor--iconLight js-actionRecommendButton"  title="Recommend to share this article with your followers and let the author know you liked it" aria-label="Recommend to share this article with your followers and let the author know you liked it" data-action="upvote" data-action-value="15fd2dd8f07b" data-action-source="post_share_widget"><span class="button-defaultState"><span class="svgIcon svgIcon--heart svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M16.215 23.716c-.348.288-.984.826-1.376 1.158a.526.526 0 0 1-.68 0c-.36-.307-.92-.78-1.22-1.03C9.22 20.734 3 15.527 3 10.734 3 7.02 5.916 4 9.5 4c1.948 0 3.77.898 5 2.434C15.73 4.898 17.552 4 19.5 4c3.584 0 6.5 3.02 6.5 6.734 0 4.9-6.125 9.96-9.785 12.982zM19.5 5.2c-1.774 0-3.423.923-4.41 2.468a.699.699 0 0 1-.59.323.706.706 0 0 1-.59-.32c-.988-1.54-2.637-2.47-4.41-2.47-2.922 0-5.3 2.49-5.3 5.54 0 4.23 6.19 9.41 9.517 12.19.217.18.566.48.783.66l.952-.79c3.496-2.88 9.348-7.72 9.348-12.05 0-3.05-2.378-5.53-5.3-5.53z"/></svg></span></span><span class="button-activeState"><span class="svgIcon svgIcon--heartFilled svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.5 4c-1.948 0-3.77.898-5 2.434C13.27 4.898 11.448 4 9.5 4 5.916 4 3 7.02 3 10.734c0 4.793 6.227 10 9.95 13.11.296.25.853.723 1.212 1.03.196.166.48.166.677 0 .39-.332 1.02-.87 1.37-1.158 3.66-3.022 9.79-8.08 9.79-12.982C26 7.02 23.08 4 19.5 4z" fill-rule="evenodd"/></svg></span></span></button><button class="button button--chromeless u-baseColor--buttonNormal  u-block u-marginAuto u-marginTopNegative5"  data-action="show-recommends" data-action-value="15fd2dd8f07b">1.3K</button></div></li><li class="u-textAlignCenter"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  title="Share on Twitter" aria-label="Share on Twitter" data-action="share-on-twitter" data-action-source="post_share_widget"><span class="svgIcon svgIcon--twitter svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M21.967 11.8c.018 5.93-4.607 11.18-11.177 11.18-2.172 0-4.25-.62-6.047-1.76l-.268.422-.038.5.186.013.168.012c.3.02.44.032.6.046 2.06-.026 3.95-.686 5.49-1.86l1.12-.85-1.4-.048c-1.57-.055-2.92-1.08-3.36-2.51l-.48.146-.05.5c.22.03.48.05.75.08.48-.02.87-.07 1.25-.15l2.33-.49-2.32-.49c-1.68-.35-2.91-1.83-2.91-3.55 0-.05 0-.01-.01.03l-.49-.1-.25.44c.63.36 1.35.57 2.07.58l1.7.04L7.4 13c-.978-.662-1.59-1.79-1.618-3.047a4.08 4.08 0 0 1 .524-1.8l-.825.07a12.188 12.188 0 0 0 8.81 4.515l.59.033-.06-.59v-.02c-.05-.43-.06-.63-.06-.87a3.617 3.617 0 0 1 6.27-2.45l.2.21.28-.06c1.01-.22 1.94-.59 2.73-1.09l-.75-.56c-.1.36-.04.89.12 1.36.23.68.58 1.13 1.17.85l-.21-.45-.42-.27c-.52.8-1.17 1.48-1.92 2L22 11l.016.28c.013.2.014.35 0 .52v.04zm.998.038c.018-.22.017-.417 0-.66l-.498.034.284.41a8.183 8.183 0 0 0 2.2-2.267l.97-1.48-1.6.755c.17-.08.3-.02.34.03a.914.914 0 0 1-.13-.292c-.1-.297-.13-.64-.1-.766l.36-1.254-1.1.695c-.69.438-1.51.764-2.41.963l.48.15a4.574 4.574 0 0 0-3.38-1.484 4.616 4.616 0 0 0-4.61 4.613c0 .29.02.51.08.984l.01.02.5-.06.03-.5c-3.17-.18-6.1-1.7-8.08-4.15l-.48-.56-.36.64c-.39.69-.62 1.48-.65 2.28.04 1.61.81 3.04 2.06 3.88l.3-.92c-.55-.02-1.11-.17-1.6-.45l-.59-.34-.14.67c-.02.08-.02.16 0 .24-.01 2.12 1.55 4.01 3.69 4.46l.1-.49-.1-.49c-.33.07-.67.12-1.03.14-.18-.02-.43-.05-.64-.07l-.76-.09.23.73c.57 1.84 2.29 3.14 4.28 3.21l-.28-.89a8.252 8.252 0 0 1-4.85 1.66c-.12-.01-.26-.02-.56-.05l-.17-.01-.18-.01L2.53 21l1.694 1.07a12.233 12.233 0 0 0 6.58 1.917c7.156 0 12.2-5.73 12.18-12.18l-.002.04z"/></svg></span></button></li><li class="u-textAlignCenter"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  title="Share on Facebook" aria-label="Share on Facebook" data-action="share-on-facebook" data-action-source="post_share_widget"><span class="svgIcon svgIcon--facebook svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M16.39 23.61v-5.808h1.846a.55.55 0 0 0 .546-.48l.36-2.797a.551.551 0 0 0-.547-.62H16.39V12.67c0-.67.12-.813.828-.813h1.474a.55.55 0 0 0 .55-.55V8.803a.55.55 0 0 0-.477-.545c-.436-.06-1.36-.116-2.22-.116-2.5 0-4.13 1.62-4.13 4.248v1.513H10.56a.551.551 0 0 0-.55.55v2.797c0 .304.248.55.55.55h1.855v5.76c-4.172-.96-7.215-4.7-7.215-9.1 0-5.17 4.17-9.36 9.31-9.36 5.14 0 9.31 4.19 9.31 9.36 0 4.48-3.155 8.27-7.43 9.15M14.51 4C8.76 4 4.1 8.684 4.1 14.46c0 5.162 3.75 9.523 8.778 10.32a.55.55 0 0 0 .637-.543v-6.985a.551.551 0 0 0-.55-.55H11.11v-1.697h1.855a.55.55 0 0 0 .55-.55v-2.063c0-2.02 1.136-3.148 3.03-3.148.567 0 1.156.027 1.597.06v1.453h-.924c-1.363 0-1.93.675-1.93 1.912v1.78c0 .3.247.55.55.55h2.132l-.218 1.69H15.84c-.305 0-.55.24-.55.55v7.02c0 .33.293.59.623.54 5.135-.7 9.007-5.11 9.007-10.36C24.92 8.68 20.26 4 14.51 4"/></svg></span></button></li><li class="u-textAlignCenter"><button class="button button--large button--dark button--chromeless is-touchIconFadeInPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon button--bookmark js-bookmarkButton"  title="Bookmark this story to read later" aria-label="Bookmark this story to read later" data-action="add-to-bookmarks" data-action-value="15fd2dd8f07b"><span class="button-defaultState"><span class="svgIcon svgIcon--bookmark svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.385 4h-9.77A2.623 2.623 0 0 0 7 6.615V23.01a1.022 1.022 0 0 0 1.595.847l5.905-4.004 5.905 4.004A1.022 1.022 0 0 0 22 23.011V6.62A2.625 2.625 0 0 0 19.385 4zM21 23l-5.91-3.955-.148-.107a.751.751 0 0 0-.884 0l-.147.107L8 23V6.615C8 5.725 8.725 5 9.615 5h9.77C20.275 5 21 5.725 21 6.615V23z" fill-rule="evenodd"/></svg></span></span><span class="button-activeState"><span class="svgIcon svgIcon--bookmarkFilled svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.385 4h-9.77A2.623 2.623 0 0 0 7 6.615V23.01a1.022 1.022 0 0 0 1.595.847l5.905-4.004 5.905 4.004A1.022 1.022 0 0 0 22 23.011V6.62A2.625 2.625 0 0 0 19.385 4z" fill-rule="evenodd"/></svg></span></span></button></li></ul></div></div><div class="postActionsBar js-postActionsBar"><div class="postActionsBar-container container"><div class="postActionsBar-content u-boxShadowNormal row js-postActionsBarContent"><div class="postActions u-height44 "><div class="u-maxWidth1250 u-marginAuto u-relative"><div class="u-absolute u-right0 u-marginRight20"><div class="u-floatLeft"><div class="u-floatRight buttonSet"><div class="buttonSet-inner"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  title="Share on Twitter" aria-label="Share on Twitter" data-action="share-on-twitter" data-action-source="post_actions_bar"><span class="svgIcon svgIcon--twitter svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M21.967 11.8c.018 5.93-4.607 11.18-11.177 11.18-2.172 0-4.25-.62-6.047-1.76l-.268.422-.038.5.186.013.168.012c.3.02.44.032.6.046 2.06-.026 3.95-.686 5.49-1.86l1.12-.85-1.4-.048c-1.57-.055-2.92-1.08-3.36-2.51l-.48.146-.05.5c.22.03.48.05.75.08.48-.02.87-.07 1.25-.15l2.33-.49-2.32-.49c-1.68-.35-2.91-1.83-2.91-3.55 0-.05 0-.01-.01.03l-.49-.1-.25.44c.63.36 1.35.57 2.07.58l1.7.04L7.4 13c-.978-.662-1.59-1.79-1.618-3.047a4.08 4.08 0 0 1 .524-1.8l-.825.07a12.188 12.188 0 0 0 8.81 4.515l.59.033-.06-.59v-.02c-.05-.43-.06-.63-.06-.87a3.617 3.617 0 0 1 6.27-2.45l.2.21.28-.06c1.01-.22 1.94-.59 2.73-1.09l-.75-.56c-.1.36-.04.89.12 1.36.23.68.58 1.13 1.17.85l-.21-.45-.42-.27c-.52.8-1.17 1.48-1.92 2L22 11l.016.28c.013.2.014.35 0 .52v.04zm.998.038c.018-.22.017-.417 0-.66l-.498.034.284.41a8.183 8.183 0 0 0 2.2-2.267l.97-1.48-1.6.755c.17-.08.3-.02.34.03a.914.914 0 0 1-.13-.292c-.1-.297-.13-.64-.1-.766l.36-1.254-1.1.695c-.69.438-1.51.764-2.41.963l.48.15a4.574 4.574 0 0 0-3.38-1.484 4.616 4.616 0 0 0-4.61 4.613c0 .29.02.51.08.984l.01.02.5-.06.03-.5c-3.17-.18-6.1-1.7-8.08-4.15l-.48-.56-.36.64c-.39.69-.62 1.48-.65 2.28.04 1.61.81 3.04 2.06 3.88l.3-.92c-.55-.02-1.11-.17-1.6-.45l-.59-.34-.14.67c-.02.08-.02.16 0 .24-.01 2.12 1.55 4.01 3.69 4.46l.1-.49-.1-.49c-.33.07-.67.12-1.03.14-.18-.02-.43-.05-.64-.07l-.76-.09.23.73c.57 1.84 2.29 3.14 4.28 3.21l-.28-.89a8.252 8.252 0 0 1-4.85 1.66c-.12-.01-.26-.02-.56-.05l-.17-.01-.18-.01L2.53 21l1.694 1.07a12.233 12.233 0 0 0 6.58 1.917c7.156 0 12.2-5.73 12.18-12.18l-.002.04z"/></svg></span></button></div><div class="buttonSet-inner"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  title="Share on Facebook" aria-label="Share on Facebook" data-action="share-on-facebook" data-action-source="post_actions_bar"><span class="svgIcon svgIcon--facebook svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M16.39 23.61v-5.808h1.846a.55.55 0 0 0 .546-.48l.36-2.797a.551.551 0 0 0-.547-.62H16.39V12.67c0-.67.12-.813.828-.813h1.474a.55.55 0 0 0 .55-.55V8.803a.55.55 0 0 0-.477-.545c-.436-.06-1.36-.116-2.22-.116-2.5 0-4.13 1.62-4.13 4.248v1.513H10.56a.551.551 0 0 0-.55.55v2.797c0 .304.248.55.55.55h1.855v5.76c-4.172-.96-7.215-4.7-7.215-9.1 0-5.17 4.17-9.36 9.31-9.36 5.14 0 9.31 4.19 9.31 9.36 0 4.48-3.155 8.27-7.43 9.15M14.51 4C8.76 4 4.1 8.684 4.1 14.46c0 5.162 3.75 9.523 8.778 10.32a.55.55 0 0 0 .637-.543v-6.985a.551.551 0 0 0-.55-.55H11.11v-1.697h1.855a.55.55 0 0 0 .55-.55v-2.063c0-2.02 1.136-3.148 3.03-3.148.567 0 1.156.027 1.597.06v1.453h-.924c-1.363 0-1.93.675-1.93 1.912v1.78c0 .3.247.55.55.55h2.132l-.218 1.69H15.84c-.305 0-.55.24-.55.55v7.02c0 .33.293.59.623.54 5.135-.7 9.007-5.11 9.007-10.36C24.92 8.68 20.26 4 14.51 4"/></svg></span></button></div><div class="buttonSet-inner"><button class="button button--large button--dark button--chromeless is-touchIconFadeInPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon button--bookmark js-bookmarkButton"  title="Bookmark this story to read later" aria-label="Bookmark this story to read later" data-action="add-to-bookmarks" data-action-value="15fd2dd8f07b"><span class="button-defaultState"><span class="svgIcon svgIcon--bookmark svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.385 4h-9.77A2.623 2.623 0 0 0 7 6.615V23.01a1.022 1.022 0 0 0 1.595.847l5.905-4.004 5.905 4.004A1.022 1.022 0 0 0 22 23.011V6.62A2.625 2.625 0 0 0 19.385 4zM21 23l-5.91-3.955-.148-.107a.751.751 0 0 0-.884 0l-.147.107L8 23V6.615C8 5.725 8.725 5 9.615 5h9.77C20.275 5 21 5.725 21 6.615V23z" fill-rule="evenodd"/></svg></span></span><span class="button-activeState"><span class="svgIcon svgIcon--bookmarkFilled svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.385 4h-9.77A2.623 2.623 0 0 0 7 6.615V23.01a1.022 1.022 0 0 0 1.595.847l5.905-4.004 5.905 4.004A1.022 1.022 0 0 0 22 23.011V6.62A2.625 2.625 0 0 0 19.385 4z" fill-rule="evenodd"/></svg></span></span></button></div></div></div><div class="u-xs-hide u-width255 u-foreground u-floatLeft js-readNextMetabarRight"></div></div><div class="container u-maxWidth740 js-postActions-actionButtons"><div class="u-floatLeft buttonSet buttonSet--withLabels"><div class="buttonSet-inner"><div class="js-actionRecommend" data-post-id="15fd2dd8f07b" data-is-icon-29px="true" data-has-recommend-list="true" data-source="post_actions_bar"><button class="button button--primary button--large button--chromeless is-touchIconFadeInPulse u-accentColor--buttonNormal button--withIcon button--withSvgIcon u-accentColor--iconLight js-actionRecommendButton"  title="Recommend to share this article with your followers and let the author know you liked it" aria-label="Recommend to share this article with your followers and let the author know you liked it" data-action="upvote" data-action-value="15fd2dd8f07b" data-action-source="post_actions_bar"><span class="button-defaultState"><span class="svgIcon svgIcon--heart svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M16.215 23.716c-.348.288-.984.826-1.376 1.158a.526.526 0 0 1-.68 0c-.36-.307-.92-.78-1.22-1.03C9.22 20.734 3 15.527 3 10.734 3 7.02 5.916 4 9.5 4c1.948 0 3.77.898 5 2.434C15.73 4.898 17.552 4 19.5 4c3.584 0 6.5 3.02 6.5 6.734 0 4.9-6.125 9.96-9.785 12.982zM19.5 5.2c-1.774 0-3.423.923-4.41 2.468a.699.699 0 0 1-.59.323.706.706 0 0 1-.59-.32c-.988-1.54-2.637-2.47-4.41-2.47-2.922 0-5.3 2.49-5.3 5.54 0 4.23 6.19 9.41 9.517 12.19.217.18.566.48.783.66l.952-.79c3.496-2.88 9.348-7.72 9.348-12.05 0-3.05-2.378-5.53-5.3-5.53z"/></svg></span></span><span class="button-activeState"><span class="svgIcon svgIcon--heartFilled svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M19.5 4c-1.948 0-3.77.898-5 2.434C13.27 4.898 11.448 4 9.5 4 5.916 4 3 7.02 3 10.734c0 4.793 6.227 10 9.95 13.11.296.25.853.723 1.212 1.03.196.166.48.166.677 0 .39-.332 1.02-.87 1.37-1.158 3.66-3.022 9.79-8.08 9.79-12.982C26 7.02 23.08 4 19.5 4z" fill-rule="evenodd"/></svg></span></span></button><button class="button button--chromeless u-baseColor--buttonNormal"  data-action="show-recommends" data-action-value="15fd2dd8f07b">1.3K</button></div></div><div class="buttonSet-inner"><button class="button button--large button--dark button--chromeless is-touchIconBlackPulse u-baseColor--buttonDark button--withIcon button--withSvgIcon"  data-action="respond" data-action-source="post_actions_bar"><span class="svgIcon svgIcon--response svgIcon--29px"><svg class="svgIcon-use" width="29" height="29" viewBox="0 0 29 29" ><path d="M21.27 20.058c1.89-1.826 2.754-4.17 2.754-6.674C24.024 8.21 19.67 4 14.1 4 8.53 4 4 8.21 4 13.384c0 5.175 4.53 9.385 10.1 9.385 1.007 0 2-.14 2.95-.41.285.25.592.49.918.7 1.306.87 2.716 1.31 4.19 1.31.276-.01.494-.14.6-.36a.625.625 0 0 0-.052-.65c-.61-.84-1.042-1.71-1.282-2.58a5.417 5.417 0 0 1-.154-.75zm-3.85 1.324l-.083-.28-.388.12a9.72 9.72 0 0 1-2.85.424c-4.96 0-8.99-3.706-8.99-8.262 0-4.556 4.03-8.263 8.99-8.263 4.95 0 8.77 3.71 8.77 8.27 0 2.25-.75 4.35-2.5 5.92l-.24.21v.32c0 .07 0 .19.02.37.03.29.1.6.19.92.19.7.49 1.4.89 2.08-.93-.14-1.83-.49-2.67-1.06-.34-.22-.88-.48-1.16-.74z"/></svg></span></button><button class="button button--chromeless u-baseColor--buttonNormal"  data-action="scroll-to-responses">37</button></div></div></div></div></div></div></div></div><style class="js-collectionStyle">
-.u-accentColor--borderLight {border-color: #848585 !important;}
-.u-accentColor--borderNormal {border-color: #848585 !important;}
-.u-accentColor--borderDark {border-color: #717272 !important;}
-.u-accentColor--iconLight .svgIcon,.u-accentColor--iconLight.svgIcon {fill: #848585 !important;}
-.u-accentColor--iconNormal .svgIcon,.u-accentColor--iconNormal.svgIcon {fill: #848585 !important;}
-.u-accentColor--iconDark .svgIcon,.u-accentColor--iconDark.svgIcon {fill: #717272 !important;}
-.u-accentColor--textNormal {color: #717272 !important;}
-.u-accentColor--hoverTextNormal:hover {color: #717272 !important;}
-.u-accentColor--textNormal.u-accentColor--textDarken:hover {color: #686868 !important;}
-.u-accentColor--textDark {color: #686868 !important;}
-.u-accentColor--backgroundLight {background-color: #848585 !important;}
-.u-accentColor--backgroundNormal {background-color: #848585 !important;}
-.u-accentColor--backgroundDark {background-color: #717272 !important;}
-.u-accentColor--buttonDark {border-color: #717272 !important; color: #686868 !important;}
-.u-accentColor--buttonDark:hover {border-color: #686868 !important;}
-.u-accentColor--buttonDark .icon:before,.u-accentColor--buttonDark .svgIcon{color: #717272 !important; fill: #717272 !important;}
-.u-accentColor--buttonNormal {border-color: #848585 !important; color: #717272 !important;}
-.u-accentColor--buttonNormal:hover {border-color: #717272 !important;}
-.u-accentColor--buttonNormal .icon:before,.u-accentColor--buttonNormal .svgIcon{color: #848585 !important; fill: #848585 !important;}
-.u-accentColor--buttonNormal.button--filled .icon:before,.u-accentColor--buttonNormal.button--filled .svgIcon{color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-accentColor--buttonDark.button--filled,.u-accentColor--buttonDark.button--withChrome.is-active,.u-accentColor--fillWhenActive.is-active {background-color: #717272 !important; border-color: #717272 !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-accentColor--buttonNormal.button--filled,.u-accentColor--buttonNormal.button--withChrome.is-active {background-color: #848585 !important; border-color: #848585 !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.postArticle.is-withAccentColors .markup--user,.postArticle.is-withAccentColors .markup--query {color: #717272 !important;}.u-tintBgColor {background-color: rgba(255, 255, 255, 1) !important;}.u-tintBgColor .u-fadeLeft:before {background-image: linear-gradient(to right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%) !important;}.u-tintBgColor .u-fadeRight:after {background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%) !important;}
-.u-tintSpectrum .u-baseColor--borderLight {border-color: #A8A8A8 !important;}
-.u-tintSpectrum .u-baseColor--borderNormal {border-color: #818282 !important;}
-.u-tintSpectrum .u-baseColor--borderDark {border-color: #575959 !important;}
-.u-tintSpectrum .u-baseColor--iconLight .svgIcon,.u-tintSpectrum .u-baseColor--iconLight.svgIcon {fill: #A8A8A8 !important;}
-.u-tintSpectrum .u-baseColor--iconNormal .svgIcon,.u-tintSpectrum .u-baseColor--iconNormal.svgIcon {fill: #818282 !important;}
-.u-tintSpectrum .u-baseColor--iconDark .svgIcon,.u-tintSpectrum .u-baseColor--iconDark.svgIcon {fill: #575959 !important;}
-.u-tintSpectrum .u-baseColor--textNormal {color: #818282 !important;}
-.u-tintSpectrum .u-baseColor--textNormal.u-baseColor--textDarken:hover {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--textDark {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--textDarker {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--backgroundLight {background-color: #A8A8A8 !important;}
-.u-tintSpectrum .u-baseColor--backgroundNormal {background-color: #818282 !important;}
-.u-tintSpectrum .u-baseColor--backgroundDark {background-color: #575959 !important;}
-.u-tintSpectrum .u-baseColor--buttonLight {border-color: #A8A8A8 !important; color: #A8A8A8 !important;}
-.u-tintSpectrum .u-baseColor--buttonLight:hover {border-color: #A8A8A8 !important;}
-.u-tintSpectrum .u-baseColor--buttonLight .icon:before,.u-tintSpectrum .u-baseColor--buttonLight .svgIcon {color: #A8A8A8 !important; fill: #A8A8A8 !important;}
-.u-tintSpectrum .u-baseColor--buttonDark {border-color: #575959 !important; color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--buttonDark:hover {border-color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--buttonDark .icon:before,.u-tintSpectrum .u-baseColor--buttonDark .svgIcon {color: #575959 !important; fill: #575959 !important;}
-.u-tintSpectrum .u-baseColor--buttonNormal {border-color: #818282 !important; color: #818282 !important;}
-.u-tintSpectrum .u-baseColor--buttonNormal:hover {border-color: #575959 !important;}
-.u-tintSpectrum .u-baseColor--buttonNormal .icon:before,.u-tintSpectrum .u-baseColor--buttonNormal .svgIcon {color: #818282 !important; fill: #818282 !important;}
-.u-tintSpectrum .u-baseColor--buttonDark.button--filled,.u-tintSpectrum .u-baseColor--buttonDark.button--withChrome.is-active {background-color: #575959 !important; border-color: #575959 !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-tintSpectrum .u-baseColor--buttonNormal.button--filled,.u-tintSpectrum .u-baseColor--buttonNormal.button--withChrome.is-active {background-color: #818282 !important; border-color: #818282 !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-tintSpectrum .u-baseColor--link {color: #818282 !important;}
-.u-tintSpectrum .u-baseColor--link.link--darkenOnHover:hover {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--link.link--darken:hover,.u-tintSpectrum .u-baseColor--link.link--darken:focus,.u-tintSpectrum .u-baseColor--link.link--darken:active {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--link.link--dark {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--link.link--dark.link--darken:hover,.u-tintSpectrum .u-baseColor--link.link--dark.link--darken:focus,.u-tintSpectrum .u-baseColor--link.link--dark.link--darken:active {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--link.link--darker {color: #404242 !important;}
-.u-tintSpectrum .u-baseColor--placeholderNormal ::-webkit-input-placeholder {color: #A8A8A8;}
-.u-tintSpectrum .u-baseColor--placeholderNormal ::-moz-placeholder {color: #A8A8A8;}
-.u-tintSpectrum .u-baseColor--placeholderNormal :-ms-input-placeholder {color: #A8A8A8;}
-.u-tintSpectrum .svgIcon--logoNew path:nth-child(1) {stroke: none !important; fill: #DDDDDD !important;}
-.u-tintSpectrum .svgIcon--logoNew path:nth-child(2) {stroke: none !important; fill: #CCCCCC !important;}
-.u-tintSpectrum .svgIcon--logoNew path:nth-child(3) {stroke: none !important; fill: #A8A8A8 !important;}
-.u-tintSpectrum .svgIcon--logoNew path:nth-child(4) {stroke: none !important; fill: #818282 !important;}
-.u-tintSpectrum .svgIcon--logoWordmarkBranding {stroke: none !important; fill: #404242 !important;}
-.u-tintSpectrum .svgIcon--logoMonogram {stroke: none !important; fill: #404242 !important;}
-.u-tintSpectrum .u-accentColor--borderLight {border-color: #A8A8A8 !important;}
-.u-tintSpectrum .u-accentColor--borderNormal {border-color: #818282 !important;}
-.u-tintSpectrum .u-accentColor--borderDark {border-color: #575959 !important;}
-.u-tintSpectrum .u-accentColor--iconLight .svgIcon,.u-tintSpectrum .u-accentColor--iconLight.svgIcon {fill: #A8A8A8 !important;}
-.u-tintSpectrum .u-accentColor--iconNormal .svgIcon,.u-tintSpectrum .u-accentColor--iconNormal.svgIcon {fill: #818282 !important;}
-.u-tintSpectrum .u-accentColor--iconDark .svgIcon,.u-tintSpectrum .u-accentColor--iconDark.svgIcon {fill: #575959 !important;}
-.u-tintSpectrum .u-accentColor--textNormal {color: #818282 !important;}
-.u-tintSpectrum .u-accentColor--hoverTextNormal:hover {color: #818282 !important;}
-.u-tintSpectrum .u-accentColor--textNormal.u-accentColor--textDarken:hover {color: #404242 !important;}
-.u-tintSpectrum .u-accentColor--textDark {color: #404242 !important;}
-.u-tintSpectrum .u-accentColor--backgroundLight {background-color: #A8A8A8 !important;}
-.u-tintSpectrum .u-accentColor--backgroundNormal {background-color: #818282 !important;}
-.u-tintSpectrum .u-accentColor--backgroundDark {background-color: #575959 !important;}
-.u-tintSpectrum .u-accentColor--buttonDark {border-color: #575959 !important; color: #404242 !important;}
-.u-tintSpectrum .u-accentColor--buttonDark:hover {border-color: #404242 !important;}
-.u-tintSpectrum .u-accentColor--buttonDark .icon:before,.u-tintSpectrum .u-accentColor--buttonDark .svgIcon{color: #575959 !important; fill: #575959 !important;}
-.u-tintSpectrum .u-accentColor--buttonNormal {border-color: #818282 !important; color: #818282 !important;}
-.u-tintSpectrum .u-accentColor--buttonNormal:hover {border-color: #575959 !important;}
-.u-tintSpectrum .u-accentColor--buttonNormal .icon:before,.u-tintSpectrum .u-accentColor--buttonNormal .svgIcon{color: #818282 !important; fill: #818282 !important;}
-.u-tintSpectrum .u-accentColor--buttonNormal.button--filled .icon:before,.u-tintSpectrum .u-accentColor--buttonNormal.button--filled .svgIcon{color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-tintSpectrum .u-accentColor--buttonDark.button--filled,.u-tintSpectrum .u-accentColor--buttonDark.button--withChrome.is-active,.u-tintSpectrum .u-accentColor--fillWhenActive.is-active {background-color: #575959 !important; border-color: #575959 !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-tintSpectrum .u-accentColor--buttonNormal.button--filled,.u-tintSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active {background-color: #818282 !important; border-color: #818282 !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-tintSpectrum .postArticle.is-withAccentColors .markup--user,.u-tintSpectrum .postArticle.is-withAccentColors .markup--query {color: #818282 !important;}
-.u-accentColor--highlightFaint {background-color: rgba(242, 240, 240, 1) !important;}
-.u-accentColor--highlightStrong.is-active .svgIcon {fill: rgba(224, 223, 223, 1) !important;}
-.postArticle.is-withAccentColors .markup--quote.is-other {background-color: rgba(242, 240, 240, 1) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-other {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(242, 240, 240, 1), rgba(242, 240, 240, 1));}
-.postArticle.is-withAccentColors .markup--quote.is-me {background-color: rgba(232, 231, 231, 1) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-me {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(232, 231, 231, 1), rgba(232, 231, 231, 1));}
-.postArticle.is-withAccentColors .markup--quote.is-targeted {background-color: rgba(224, 223, 223, 1) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-targeted {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(224, 223, 223, 1), rgba(224, 223, 223, 1));}
-.postArticle.is-withAccentColors .markup--quote.is-selected {background-color: rgba(224, 223, 223, 1) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-selected {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(224, 223, 223, 1), rgba(224, 223, 223, 1));}
-.postArticle.is-withAccentColors .markup--highlight {background-color: rgba(224, 223, 223, 1) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--highlight {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(224, 223, 223, 1), rgba(224, 223, 223, 1));}</style><style class="js-collectionStyleConstant">.u-imageBgColor {background-color: rgba(0, 0, 0, 0.24705882352941178);}
-.u-imageSpectrum .u-baseColor--borderLight {border-color: rgba(255, 255, 255, 0.6980392156862745) !important;}
-.u-imageSpectrum .u-baseColor--borderNormal {border-color: rgba(255, 255, 255, 0.8980392156862745) !important;}
-.u-imageSpectrum .u-baseColor--borderDark {border-color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--iconLight .svgIcon,.u-imageSpectrum .u-baseColor--iconLight.svgIcon {fill: rgba(255, 255, 255, 0.8) !important;}
-.u-imageSpectrum .u-baseColor--iconNormal .svgIcon,.u-imageSpectrum .u-baseColor--iconNormal.svgIcon {fill: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--iconDark .svgIcon,.u-imageSpectrum .u-baseColor--iconDark.svgIcon {fill: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--textNormal {color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--textNormal.u-baseColor--textDarken:hover {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--textDark {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--textDarker {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--backgroundLight {background-color: rgba(255, 255, 255, 0.8980392156862745) !important;}
-.u-imageSpectrum .u-baseColor--backgroundNormal {background-color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--backgroundDark {background-color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--buttonLight {border-color: rgba(255, 255, 255, 0.6980392156862745) !important; color: rgba(255, 255, 255, 0.8) !important;}
-.u-imageSpectrum .u-baseColor--buttonLight:hover {border-color: rgba(255, 255, 255, 0.6980392156862745) !important;}
-.u-imageSpectrum .u-baseColor--buttonLight .icon:before,.u-imageSpectrum .u-baseColor--buttonLight .svgIcon {color: rgba(255, 255, 255, 0.8) !important; fill: rgba(255, 255, 255, 0.8) !important;}
-.u-imageSpectrum .u-baseColor--buttonDark {border-color: rgba(255, 255, 255, 0.9490196078431372) !important; color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--buttonDark:hover {border-color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--buttonDark .icon:before,.u-imageSpectrum .u-baseColor--buttonDark .svgIcon {color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--buttonNormal {border-color: rgba(255, 255, 255, 0.8980392156862745) !important; color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--buttonNormal:hover {border-color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--buttonNormal .icon:before,.u-imageSpectrum .u-baseColor--buttonNormal .svgIcon {color: rgba(255, 255, 255, 0.9490196078431372) !important; fill: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--buttonDark.button--filled,.u-imageSpectrum .u-baseColor--buttonDark.button--withChrome.is-active {background-color: rgba(255, 255, 255, 1) !important; border-color: rgba(255, 255, 255, 1) !important; color: rgba(0, 0, 0, 0.24705882352941178) !important; fill: rgba(0, 0, 0, 0.24705882352941178) !important;}
-.u-imageSpectrum .u-baseColor--buttonNormal.button--filled,.u-imageSpectrum .u-baseColor--buttonNormal.button--withChrome.is-active {background-color: rgba(255, 255, 255, 0.9490196078431372) !important; border-color: rgba(255, 255, 255, 0.9490196078431372) !important; color: rgba(0, 0, 0, 0.24705882352941178) !important; fill: rgba(0, 0, 0, 0.24705882352941178) !important;}
-.u-imageSpectrum .u-baseColor--link {color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-baseColor--link.link--darkenOnHover:hover {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--link.link--darken:hover,.u-imageSpectrum .u-baseColor--link.link--darken:focus,.u-imageSpectrum .u-baseColor--link.link--darken:active {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--link.link--dark {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--link.link--dark.link--darken:hover,.u-imageSpectrum .u-baseColor--link.link--dark.link--darken:focus,.u-imageSpectrum .u-baseColor--link.link--dark.link--darken:active {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--link.link--darker {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-baseColor--placeholderNormal ::-webkit-input-placeholder {color: rgba(255, 255, 255, 0.8);}
-.u-imageSpectrum .u-baseColor--placeholderNormal ::-moz-placeholder {color: rgba(255, 255, 255, 0.8);}
-.u-imageSpectrum .u-baseColor--placeholderNormal :-ms-input-placeholder {color: rgba(255, 255, 255, 0.8);}
-.u-imageSpectrum .svgIcon--logoNew path:nth-child(1) {stroke: none !important; fill: rgba(255, 255, 255, 0.4) !important;}
-.u-imageSpectrum .svgIcon--logoNew path:nth-child(2) {stroke: none !important; fill: rgba(255, 255, 255, 0.4980392156862745) !important;}
-.u-imageSpectrum .svgIcon--logoNew path:nth-child(3) {stroke: none !important; fill: rgba(255, 255, 255, 0.6980392156862745) !important;}
-.u-imageSpectrum .svgIcon--logoNew path:nth-child(4) {stroke: none !important; fill: rgba(255, 255, 255, 0.8980392156862745) !important;}
-.u-imageSpectrum .svgIcon--logoWordmarkBranding {stroke: none !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .svgIcon--logoMonogram {stroke: none !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--borderLight {border-color: rgba(255, 255, 255, 0.6980392156862745) !important;}
-.u-imageSpectrum .u-accentColor--borderNormal {border-color: rgba(255, 255, 255, 0.8980392156862745) !important;}
-.u-imageSpectrum .u-accentColor--borderDark {border-color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--iconLight .svgIcon,.u-imageSpectrum .u-accentColor--iconLight.svgIcon {fill: rgba(255, 255, 255, 0.8) !important;}
-.u-imageSpectrum .u-accentColor--iconNormal .svgIcon,.u-imageSpectrum .u-accentColor--iconNormal.svgIcon {fill: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--iconDark .svgIcon,.u-imageSpectrum .u-accentColor--iconDark.svgIcon {fill: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--textNormal {color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--hoverTextNormal:hover {color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--textNormal.u-accentColor--textDarken:hover {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--textDark {color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--backgroundLight {background-color: rgba(255, 255, 255, 0.8980392156862745) !important;}
-.u-imageSpectrum .u-accentColor--backgroundNormal {background-color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--backgroundDark {background-color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--buttonDark {border-color: rgba(255, 255, 255, 0.9490196078431372) !important; color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--buttonDark:hover {border-color: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--buttonDark .icon:before,.u-imageSpectrum .u-accentColor--buttonDark .svgIcon{color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-imageSpectrum .u-accentColor--buttonNormal {border-color: rgba(255, 255, 255, 0.8980392156862745) !important; color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--buttonNormal:hover {border-color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--buttonNormal .icon:before,.u-imageSpectrum .u-accentColor--buttonNormal .svgIcon{color: rgba(255, 255, 255, 0.9490196078431372) !important; fill: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--buttonNormal.button--filled .icon:before,.u-imageSpectrum .u-accentColor--buttonNormal.button--filled .svgIcon{color: rgba(0, 0, 0, 0.24705882352941178) !important; fill: rgba(0, 0, 0, 0.24705882352941178) !important;}
-.u-imageSpectrum .u-accentColor--buttonDark.button--filled,.u-imageSpectrum .u-accentColor--buttonDark.button--withChrome.is-active,.u-imageSpectrum .u-accentColor--fillWhenActive.is-active {background-color: rgba(255, 255, 255, 1) !important; border-color: rgba(255, 255, 255, 1) !important; color: rgba(0, 0, 0, 0.24705882352941178) !important; fill: rgba(0, 0, 0, 0.24705882352941178) !important;}
-.u-imageSpectrum .u-accentColor--buttonNormal.button--filled,.u-imageSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active {background-color: rgba(255, 255, 255, 0.9490196078431372) !important; border-color: rgba(255, 255, 255, 0.9490196078431372) !important; color: rgba(0, 0, 0, 0.24705882352941178) !important; fill: rgba(0, 0, 0, 0.24705882352941178) !important;}
-.u-imageSpectrum .postArticle.is-withAccentColors .markup--user,.u-imageSpectrum .postArticle.is-withAccentColors .markup--query {color: rgba(255, 255, 255, 0.9490196078431372) !important;}
-.u-imageSpectrum .u-accentColor--highlightFaint {background-color: rgba(255, 255, 255, 0.2) !important;}
-.u-imageSpectrum .u-accentColor--highlightStrong.is-active .svgIcon {fill: rgba(255, 255, 255, 0.6) !important;}
-.postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-other {background-color: rgba(255, 255, 255, 0.2) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-other {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.2));}
-.postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-me {background-color: rgba(255, 255, 255, 0.4) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-me {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.4));}
-.postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-targeted {background-color: rgba(255, 255, 255, 0.6) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-targeted {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));}
-.postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-selected {background-color: rgba(255, 255, 255, 0.6) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .u-imageSpectrum .markup--quote.is-selected {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));}
-.postArticle.is-withAccentColors .u-imageSpectrum .markup--highlight {background-color: rgba(255, 255, 255, 0.6) !important;}
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .u-imageSpectrum .markup--highlight {background-color: transparent !important; background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));}.u-resetSpectrum .u-tintBgColor {background-color: rgba(255, 255, 255, 1) !important;}.u-resetSpectrum .u-tintBgColor .u-fadeLeft:before {background-image: linear-gradient(to right, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%) !important;}.u-resetSpectrum .u-tintBgColor .u-fadeRight:after {background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%) !important;}
-.u-resetSpectrum .u-baseColor--borderLight {border-color: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--borderNormal {border-color: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--borderDark {border-color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--iconLight .svgIcon,.u-resetSpectrum .u-baseColor--iconLight.svgIcon {fill: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--iconNormal .svgIcon,.u-resetSpectrum .u-baseColor--iconNormal.svgIcon {fill: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--iconDark .svgIcon,.u-resetSpectrum .u-baseColor--iconDark.svgIcon {fill: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--textNormal {color: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--textNormal.u-baseColor--textDarken:hover {color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--textDark {color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--textDarker {color: rgba(0, 0, 0, 0.8) !important;}
-.u-resetSpectrum .u-baseColor--backgroundLight {background-color: rgba(0, 0, 0, 0.09803921568627451) !important;}
-.u-resetSpectrum .u-baseColor--backgroundNormal {background-color: rgba(0, 0, 0, 0.2) !important;}
-.u-resetSpectrum .u-baseColor--backgroundDark {background-color: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--buttonLight {border-color: rgba(0, 0, 0, 0.2980392156862745) !important; color: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--buttonLight:hover {border-color: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--buttonLight .icon:before,.u-resetSpectrum .u-baseColor--buttonLight .svgIcon {color: rgba(0, 0, 0, 0.2980392156862745) !important; fill: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--buttonDark {border-color: rgba(0, 0, 0, 0.6) !important; color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--buttonDark:hover {border-color: rgba(0, 0, 0, 0.8) !important;}
-.u-resetSpectrum .u-baseColor--buttonDark .icon:before,.u-resetSpectrum .u-baseColor--buttonDark .svgIcon {color: rgba(0, 0, 0, 0.6) !important; fill: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--buttonNormal {border-color: rgba(0, 0, 0, 0.4980392156862745) !important; color: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--buttonNormal:hover {border-color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--buttonNormal .icon:before,.u-resetSpectrum .u-baseColor--buttonNormal .svgIcon {color: rgba(0, 0, 0, 0.4980392156862745) !important; fill: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--buttonDark.button--filled,.u-resetSpectrum .u-baseColor--buttonDark.button--withChrome.is-active {background-color: rgba(0, 0, 0, 0.2980392156862745) !important; border-color: rgba(0, 0, 0, 0.2980392156862745) !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-resetSpectrum .u-baseColor--buttonNormal.button--filled,.u-resetSpectrum .u-baseColor--buttonNormal.button--withChrome.is-active {background-color: rgba(0, 0, 0, 0.2) !important; border-color: rgba(0, 0, 0, 0.2) !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-resetSpectrum .u-baseColor--link {color: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .u-baseColor--link.link--darkenOnHover:hover {color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--link.link--darken:hover,.u-resetSpectrum .u-baseColor--link.link--darken:focus,.u-resetSpectrum .u-baseColor--link.link--darken:active {color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--link.link--dark {color: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-baseColor--link.link--dark.link--darken:hover,.u-resetSpectrum .u-baseColor--link.link--dark.link--darken:focus,.u-resetSpectrum .u-baseColor--link.link--dark.link--darken:active {color: rgba(0, 0, 0, 0.8) !important;}
-.u-resetSpectrum .u-baseColor--link.link--darker {color: rgba(0, 0, 0, 0.8) !important;}
-.u-resetSpectrum .u-baseColor--placeholderNormal ::-webkit-input-placeholder {color: rgba(0, 0, 0, 0.2980392156862745);}
-.u-resetSpectrum .u-baseColor--placeholderNormal ::-moz-placeholder {color: rgba(0, 0, 0, 0.2980392156862745);}
-.u-resetSpectrum .u-baseColor--placeholderNormal :-ms-input-placeholder {color: rgba(0, 0, 0, 0.2980392156862745);}
-.u-resetSpectrum .svgIcon--logoNew path:nth-child(1) {stroke: none !important; fill: rgba(0, 0, 0, 0.2) !important;}
-.u-resetSpectrum .svgIcon--logoNew path:nth-child(2) {stroke: none !important; fill: rgba(0, 0, 0, 0.2980392156862745) !important;}
-.u-resetSpectrum .svgIcon--logoNew path:nth-child(3) {stroke: none !important; fill: rgba(0, 0, 0, 0.4) !important;}
-.u-resetSpectrum .svgIcon--logoNew path:nth-child(4) {stroke: none !important; fill: rgba(0, 0, 0, 0.4980392156862745) !important;}
-.u-resetSpectrum .svgIcon--logoWordmarkBranding {stroke: none !important; fill: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .svgIcon--logoMonogram {stroke: none !important; fill: rgba(0, 0, 0, 0.6) !important;}
-.u-resetSpectrum .u-accentColor--borderLight {border-color: rgba(2, 184, 117, 1) !important;}
-.u-resetSpectrum .u-accentColor--borderNormal {border-color: rgba(2, 184, 117, 1) !important;}
-.u-resetSpectrum .u-accentColor--borderDark {border-color: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--iconLight .svgIcon,.u-resetSpectrum .u-accentColor--iconLight.svgIcon {fill: rgba(2, 184, 117, 1) !important;}
-.u-resetSpectrum .u-accentColor--iconNormal .svgIcon,.u-resetSpectrum .u-accentColor--iconNormal.svgIcon {fill: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--iconDark .svgIcon,.u-resetSpectrum .u-accentColor--iconDark.svgIcon {fill: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--textNormal {color: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--hoverTextNormal:hover {color: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--textNormal.u-accentColor--textDarken:hover {color: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--textDark {color: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--backgroundLight {background-color: rgba(2, 184, 117, 1) !important;}
-.u-resetSpectrum .u-accentColor--backgroundNormal {background-color: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--backgroundDark {background-color: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonDark {border-color: rgba(0, 171, 107, 1) !important; color: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonDark:hover {border-color: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonDark .icon:before,.u-resetSpectrum .u-accentColor--buttonDark .svgIcon{color: rgba(28, 153, 99, 1) !important; fill: rgba(28, 153, 99, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonNormal {border-color: rgba(2, 184, 117, 1) !important; color: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonNormal:hover {border-color: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonNormal .icon:before,.u-resetSpectrum .u-accentColor--buttonNormal .svgIcon{color: rgba(0, 171, 107, 1) !important; fill: rgba(0, 171, 107, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonNormal.button--filled .icon:before,.u-resetSpectrum .u-accentColor--buttonNormal.button--filled .svgIcon{color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonDark.button--filled,.u-resetSpectrum .u-accentColor--buttonDark.button--withChrome.is-active,.u-resetSpectrum .u-accentColor--fillWhenActive.is-active {background-color: rgba(28, 153, 99, 1) !important; border-color: rgba(28, 153, 99, 1) !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-resetSpectrum .u-accentColor--buttonNormal.button--filled,.u-resetSpectrum .u-accentColor--buttonNormal.button--withChrome.is-active {background-color: rgba(0, 171, 107, 1) !important; border-color: rgba(0, 171, 107, 1) !important; color: rgba(255, 255, 255, 1) !important; fill: rgba(255, 255, 255, 1) !important;}
-.u-resetSpectrum .postArticle.is-withAccentColors .markup--user,.u-resetSpectrum .postArticle.is-withAccentColors .markup--query {color: rgba(0, 171, 107, 1) !important;}</style></div></div></div><div class="loadingBar"></div><script>// <![CDATA[
-window["obvInit"] = function (opt_embedded) {window["obvInit"]["embedded"] = opt_embedded; window["obvInit"]["ready"] = true;}
-// ]]></script><script>// <![CDATA[
-var GLOBALS = {"audioUrl":"https://d1fcbxp97j4nb2.cloudfront.net","baseUrl":"https://medium.com","buildLabel":"29628-f0e4298","currentUser":{"userId":"c9ef5404fa69","username":"kikobeats","flags":7,"name":"Kiko Beats","email":"kikohumanbeatbox@gmail.com","bio":"Web is the Platform. Programmer, Computer Science & Software Engineer. Working at @audienseco. UNIX, JavaScript & Open Source.","salt":"gvCfACrGP8vx83t5","imageId":"1*j31ieu3b9LqPTf3tj_mhcw.jpeg","backgroundImageId":"1*_gpOxzXPub2buuE9MeJ3YQ.jpeg","twitterAccessToken":"101198215-zQHUI4dxdMekAPY5jktsi1TWc8HuTXbMNTU6Y5on","twitterAccessTokenSecret":"dcICJHup64lhfxWBVDeEM98HJuQQO68JZYA377lPqyo3s","twitterId":"101198215","twitterScreenName":"Kikobeats","twitterAvatar":"https://pbs.twimg.com/profile_images/819125136221683712/oUuQv7DX.jpg","createdAt":1385302017564,"updatedAt":1499259546041,"lastPostCreatedAt":1498494699221,"writeAccessGrantedAt":1385302033402,"lastTimezoneOffsetMin":-120,"languageCode":"es","allowEmails":1,"allowSocialEmails":2,"twitterLastImportedAt":1427124723670,"isVerified":true,"subscriberEmail":"","lastOpenedIosApp":1487379579578,"googleAccountId":"115065145403012295856","activityLastSeenAt":1494282905842,"googleEmail":"kikohumanbeatbox@gmail.com"},"currentUserHasUnverifiedEmail":false,"isAuthenticated":true,"isCurrentUserVerified":true,"language":"es","mediumTwitterScreenName":"medium","miroUrl":"https://cdn-images-1.medium.com","moduleUrls":{"base":"https://cdn-static-1.medium.com/_/fp/gen-js/main-base.bundle.DY9d9kIzksrFy-_OO43Bog.js","notes":"https://cdn-static-1.medium.com/_/fp/gen-js/main-notes.bundle.nzp_emdgmrNfdpZsECz_qA.js","payments":"https://cdn-static-1.medium.com/_/fp/gen-js/main-payments.bundle.W7pD3z5AbNeCDiD0Y4rwMQ.js","posters":"https://cdn-static-1.medium.com/_/fp/gen-js/main-posters.bundle.fkp0PhQFdc-6sJ3fykbGZg.js","common-async":"https://cdn-static-1.medium.com/_/fp/gen-js/main-common-async.bundle.rveSsmK67CS4J539DF2IPQ.js","stats":"https://cdn-static-1.medium.com/_/fp/gen-js/main-stats.bundle.7JKKtS9GGBnbVCzIpBUcmQ.js","home-screens":"https://cdn-static-1.medium.com/_/fp/gen-js/main-home-screens.bundle.8vvoEHHxxZum-y2pabI46A.js","misc-screens":"https://cdn-static-1.medium.com/_/fp/gen-js/main-misc-screens.bundle.ZuR-hqsL7_zf_E4Iata-wg.js"},"previewConfig":{"weightThreshold":1,"weightImageParagraph":0.51,"weightIframeParagraph":0.8,"weightTextParagraph":0.08,"weightEmptyParagraph":0,"weightP":0.003,"weightH":0.005,"weightBq":0.003,"minPTextLength":60,"truncateBoundaryChars":20,"detectTitle":true,"detectTitleLevThreshold":0.15},"productName":"Medium","supportsEdit":true,"termsUrl":"//medium.com/policy/9db0094a1e0f","textshotHost":"textshot.medium.com","transactionId":"1499262801224:960ffa22b0bf","useragent":{"browser":"chrome","family":"chrome","os":"mac","version":59,"supportsDesktopEdit":true,"supportsInteract":true,"supportsView":true,"isMobile":false,"isTablet":false,"isNative":false,"supportsFileAPI":true,"isTier1":true,"clientVersion":"","unknownParagraphsBad":false,"clientChannel":"","supportsRealScrollEvents":true,"supportsVhUnits":true,"ruinsViewportSections":false,"supportsHtml5Video":true,"supportsMagicUnderlines":true,"isWebView":false,"isFacebookWebView":false,"supportsProgressiveMedia":true,"supportsPromotedPosts":true,"isBot":false,"isNativeIphone":false,"supportsCssVariables":true,"supportsVideoSections":false,"emojiSupportLevel":5,"supportsScrollableMetabar":true},"variants":{"allow_access":true,"allow_signup":true,"allow_test_auth":"disallow","signin_services":"twitter,facebook,google,email,google-fastidv","signup_services":"twitter,facebook,google,email,google-fastidv","android_rating_prompt_recommend_threshold":5,"google_sign_in_android":true,"enable_onboarding":true,"ios_custom_miro_url":"https://cdn-images-1.medium.com","reengagement_notification_duration":3,"enable_adsnative_integration":true,"browsable_stream_config_bucket":"curated-topics","ios_small_post_preview_truncation_length":5.5,"ios_large_post_preview_truncation_length":5.5,"disable_ios_catalog_badging":true,"enable_series_creation":true,"enable_your_series_pages":true,"enable_productionized_series":true,"enable_dedicated_series_tab_api_ios":true,"enable_clap_milestone_notifications":true,"enable_series_stats_page":true,"enable_direct_auth_connect":true,"enable_post_import":true,"enable_sponsored_post_labelling":true,"enable_logged_in_follow_on_collection_post":true,"promoted_story_placement_locations":"POST_PAGE_FOOTER","enable_chunky_home_page":true,"enable_search_collection_by_tag_recency_filter":true,"search_collection_by_tag_filter_min_votes":10,"enable_sms_app_promo":true,"enable_export_members":true,"enable_series_card_background_creation":true,"available_membership_plans":"60e220181034","double_write_post_from_followed_tag_items":true,"enable_sms":true,"enable_series_in_user_profiles":true,"enable_new_logged_out_bento_operation":true,"enable_user_social_suggestions":true,"disable_twitter_autofollow":true,"enable_sequences":true,"enable_web_audio":true,"enable_updated_auto_grid_style":true,"is_not_medium_subscriber":true,"subs_landing_copy_experiments":"long","enable_free_trial_reminders":true,"add_suggested_topics_to_edition":true,"add_suggested_topics_to_edition_survey":true,"enable_emoji_in_editor":true,"glyph_font_set":"m","enable_upsell_tracking":true,"post_page_wall_limit":3,"enable_rainbow_logo":true,"membership_reminder_email_subject_bucket":"control","enable_noteworthy_promo":true},"xsrfToken":"G8yCtKY4gCmbPwbE","iosAppId":"828256236","supportEmail":"yourfriends@medium.com","teamName":"Team Medium","fp":{"/icons/favicon.svg":"https://cdn-static-1.medium.com/_/fp/icons/favicon.KjTfUJo7yJH_fCoUzzH3cg.svg","/icons/favicon-dev-editor.ico":"https://cdn-static-1.medium.com/_/fp/icons/favicon-dev-editor.YKKRxBO8EMvIqhyCwIiJeQ.ico","/icons/favicon-hatch-editor.ico":"https://cdn-static-1.medium.com/_/fp/icons/favicon-hatch-editor.BuEyHIqlyh2s_XEk4Rl32Q.ico","/icons/favicon-medium-editor.ico":"https://cdn-static-1.medium.com/_/fp/icons/favicon-medium-editor.PiakrZWB7Yb80quUVQWM6g.ico"},"authBaseUrl":"https://medium.com","imageUploadSizeMb":25,"isAuthDomainRequest":true,"algoliaApiEndpoint":"https://MQ57UUUQZ2-dsn.algolia.net","algoliaAppId":"MQ57UUUQZ2","algoliaSearchOnlyApiKey":"394474ced050e3911ae2249ecc774921","iosAppStoreUrl":"https://itunes.apple.com/app/medium-everyones-stories/id828256236?pt=698524&mt=8","iosAppLinkBaseUrl":"medium:","algoliaIndexPrefix":"medium_","androidPlayStoreUrl":"https://play.google.com/store/apps/details?id=com.medium.reader","googleClientId":"216296035834-k1k6qe060s2tp2a2jam4ljdcms00sttg.apps.googleusercontent.com","androidPackage":"com.medium.reader","androidPlayStoreMarketScheme":"market://details?id=com.medium.reader","googleAuthUri":"https://accounts.google.com/o/oauth2/auth","androidScheme":"medium","layoutData":{"useDynamicScripts":false,"googleAnalyticsTrackingCode":"UA-24232453-2","jsShivUrl":"https://cdn-static-1.medium.com/_/fp/js/shiv.RI2ePTZ5gFmMgLzG5bEVAA.js","useDynamicCss":false,"faviconUrl":"https://cdn-static-1.medium.com/_/fp/icons/favicon-medium.TAS6uQ-Y7kcKgi0xjcYHXw.ico","faviconImageId":"1*W0nmth_X8nFKjn6BZ388UQ.png","fontSets":[{"id":1,"url":"https://cdn-static-1.medium.com/_/fp/css/fonts-base.by5Oi_VbnwEIvhnWIsuUjA.css"},{"id":4,"url":"https://cdn-static-1.medium.com/_/fp/css/fonts-lazy-base.g08Jj5TZPAiuPWj5YNUsSg.css"},{"id":6,"url":"https://cdn-static-1.medium.com/_/fp/css/fonts-latin-base.141WxxXgxGxNcfeza73H7Q.css"},{"id":7,"url":"https://cdn-static-1.medium.com/_/fp/css/fonts-lazy-latin-base.jMU532QDmysQMOINr-cr2A.css"}],"editorFaviconUrl":"https://cdn-static-1.medium.com/_/fp/icons/favicon-medium-editor.PiakrZWB7Yb80quUVQWM6g.ico"},"authBaseUrlRev":"moc.muidem//:sptth","isDnt":false,"stripePublishableKey":"pk_live_7FReX44VnNIInZwrIIx6ghjl","archiveUploadSizeMb":100,"paymentData":{"currencies":{"1":{"label":"US Dollar","external":"usd"}},"countries":{"1":{"label":"United States of America","external":"US"}},"accountTypes":{"1":{"label":"Individual","external":"individual"},"2":{"label":"Company","external":"company"}}},"previewConfig2":{"weightThreshold":1,"weightImageParagraph":0.05,"raiseImage":true,"enforceHeaderHierarchy":true,"isImageInsetRight":true},"isAmp":false,"iosScheme":"medium","isSwBoot":false,"lightstep":{"accessToken":"ce5be895bef60919541332990ac9fef2","carrier":"{\"ot-tracer-spanid\":\"03286b532838d987\",\"ot-tracer-traceid\":\"71e81f071a842734\",\"ot-tracer-sampled\":\"true\"}","host":"collector-medium.lightstep.com"},"facebook":{"key":"542599432471018","namespace":"medium-com","scope":{"default":["public_profile","email","user_friends"],"connect":["public_profile","email","user_friends"],"login":["public_profile","email","user_friends"],"share":["public_profile","email","user_friends","publish_actions"]}},"mailingListArchiveUploadSizeMb":2,"availableMembershipPlans":["60e220181034"],"editorsPicksTopicId":"3985d2a191c5","popularOnMediumTopicId":"9d34e48ecf94","memberContentTopicId":"13d7efd82fb2","audioContentTopicId":"3792abbd134","brandedSequenceId":"7d337ddf1941","isDoNotAuth":false,"goldfinchUrl":"https://goldfinch.medium.com","buggle":{"url":"https://buggle.medium.com","videoUrl":"https://cdn-videos-1.medium.com","audioUrl":"https://cdn-audio-1.medium.com","accessToken":"pJN6XGc43dDJLHJQ2ixamOFHUnAgKvhp"}}
-// ]]></script><script charset="UTF-8" src="https://cdn-static-1.medium.com/_/fp/gen-js/main-base.bundle.DY9d9kIzksrFy-_OO43Bog.js" async></script><script>// <![CDATA[
-window["obvInit"]({"value":{"id":"15fd2dd8f07b","versionId":"aca3888b20f","creatorId":"393110b0b9e4","creator":{"userId":"393110b0b9e4","name":"Sean T. Larkin","username":"TheLarkInn","createdAt":1426695004676,"lastPostCreatedAt":1498710705921,"imageId":"1*64H5DfQ6_WwZ0WbsY430dA.jpeg","backgroundImageId":"","bio":"@Webpack Core team & AngularCLI team. User Experience Developer @ Mutual of Omaha, Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and Gardener!","twitterScreenName":"TheLarkInn","socialStats":{"userId":"393110b0b9e4","usersFollowedCount":300,"usersFollowedByCount":3842,"type":"SocialStats"},"social":{"userId":"c9ef5404fa69","targetUserId":"393110b0b9e4","type":"Social"},"facebookAccountId":"781525381174","allowNotes":1,"type":"User"},"homeCollection":{"id":"b2f039622545","name":"webpack","slug":"webpack","tags":["WEB PERFORMANCE","TECH","JAVASCRIPT","WEBPACK","OPEN SOURCE"],"creatorId":"cccc522e775a","description":"The official Medium publication for the webpack opensource project!","shortDescription":"The official Medium publication for the webpack opensource…","image":{"imageId":"1*Wx82vEGrMfW4AdSLodZXgQ.png","filter":"","backgroundSize":"","originalWidth":874,"originalHeight":989,"strategy":"resample","height":0,"width":0},"metadata":{"followerCount":7228,"activeAt":1498548836430},"virtuals":{"permissions":{"canPublish":false,"canPublishAll":false,"canRepublish":false,"canRemove":false,"canManageAll":false,"canSubmit":false,"canEditPosts":false,"canAddWriters":false,"canViewStats":false,"canSendNewsletter":false,"canViewLockedPosts":false,"canViewCloaked":false,"canEditOwnPosts":false,"canBeAssignedAuthor":false},"isSubscribed":false,"isNewsletterSubscribed":false,"memberOfMembershipPlanId":""},"logo":{"imageId":"1*gdoQ1_5OID90wf1eLTFvWw.png","filter":"","backgroundSize":"","originalWidth":3916,"originalHeight":1524,"strategy":"resample","height":0,"width":0},"publicEmail":"webpack@opencollective.com","collectionMastheadId":"b44e034c9e36","sections":[{"type":2,"collectionHeaderMetadata":{"title":"webpack","backgroundImage":{},"logoImage":{},"alignment":2,"layout":4}},{"type":1,"postListMetadata":{"source":1,"layout":2,"number":1,"postIds":[],"sectionHeader":"Latest Story"}},{"type":1,"postListMetadata":{"source":3,"layout":4,"number":3,"postIds":["15fd2dd8f07b","a38fd3e296a","8519def2cac7"],"sectionHeader":"Featured Stories"}},{"type":1,"postListMetadata":{"source":2,"layout":4,"number":4,"postIds":[],"sectionHeader":"Trending"}},{"type":1,"postListMetadata":{"source":1,"layout":6,"number":7,"postIds":[]}}],"tintColor":"#FFFFFFFF","lightText":false,"favicon":{"imageId":"","filter":"","backgroundSize":"","originalWidth":0,"originalHeight":0,"strategy":"resample","height":0,"width":0},"colorPalette":{"defaultBackgroundSpectrum":{"colorPoints":[{"color":"#FF848585","point":0},{"color":"#FF7B7B7B","point":0.1},{"color":"#FF717272","point":0.2},{"color":"#FF686868","point":0.3},{"color":"#FF5E5E5E","point":0.4},{"color":"#FF545454","point":0.5},{"color":"#FF494A4A","point":0.6},{"color":"#FF3F3F3F","point":0.7},{"color":"#FF333333","point":0.8},{"color":"#FF272727","point":0.9},{"color":"#FF1A1A1A","point":1}],"backgroundColor":"#FFFFFFFF"},"tintBackgroundSpectrum":{"colorPoints":[{"color":"#FFFFFFFF","point":0},{"color":"#FFEEEEEE","point":0.1},{"color":"#FFDDDDDD","point":0.2},{"color":"#FFCCCCCC","point":0.3},{"color":"#FFBABABB","point":0.4},{"color":"#FFA8A8A8","point":0.5},{"color":"#FF959696","point":0.6},{"color":"#FF818282","point":0.7},{"color":"#FF6D6E6E","point":0.8},{"color":"#FF575959","point":0.9},{"color":"#FF404242","point":1}],"backgroundColor":"#FFFFFFFF"},"highlightSpectrum":{"colorPoints":[{"color":"#FFF4F2F2","point":0},{"color":"#FFF2F0F0","point":0.1},{"color":"#FFF0EEEE","point":0.2},{"color":"#FFEEECEC","point":0.3},{"color":"#FFECEBEA","point":0.4},{"color":"#FFEAE9E8","point":0.5},{"color":"#FFE8E7E7","point":0.6},{"color":"#FFE6E5E5","point":0.7},{"color":"#FFE4E3E3","point":0.8},{"color":"#FFE2E1E1","point":0.9},{"color":"#FFE0DFDF","point":1}],"backgroundColor":"#FFFFFFFF"}},"navItems":[{"type":4,"title":"Announcments","url":"https://medium.com/webpack/announcements/home","topicId":"93793abf70c9","source":"topicId"},{"type":4,"title":"Freelance Log Book","url":"https://medium.com/webpack/freelancing-log-book/home","topicId":"fd7d773f7e5f","source":"topicId"},{"type":4,"title":"Contributors Guide","url":"https://medium.com/webpack/contributors-guide/home","topicId":"169a47a764ae","source":"topicId"},{"type":4,"title":"Tips and Tricks","url":"https://medium.com/webpack/tips-and-tricks/home","topicId":"8d6c6bf5b3b0","source":"topicId"},{"type":6,"title":"About Us","url":"https://medium.com/webpack/about"},{"type":3,"title":"Official Documentation","url":"http://webpack.js.org"}],"colorBehavior":1,"instantArticlesState":0,"acceleratedMobilePagesState":0,"ampLogo":{"imageId":"","filter":"","backgroundSize":"","originalWidth":0,"originalHeight":0,"strategy":"resample","height":0,"width":0},"header":{"title":"webpack","backgroundImage":{},"logoImage":{},"alignment":2,"layout":4},"type":"Collection"},"homeCollectionId":"b2f039622545","title":"🍾🚀 webpack 3: Official Release!! 🚀🍾","detectedLanguage":"en","latestVersion":"aca3888b20f","latestPublishedVersion":"aca3888b20f","hasUnpublishedEdits":false,"latestRev":707,"createdAt":1497886912254,"updatedAt":1499255654175,"acceptedAt":0,"firstPublishedAt":1497893008613,"latestPublishedAt":1498064228802,"vote":false,"experimentalCss":"","displayAuthor":"","content":{"subtitle":"Now with Scope Hoisting, “magic comments”, and more!","bodyModel":{"paragraphs":[{"name":"821e","type":4,"text":"It’s finally here. And it’s beautiful.","markups":[],"layout":3,"metadata":{"id":"1*Ac4K68j43uSbvHnKZKfXPw.jpeg","originalWidth":4896,"originalHeight":3264}},{"name":"ea51","type":3,"text":"🍾🚀 webpack 3: Official Release!! 🚀🍾","markups":[]},{"name":"8fe8","type":13,"text":"Scope Hoisting, “magic comments”, and more!","markups":[]},{"name":"927b","type":1,"text":"After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Moreover, we promised to deliver them in a faster, more stable release cycle.","markups":[{"type":1,"start":175,"end":181},{"type":1,"start":183,"end":194},{"type":2,"start":175,"end":181},{"type":2,"start":183,"end":194}]},{"name":"efac","type":1,"text":"No more year-long betas, no breaking changes between release candidates. We promised to do you right by you, the community that makes webpack thrive.","markups":[{"type":1,"start":104,"end":108},{"type":2,"start":103,"end":149}]},{"name":"ca2d","type":1,"text":"The webpack team is proud to announce that today we have released webpack 3.0.0!!! You can download or upgrade to it today!!","markups":[]},{"name":"549b","type":1,"text":"npm install webpack@3.0.0 --save-dev","markups":[{"type":10,"start":0,"end":36}]},{"name":"69df","type":1,"text":"or with","markups":[]},{"name":"4ef7","type":1,"text":"yarn add webpack@3.0.0 --dev","markups":[{"type":10,"start":0,"end":28}]},{"name":"17f8","type":1,"text":"Migrating from webpack 2 to 3, should involve no effort beyond running the upgrade commands in your terminal. We marked this as a Major change because of internal breaking changes that could affect some plugins.","markups":[{"type":1,"start":46,"end":109},{"type":2,"start":46,"end":109}]},{"name":"2878","type":1,"text":"So far we’ve seen 98% of users upgrade with no breaking functionality at all!!!","markups":[{"type":1,"start":0,"end":79},{"type":2,"start":0,"end":79}]},{"name":"3750","type":3,"text":"What’s new?","markups":[]},{"name":"3c03","type":1,"text":"As we mentioned, we aimed to deliver the features that you voted for! Because of the overwhelming GitHub contributions, support from our backers and sponsors, we have been able to hit each one. 😍","markups":[{"type":3,"start":59,"end":68,"href":"https://webpack.js.org/vote","title":"","rel":"noopener","anchorType":0},{"type":3,"start":120,"end":157,"href":"http://opencollective.com/webpack","title":"","rel":"","anchorType":0}]},{"name":"c11e","type":13,"text":"🔬 Scope Hoisting 🔬","markups":[]},{"name":"0014","type":1,"text":"Scope Hoisting is the flagship feature of webpack 3. One of webpack’s trade-offs when bundling was that each module in your bundle would be wrapped in individual function closures. These wrapper functions made it slower for your JavaScript to execute in the browser. In comparison, tools like Closure Compiler and RollupJS ‘hoist’ or concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser.","markups":[]},{"name":"d5a2","type":11,"text":"","markups":[],"layout":1,"iframe":{"mediaResourceId":"4533845503a873853b93e6aaf0833c57","iframeWidth":500,"iframeHeight":185,"thumbnailUrl":"https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDCih0NiWAAAAtZl.jpg%3Alarge&key=a19fcc184b9711e1b4764040d3dc5c07"}},{"name":"4965","type":1,"text":"As of today, with webpack 3, you can now add the following plugin to your configuration to enable scope hoisting:","markups":[{"type":1,"start":37,"end":113}]},{"name":"7078","type":8,"text":"module.exports = {  \n  plugins: [\n    new webpack.optimize.ModuleConcatenationPlugin()\n  ]\n};","markups":[]},{"name":"95b8","type":1,"text":"Scope Hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and other conditions.","markups":[{"type":3,"start":189,"end":205,"href":"https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""}]},{"name":"40b6","type":1,"text":"To stay informed on what triggers these fallbacks, we’ve added a --display-optimization-bailout cli flag that will tell you what caused the fallback.","markups":[{"type":10,"start":65,"end":95,"href":"","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""}]},{"name":"6a0e","type":11,"text":"","markups":[],"layout":1,"iframe":{"mediaResourceId":"6663aed6525e9200886db81c9415337c","iframeWidth":500,"iframeHeight":185,"thumbnailUrl":"https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F838369206907387904%2FPNdDKe77_400x400.jpg&key=a19fcc184b9711e1b4764040d3dc5c07"}},{"name":"f203","type":1,"text":"Because scope hoisting will remove function wrappers around your modules, you may see some small size improvements. However, the significant improvement will be how fast the JavaScript loads in the browser. If you have awesome before and after comparisons, feel free to respond with some data as we’d be honored to share it!","markups":[]},{"name":"ea65","type":13,"text":"🔮 ”Magic Comments” 🔮","markups":[]},{"name":"b50c","type":1,"text":"When we introduced in webpack 2 the ability to use the dynamic import syntax ( import() ), users expressed their concerns that they could not create named chunks like they were able to with require.ensure.","markups":[{"type":10,"start":79,"end":87},{"type":10,"start":190,"end":204}]},{"name":"b465","type":1,"text":"We have now introduced what the community has coined “magic comments”, the ability to pass chunk name, and more as an inline comment to your import() statements.","markups":[{"type":10,"start":141,"end":149},{"type":3,"start":103,"end":111,"href":"https://medium.com/webpack/how-to-use-webpacks-new-magic-comment-feature-with-react-universal-component-ssr-a38fd3e296a","title":"","rel":"","anchorType":0}]},{"name":"1049","type":11,"text":"By using comments, we are able to stay true to the load specification, and still give you the great chunk naming features you love.","markups":[],"layout":1,"iframe":{"mediaResourceId":"1de84d98f7926e813eccd95ddac64e1b","thumbnailUrl":"https://i.embed.ly/1/image?url=https%3A%2F%2Favatars3.githubusercontent.com%2Fu%2F3408176%3Fv%3D3%26s%3D400&key=a19fcc184b9711e1b4764040d3dc5c07"}},{"name":"f813","type":1,"text":"Although these are technically features we released in v2.4 and v2.6, we worked to stabilize and fix bugs for these features that have landed in v3. This now allows the dynamic import syntax to have the same flexibility as require.ensure.","markups":[{"type":10,"start":223,"end":237}]},{"name":"e1b1","type":11,"text":"","markups":[],"layout":1,"iframe":{"mediaResourceId":"fd3c12141eb0e7363d3e33feb528480c","iframeWidth":500,"iframeHeight":185,"thumbnailUrl":"https://i.embed.ly/1/image?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDBwao-MVwAAnydG.jpg%3Alarge&key=a19fcc184b9711e1b4764040d3dc5c07"}},{"name":"a2af","type":1,"text":"To learn more information, see our newest documentation guide on code-splitting that highlights these features!!!","markups":[{"type":3,"start":35,"end":79,"href":"https://webpack.js.org/guides/code-splitting-async","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""}]},{"name":"5371","type":3,"text":"😍 What’s next? 😍","markups":[]},{"name":"4f06","type":1,"text":"We have quite a few features and enhancements that we are hoping to bring you!!! But to take control of the ones we should be working one, stop by our vote page, and upvote the features you would like to see!","markups":[{"type":3,"start":150,"end":208,"href":"http://webpack.js.org/vote","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""},{"type":2,"start":150,"end":208,"href":"","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""}]},{"name":"92e2","type":1,"text":"Here are some of those things we are hoping to bring you still:","markups":[]},{"name":"b1a0","type":9,"text":"Better Build Caching","markups":[]},{"name":"e784","type":9,"text":"Faster initial and incremental builds","markups":[]},{"name":"9ec9","type":9,"text":"Better TypeScript experience","markups":[]},{"name":"98e6","type":9,"text":"Revamped Long term caching","markups":[]},{"name":"8e9d","type":9,"text":"WASM Module Support","markups":[]},{"name":"8948","type":9,"text":"Improve User Experience","markups":[]},{"name":"f87b","type":3,"text":"🙇Thank you 🙇","markups":[]},{"name":"48ea","type":1,"text":"All of our users, contributors, documentation writers, bloggers, sponsors, backers, and maintainers are all shareholders in helping us ensure webpack is successful for years to come.","markups":[]},{"name":"9f50","type":1,"text":"For this, we thank you all. It is not possible without you and we can’t wait to share what is in store for the future!!","markups":[]},{"name":"d2ed","type":1,"text":"No time to help contribute? Want to give back in other ways? Become a Backer or Sponsor to webpack by donating to our open collective. Open Collective not only helps support the Core Team, but also supports contributors who have spent significant time improving our organization on their free time! ❤","markups":[{"type":3,"start":118,"end":133,"href":"http://opencollective.com/webpack","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""},{"type":1,"start":61,"end":134,"href":"","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""},{"type":2,"start":0,"end":300,"href":"","title":"","rel":"","name":"","anchorType":0,"creatorIds":[],"userId":""}]}],"sections":[{"name":"33b6","startIndex":0,"textLayout":1,"imageLayout":1,"backgroundColor":1,"type":0,"videoLayout":1},{"name":"33f3","startIndex":9},{"name":"f349","startIndex":41}]},"postDisplay":{"coverless":true},"metaDescription":"After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Today, we’ve fulfilled these promises."},"virtuals":{"statusForCollection":"APPROVED","allowNotes":true,"previewImage":{"imageId":"1*Ac4K68j43uSbvHnKZKfXPw.jpeg","filter":"","backgroundSize":"","originalWidth":4896,"originalHeight":3264,"strategy":"resample","height":0,"width":0},"wordCount":718,"imageCount":1,"readingTime":2.909433962264151,"subtitle":"Now with Scope Hoisting, “magic comments”, and more!","userPostRelation":{"userId":"c9ef5404fa69","postId":"15fd2dd8f07b","readAt":1497946800534,"readLaterAddedAt":0,"votedAt":0,"collaboratorAddedAt":0,"notesAddedAt":0,"subscribedAt":0,"lastReadSectionName":"33f3","lastReadVersionId":"aca3888b20f","lastReadAt":1499116330487,"lastReadParagraphName":"d5a2","lastReadPercentage":0.42,"viewedAt":1499261110632,"presentedCountInResponseManagement":0,"clapCount":0,"seriesUpdateNotifsOptedInAt":0,"queuedAt":0,"seriesFirstViewedAt":0,"presentedCountInStream":6,"seriesLastViewedAt":0,"audioProgressSec":0},"publishedInCount":1,"usersBySocialRecommends":[{"userId":"b26b29e32f86","name":"Guilherme Rodrigues","username":"firstdoit","createdAt":1367452236234,"lastPostCreatedAt":1496773981977,"imageId":"1*Oa8k9U58pNWOYBl_UJla_g.jpeg","backgroundImageId":"","bio":"Carioca Software Developer","twitterScreenName":"first_doit","facebookAccountId":"809852039059150","allowNotes":1,"mediumMemberAt":1490379505000,"isNsfw":false,"type":"User"},{"userId":"a789923b5cad","name":"Chris Coyier","username":"chriscoyier","createdAt":1358397641621,"lastPostCreatedAt":1492548816894,"imageId":"0*ltJQnmNlaag0qp8N.jpeg","backgroundImageId":"","bio":"Designer @CodePen. Writer @real_css_tricks. Podcaster @ShopTalkShow. Lead Hucklebucker.","twitterScreenName":"chriscoyier","facebookAccountId":"","allowNotes":1,"mediumMemberAt":0,"isNsfw":false,"type":"User"}],"recommends":1352,"socialRecommends":[{"user":{"userId":"a789923b5cad","name":"Chris Coyier","username":"chriscoyier","createdAt":1358397641621,"lastPostCreatedAt":1492548816894,"imageId":"0*ltJQnmNlaag0qp8N.jpeg","backgroundImageId":"","bio":"Designer @CodePen. Writer @real_css_tricks. Podcaster @ShopTalkShow. Lead Hucklebucker.","twitterScreenName":"chriscoyier","facebookAccountId":"","allowNotes":1,"mediumMemberAt":0,"isNsfw":false,"type":"User"}},{"user":{"userId":"b26b29e32f86","name":"Guilherme Rodrigues","username":"firstdoit","createdAt":1367452236234,"lastPostCreatedAt":1496773981977,"imageId":"1*Oa8k9U58pNWOYBl_UJla_g.jpeg","backgroundImageId":"","bio":"Carioca Software Developer","twitterScreenName":"first_doit","facebookAccountId":"809852039059150","allowNotes":1,"mediumMemberAt":1490379505000,"isNsfw":false,"type":"User"}}],"isBookmarked":false,"tags":[{"slug":"javascript","name":"JavaScript","postCount":35111,"virtuals":{"isFollowing":false},"metadata":{"followerCount":36557,"postCount":35111,"coverImage":{"id":"1*zISOb74W7PriWKX0y7biKg.jpeg","originalWidth":1920,"originalHeight":1200}},"type":"Tag"},{"slug":"webpack","name":"Webpack","postCount":965,"virtuals":{"isFollowing":false},"metadata":{"followerCount":2224,"postCount":965,"coverImage":{"id":"1*BF-1rLosUtajBry7wl6QrA.png","originalWidth":3156,"originalHeight":1994}},"type":"Tag"},{"slug":"tech","name":"Tech","postCount":89606,"virtuals":{"isFollowing":false},"metadata":{"followerCount":1069621,"postCount":89606,"coverImage":{"id":"1*rH21ekNDsOeeVLWCLxCzwA.png","originalWidth":2500,"originalHeight":558,"isFeatured":true}},"type":"Tag"},{"slug":"technology","name":"Technology","postCount":80119,"virtuals":{"isFollowing":false},"metadata":{"followerCount":1821680,"postCount":80119,"coverImage":{"id":"1*yH2cmH1uhoFpR7HIseOAsw.jpeg"}},"type":"Tag"},{"slug":"web-development","name":"Web Development","postCount":46174,"virtuals":{"isFollowing":false},"metadata":{"followerCount":40397,"postCount":46174,"coverImage":{"id":"1*zISOb74W7PriWKX0y7biKg.jpeg","originalWidth":1920,"originalHeight":1200}},"type":"Tag"}],"socialRecommendsCount":2,"responsesCreatedCount":37,"links":{"entries":[{"url":"https://webpack.js.org/vote","alts":[],"httpStatus":200},{"url":"https://webpack.js.org/guides/code-splitting-async","alts":[],"httpStatus":200},{"url":"http://webpack.js.org/vote","alts":[],"httpStatus":200},{"url":"https://medium.com/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5","alts":[{"type":2,"url":"medium://p/4764be3266f5"},{"type":3,"url":"medium://p/4764be3266f5"}],"httpStatus":200},{"url":"https://medium.com/webpack/how-to-use-webpacks-new-magic-comment-feature-with-react-universal-component-ssr-a38fd3e296a","alts":[{"type":2,"url":"medium://p/a38fd3e296a"},{"type":3,"url":"medium://p/a38fd3e296a"}],"httpStatus":200},{"url":"http://opencollective.com/webpack","alts":[],"httpStatus":200}],"version":"0.3","generatedAt":1498064229632},"isLockedPreviewOnly":false,"takeoverId":"","metaDescription":"After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Today, we’ve fulfilled these promises.","totalClapCount":0,"sectionCount":3},"coverless":true,"slug":"webpack-3-official-release","translationSourcePostId":"","translationSourceCreatorId":"","isApprovedTranslation":false,"inResponseToPostId":"","inResponseToRemovedAt":0,"isTitleSynthesized":false,"allowResponses":true,"importedUrl":"","importedPublishedAt":0,"visibility":0,"uniqueSlug":"webpack-3-official-release-15fd2dd8f07b","previewContent":{"bodyModel":{"paragraphs":[{"name":"821e","type":4,"text":"","markups":[],"layout":10,"metadata":{"id":"1*Ac4K68j43uSbvHnKZKfXPw.jpeg","originalWidth":4896,"originalHeight":3264}},{"name":"ea51","type":3,"text":"🍾🚀 webpack 3: Official Release!! 🚀🍾","markups":[],"alignment":1},{"name":"8fe8","type":13,"text":"Scope Hoisting, “magic comments”, and more!","markups":[],"alignment":1}],"sections":[{"startIndex":0}]},"isFullContent":false},"license":0,"inResponseToMediaResourceId":"","canonicalUrl":"https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b","approvedHomeCollectionId":"b2f039622545","approvedHomeCollection":{"id":"b2f039622545","name":"webpack","slug":"webpack","tags":["WEB PERFORMANCE","TECH","JAVASCRIPT","WEBPACK","OPEN SOURCE"],"creatorId":"cccc522e775a","description":"The official Medium publication for the webpack opensource project!","shortDescription":"The official Medium publication for the webpack opensource…","image":{"imageId":"1*Wx82vEGrMfW4AdSLodZXgQ.png","filter":"","backgroundSize":"","originalWidth":874,"originalHeight":989,"strategy":"resample","height":0,"width":0},"metadata":{"followerCount":7228,"activeAt":1498548836430},"virtuals":{"permissions":{"canPublish":false,"canPublishAll":false,"canRepublish":false,"canRemove":false,"canManageAll":false,"canSubmit":false,"canEditPosts":false,"canAddWriters":false,"canViewStats":false,"canSendNewsletter":false,"canViewLockedPosts":false,"canViewCloaked":false,"canEditOwnPosts":false,"canBeAssignedAuthor":false},"isSubscribed":false,"isNewsletterSubscribed":false,"memberOfMembershipPlanId":""},"logo":{"imageId":"1*gdoQ1_5OID90wf1eLTFvWw.png","filter":"","backgroundSize":"","originalWidth":3916,"originalHeight":1524,"strategy":"resample","height":0,"width":0},"publicEmail":"webpack@opencollective.com","collectionMastheadId":"b44e034c9e36","sections":[{"type":2,"collectionHeaderMetadata":{"title":"webpack","backgroundImage":{},"logoImage":{},"alignment":2,"layout":4}},{"type":1,"postListMetadata":{"source":1,"layout":2,"number":1,"postIds":[],"sectionHeader":"Latest Story"}},{"type":1,"postListMetadata":{"source":3,"layout":4,"number":3,"postIds":["15fd2dd8f07b","a38fd3e296a","8519def2cac7"],"sectionHeader":"Featured Stories"}},{"type":1,"postListMetadata":{"source":2,"layout":4,"number":4,"postIds":[],"sectionHeader":"Trending"}},{"type":1,"postListMetadata":{"source":1,"layout":6,"number":7,"postIds":[]}}],"tintColor":"#FFFFFFFF","lightText":false,"favicon":{"imageId":"","filter":"","backgroundSize":"","originalWidth":0,"originalHeight":0,"strategy":"resample","height":0,"width":0},"colorPalette":{"defaultBackgroundSpectrum":{"colorPoints":[{"color":"#FF848585","point":0},{"color":"#FF7B7B7B","point":0.1},{"color":"#FF717272","point":0.2},{"color":"#FF686868","point":0.3},{"color":"#FF5E5E5E","point":0.4},{"color":"#FF545454","point":0.5},{"color":"#FF494A4A","point":0.6},{"color":"#FF3F3F3F","point":0.7},{"color":"#FF333333","point":0.8},{"color":"#FF272727","point":0.9},{"color":"#FF1A1A1A","point":1}],"backgroundColor":"#FFFFFFFF"},"tintBackgroundSpectrum":{"colorPoints":[{"color":"#FFFFFFFF","point":0},{"color":"#FFEEEEEE","point":0.1},{"color":"#FFDDDDDD","point":0.2},{"color":"#FFCCCCCC","point":0.3},{"color":"#FFBABABB","point":0.4},{"color":"#FFA8A8A8","point":0.5},{"color":"#FF959696","point":0.6},{"color":"#FF818282","point":0.7},{"color":"#FF6D6E6E","point":0.8},{"color":"#FF575959","point":0.9},{"color":"#FF404242","point":1}],"backgroundColor":"#FFFFFFFF"},"highlightSpectrum":{"colorPoints":[{"color":"#FFF4F2F2","point":0},{"color":"#FFF2F0F0","point":0.1},{"color":"#FFF0EEEE","point":0.2},{"color":"#FFEEECEC","point":0.3},{"color":"#FFECEBEA","point":0.4},{"color":"#FFEAE9E8","point":0.5},{"color":"#FFE8E7E7","point":0.6},{"color":"#FFE6E5E5","point":0.7},{"color":"#FFE4E3E3","point":0.8},{"color":"#FFE2E1E1","point":0.9},{"color":"#FFE0DFDF","point":1}],"backgroundColor":"#FFFFFFFF"}},"navItems":[{"type":4,"title":"Announcments","url":"https://medium.com/webpack/announcements/home","topicId":"93793abf70c9","source":"topicId"},{"type":4,"title":"Freelance Log Book","url":"https://medium.com/webpack/freelancing-log-book/home","topicId":"fd7d773f7e5f","source":"topicId"},{"type":4,"title":"Contributors Guide","url":"https://medium.com/webpack/contributors-guide/home","topicId":"169a47a764ae","source":"topicId"},{"type":4,"title":"Tips and Tricks","url":"https://medium.com/webpack/tips-and-tricks/home","topicId":"8d6c6bf5b3b0","source":"topicId"},{"type":6,"title":"About Us","url":"https://medium.com/webpack/about"},{"type":3,"title":"Official Documentation","url":"http://webpack.js.org"}],"colorBehavior":1,"instantArticlesState":0,"acceleratedMobilePagesState":0,"ampLogo":{"imageId":"","filter":"","backgroundSize":"","originalWidth":0,"originalHeight":0,"strategy":"resample","height":0,"width":0},"header":{"title":"webpack","backgroundImage":{},"logoImage":{},"alignment":2,"layout":4},"type":"Collection"},"newsletterId":"","webCanonicalUrl":"https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b","mediumUrl":"https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b","migrationId":"","notifyFollowers":true,"notifyTwitter":true,"isSponsored":false,"isRequestToPubDisabled":false,"notifyFacebook":false,"responseHiddenOnParentPostAt":0,"isSeries":false,"isSubscriptionLocked":false,"seriesLastAppendedAt":0,"audioVersionDurationSec":0,"sequenceId":"","isNsfw":false,"premiumTier":1,"type":"Post"},"mentionedUsers":[],"collaborators":[],"membershipPlans":[],"collectionUserRelations":[{"collectionId":"1c8c698c3794","userId":"c9ef5404fa69","role":"ADMIN"}],"mode":null,"references":{"User":{"393110b0b9e4":{"userId":"393110b0b9e4","name":"Sean T. Larkin","username":"TheLarkInn","createdAt":1426695004676,"lastPostCreatedAt":1498710705921,"imageId":"1*64H5DfQ6_WwZ0WbsY430dA.jpeg","backgroundImageId":"","bio":"@Webpack Core team & AngularCLI team. User Experience Developer @ Mutual of Omaha, Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and Gardener!","twitterScreenName":"TheLarkInn","socialStats":{"userId":"393110b0b9e4","usersFollowedCount":300,"usersFollowedByCount":3842,"type":"SocialStats"},"social":{"userId":"c9ef5404fa69","targetUserId":"393110b0b9e4","type":"Social"},"facebookAccountId":"781525381174","allowNotes":1,"type":"User"}},"Collection":{"b2f039622545":{"id":"b2f039622545","name":"webpack","slug":"webpack","tags":["WEB PERFORMANCE","TECH","JAVASCRIPT","WEBPACK","OPEN SOURCE"],"creatorId":"cccc522e775a","description":"The official Medium publication for the webpack opensource project!","shortDescription":"The official Medium publication for the webpack opensource…","image":{"imageId":"1*Wx82vEGrMfW4AdSLodZXgQ.png","filter":"","backgroundSize":"","originalWidth":874,"originalHeight":989,"strategy":"resample","height":0,"width":0},"metadata":{"followerCount":7228,"activeAt":1498548836430},"virtuals":{"permissions":{"canPublish":false,"canPublishAll":false,"canRepublish":false,"canRemove":false,"canManageAll":false,"canSubmit":false,"canEditPosts":false,"canAddWriters":false,"canViewStats":false,"canSendNewsletter":false,"canViewLockedPosts":false,"canViewCloaked":false,"canEditOwnPosts":false,"canBeAssignedAuthor":false},"isSubscribed":false,"isNewsletterSubscribed":false,"memberOfMembershipPlanId":""},"logo":{"imageId":"1*gdoQ1_5OID90wf1eLTFvWw.png","filter":"","backgroundSize":"","originalWidth":3916,"originalHeight":1524,"strategy":"resample","height":0,"width":0},"publicEmail":"webpack@opencollective.com","collectionMastheadId":"b44e034c9e36","sections":[{"type":2,"collectionHeaderMetadata":{"title":"webpack","backgroundImage":{},"logoImage":{},"alignment":2,"layout":4}},{"type":1,"postListMetadata":{"source":1,"layout":2,"number":1,"postIds":[],"sectionHeader":"Latest Story"}},{"type":1,"postListMetadata":{"source":3,"layout":4,"number":3,"postIds":["15fd2dd8f07b","a38fd3e296a","8519def2cac7"],"sectionHeader":"Featured Stories"}},{"type":1,"postListMetadata":{"source":2,"layout":4,"number":4,"postIds":[],"sectionHeader":"Trending"}},{"type":1,"postListMetadata":{"source":1,"layout":6,"number":7,"postIds":[]}}],"tintColor":"#FFFFFFFF","lightText":false,"favicon":{"imageId":"","filter":"","backgroundSize":"","originalWidth":0,"originalHeight":0,"strategy":"resample","height":0,"width":0},"colorPalette":{"defaultBackgroundSpectrum":{"colorPoints":[{"color":"#FF848585","point":0},{"color":"#FF7B7B7B","point":0.1},{"color":"#FF717272","point":0.2},{"color":"#FF686868","point":0.3},{"color":"#FF5E5E5E","point":0.4},{"color":"#FF545454","point":0.5},{"color":"#FF494A4A","point":0.6},{"color":"#FF3F3F3F","point":0.7},{"color":"#FF333333","point":0.8},{"color":"#FF272727","point":0.9},{"color":"#FF1A1A1A","point":1}],"backgroundColor":"#FFFFFFFF"},"tintBackgroundSpectrum":{"colorPoints":[{"color":"#FFFFFFFF","point":0},{"color":"#FFEEEEEE","point":0.1},{"color":"#FFDDDDDD","point":0.2},{"color":"#FFCCCCCC","point":0.3},{"color":"#FFBABABB","point":0.4},{"color":"#FFA8A8A8","point":0.5},{"color":"#FF959696","point":0.6},{"color":"#FF818282","point":0.7},{"color":"#FF6D6E6E","point":0.8},{"color":"#FF575959","point":0.9},{"color":"#FF404242","point":1}],"backgroundColor":"#FFFFFFFF"},"highlightSpectrum":{"colorPoints":[{"color":"#FFF4F2F2","point":0},{"color":"#FFF2F0F0","point":0.1},{"color":"#FFF0EEEE","point":0.2},{"color":"#FFEEECEC","point":0.3},{"color":"#FFECEBEA","point":0.4},{"color":"#FFEAE9E8","point":0.5},{"color":"#FFE8E7E7","point":0.6},{"color":"#FFE6E5E5","point":0.7},{"color":"#FFE4E3E3","point":0.8},{"color":"#FFE2E1E1","point":0.9},{"color":"#FFE0DFDF","point":1}],"backgroundColor":"#FFFFFFFF"}},"navItems":[{"type":4,"title":"Announcments","url":"https://medium.com/webpack/announcements/home","topicId":"93793abf70c9","source":"topicId"},{"type":4,"title":"Freelance Log Book","url":"https://medium.com/webpack/freelancing-log-book/home","topicId":"fd7d773f7e5f","source":"topicId"},{"type":4,"title":"Contributors Guide","url":"https://medium.com/webpack/contributors-guide/home","topicId":"169a47a764ae","source":"topicId"},{"type":4,"title":"Tips and Tricks","url":"https://medium.com/webpack/tips-and-tricks/home","topicId":"8d6c6bf5b3b0","source":"topicId"},{"type":6,"title":"About Us","url":"https://medium.com/webpack/about"},{"type":3,"title":"Official Documentation","url":"http://webpack.js.org"}],"colorBehavior":1,"instantArticlesState":0,"acceleratedMobilePagesState":0,"ampLogo":{"imageId":"","filter":"","backgroundSize":"","originalWidth":0,"originalHeight":0,"strategy":"resample","height":0,"width":0},"header":{"title":"webpack","backgroundImage":{},"logoImage":{},"alignment":2,"layout":4},"type":"Collection"}},"Social":{"393110b0b9e4":{"userId":"c9ef5404fa69","targetUserId":"393110b0b9e4","type":"Social"}},"SocialStats":{"393110b0b9e4":{"userId":"393110b0b9e4","usersFollowedCount":300,"usersFollowedByCount":3842,"type":"SocialStats"}}}})
-// ]]></script></body></html>
+<!doctype html>
+<html lang="en">
+
+<head>
+  <script defer src="https://cdn.optimizely.com/js/16180790160.js"></script>
+  <title data-rh="true">🍾🚀 webpack 3: Official Release!! 🚀🍾 | by Sean T. Larkin | webpack | Medium</title>
+  <meta data-rh="true" charset="utf-8" />
+  <meta data-rh="true" name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
+  <meta data-rh="true" name="theme-color" content="#000000" />
+  <meta data-rh="true" name="twitter:app:name:iphone" content="Medium" />
+  <meta data-rh="true" name="twitter:app:id:iphone" content="828256236" />
+  <meta data-rh="true" property="al:ios:app_name" content="Medium" />
+  <meta data-rh="true" property="al:ios:app_store_id" content="828256236" />
+  <meta data-rh="true" property="al:android:package" content="com.medium.reader" />
+  <meta data-rh="true" property="fb:app_id" content="542599432471018" />
+  <meta data-rh="true" property="og:site_name" content="Medium" />
+  <meta data-rh="true" property="og:type" content="article" />
+  <meta data-rh="true" property="article:published_time" content="2017-06-21T16:57:08.802Z" />
+  <meta data-rh="true" name="title"
+    content="🍾🚀 webpack 3: Official Release!! 🚀🍾 | by Sean T. Larkin | webpack | Medium" />
+  <meta data-rh="true" property="og:title" content="🍾🚀 webpack 3: Official Release!! 🚀🍾" />
+  <meta data-rh="true" property="twitter:title" content="🍾🚀 webpack 3: Official Release!! 🚀🍾" />
+  <meta data-rh="true" name="twitter:site" content="@webpack" />
+  <meta data-rh="true" name="twitter:app:url:iphone" content="medium://p/15fd2dd8f07b" />
+  <meta data-rh="true" property="al:android:url" content="medium://p/15fd2dd8f07b" />
+  <meta data-rh="true" property="al:ios:url" content="medium://p/15fd2dd8f07b" />
+  <meta data-rh="true" property="al:android:app_name" content="Medium" />
+  <meta data-rh="true" name="description"
+    content="After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Today, we’ve fulfilled these promises." />
+  <meta data-rh="true" property="og:description" content="Now with Scope Hoisting, “magic comments”, and more!" />
+  <meta data-rh="true" property="twitter:description" content="Now with Scope Hoisting, “magic comments”, and more!" />
+  <meta data-rh="true" property="og:url" content="https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b" />
+  <meta data-rh="true" property="al:web:url"
+    content="https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b" />
+  <meta data-rh="true" property="og:image" content="https://miro.medium.com/max/1200/1*Ac4K68j43uSbvHnKZKfXPw.jpeg" />
+  <meta data-rh="true" name="twitter:image:src"
+    content="https://miro.medium.com/max/1200/1*Ac4K68j43uSbvHnKZKfXPw.jpeg" />
+  <meta data-rh="true" name="twitter:card" content="summary_large_image" />
+  <meta data-rh="true" property="article:author" content="https://medium.com/@TheLarkInn" />
+  <meta data-rh="true" name="twitter:creator" content="@TheLarkInn" />
+  <meta data-rh="true" name="author" content="Sean T. Larkin" />
+  <meta data-rh="true" name="robots" content="index,follow,max-image-preview:large" />
+  <meta data-rh="true" name="referrer" content="unsafe-url" />
+  <meta data-rh="true" name="twitter:label1" value="Reading time" />
+  <meta data-rh="true" name="twitter:data1" value="3 min read" />
+  <meta data-rh="true" name="parsely-post-id" content="15fd2dd8f07b" />
+  <link data-rh="true" rel="search" type="application/opensearchdescription+xml" title="Medium" href="/osd.xml" />
+  <link data-rh="true" rel="apple-touch-icon" sizes="152x152"
+    href="https://miro.medium.com/fit/c/152/152/1*sHhtYhaCe2Uc3IU0IgKwIQ.png" />
+  <link data-rh="true" rel="apple-touch-icon" sizes="120x120"
+    href="https://miro.medium.com/fit/c/120/120/1*sHhtYhaCe2Uc3IU0IgKwIQ.png" />
+  <link data-rh="true" rel="apple-touch-icon" sizes="76x76"
+    href="https://miro.medium.com/fit/c/76/76/1*sHhtYhaCe2Uc3IU0IgKwIQ.png" />
+  <link data-rh="true" rel="apple-touch-icon" sizes="60x60"
+    href="https://miro.medium.com/fit/c/60/60/1*sHhtYhaCe2Uc3IU0IgKwIQ.png" />
+  <link data-rh="true" rel="mask-icon" href="https://cdn-static-1.medium.com/_/fp/icons/Medium-Avatar-500x500.svg"
+    color="#171717" />
+  <link data-rh="true" id="glyph_preload_link" rel="preload" as="style" type="text/css"
+    href="https://glyph.medium.com/css/unbound.css" />
+  <link data-rh="true" id="glyph_link" rel="stylesheet" type="text/css"
+    href="https://glyph.medium.com/css/unbound.css" />
+  <link data-rh="true" rel="author" href="https://medium.com/@TheLarkInn" />
+  <link data-rh="true" rel="canonical" href="https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b" />
+  <link data-rh="true" rel="alternate" href="android-app://com.medium.reader/https/medium.com/p/15fd2dd8f07b" />
+  <link data-rh="true" rel="icon" href="https://miro.medium.com/1*m-R_BkNf1Qjr1YbyOIJY2w.png" />
+  <script data-rh="true"
+    type="application/ld+json">{"@context":"http:\u002F\u002Fschema.org","@type":"NewsArticle","image":["https:\u002F\u002Fmiro.medium.com\u002Fmax\u002F1200\u002F1*Ac4K68j43uSbvHnKZKfXPw.jpeg"],"url":"https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fwebpack-3-official-release-15fd2dd8f07b","dateCreated":"2017-06-19T17:23:28.613Z","datePublished":"2017-06-19T17:23:28.613Z","dateModified":"2018-06-05T03:29:05.031Z","headline":"🍾🚀 webpack 3: Official Release!! 🚀🍾 - webpack - Medium","name":"🍾🚀 webpack 3: Official Release!! 🚀🍾 - webpack - Medium","description":"After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Today, we’ve fulfilled these promises.","identifier":"15fd2dd8f07b","keywords":["Lite:true","Tag:JavaScript","Tag:Webpack","Tag:Tech","Tag:Technology","Tag:Web Development","Publication:webpack","Elevated:false","LockedPostSource:LOCKED_POST_SOURCE_NONE","LayerCake:0"],"author":{"@type":"Person","name":"Sean T. Larkin","url":"https:\u002F\u002Fmedium.com\u002F@TheLarkInn"},"creator":["Sean T. Larkin"],"publisher":{"@type":"Organization","name":"webpack","url":"https:\u002F\u002Fmedium.com\u002Fwebpack","logo":{"@type":"ImageObject","width":154,"height":60,"url":"https:\u002F\u002Fmiro.medium.com\u002Fmax\u002F308\u002F1*gdoQ1_5OID90wf1eLTFvWw.png"}},"mainEntityOfPage":"https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fwebpack-3-official-release-15fd2dd8f07b"}</script>
+  <link rel="preload" href="https://cdn.optimizely.com/js/16180790160.js" as="script">
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="STATIC">
+    html {
+      box-sizing: border-box
+    }
+
+    *,
+    *:before,
+    *:after {
+      box-sizing: inherit
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      color: rgba(0, 0, 0, 0.8);
+      position: relative;
+      min-height: 100vh
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    dl,
+    dd,
+    ol,
+    ul,
+    menu,
+    figure,
+    blockquote,
+    p,
+    pre,
+    form {
+      margin: 0
+    }
+
+    menu,
+    ol,
+    ul {
+      padding: 0;
+      list-style: none;
+      list-style-image: none
+    }
+
+    main {
+      display: block
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none
+    }
+
+    a,
+    button,
+    input {
+      -webkit-tap-highlight-color: transparent
+    }
+
+    img,
+    svg {
+      vertical-align: middle
+    }
+
+    button {
+      background: transparent;
+      overflow: visible
+    }
+
+    button,
+    input,
+    optgroup,
+    select,
+    textarea {
+      margin: 0
+    }
+
+    :root {
+      --reach-tabs: 1;
+      --reach-menu-button: 1
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE">
+    .a {
+      font-family: medium-content-sans-serif-font, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif
+    }
+
+    .b {
+      font-weight: 400
+    }
+
+    .c {
+      background-color: rgba(255, 255, 255, 1)
+    }
+
+    .l {
+      height: 100vh
+    }
+
+    .m {
+      width: 100vw
+    }
+
+    .n {
+      display: flex
+    }
+
+    .o {
+      align-items: center
+    }
+
+    .p {
+      justify-content: center
+    }
+
+    .q {
+      height: 25px
+    }
+
+    .r {
+      fill: rgba(41, 41, 41, 1)
+    }
+
+    .s {
+      display: block
+    }
+
+    .t {
+      position: absolute
+    }
+
+    .u {
+      top: 0
+    }
+
+    .v {
+      left: 0
+    }
+
+    .w {
+      right: 0
+    }
+
+    .x {
+      z-index: 500
+    }
+
+    .y {
+      box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.05)
+    }
+
+    .ah {
+      max-width: 1192px
+    }
+
+    .ai {
+      min-width: 0
+    }
+
+    .aj {
+      width: 100%
+    }
+
+    .ak {
+      height: 65px
+    }
+
+    .an {
+      flex: 1 0 auto
+    }
+
+    .ao {
+      fill: rgba(25, 25, 25, 1)
+    }
+
+    .ap {
+      flex: 0 0 auto
+    }
+
+    .aq {
+      visibility: hidden
+    }
+
+    .ar {
+      margin-left: 16px
+    }
+
+    .as {
+      color: rgba(132, 133, 133, 1)
+    }
+
+    .at {
+      fill: rgba(132, 133, 133, 1)
+    }
+
+    .au {
+      font-size: inherit
+    }
+
+    .av {
+      border: inherit
+    }
+
+    .aw {
+      font-family: inherit
+    }
+
+    .ax {
+      letter-spacing: inherit
+    }
+
+    .ay {
+      font-weight: inherit
+    }
+
+    .az {
+      padding: 0
+    }
+
+    .ba {
+      margin: 0
+    }
+
+    .be:disabled {
+      cursor: default
+    }
+
+    .bf:disabled {
+      color: rgba(163, 208, 162, 0.5)
+    }
+
+    .bg:disabled {
+      fill: rgba(163, 208, 162, 0.5)
+    }
+
+    .bh {
+      border-top: 1px solid rgba(230, 230, 230, 1)
+    }
+
+    .bj {
+      height: 54px
+    }
+
+    .bk {
+      overflow: hidden
+    }
+
+    .bl {
+      margin-right: 40px
+    }
+
+    .bm {
+      height: 36px
+    }
+
+    .bn {
+      width: 93px
+    }
+
+    .bo {
+      overflow: auto
+    }
+
+    .bp {
+      flex: 0 1 auto
+    }
+
+    .bq {
+      list-style-type: none
+    }
+
+    .br {
+      line-height: 40px
+    }
+
+    .bs {
+      white-space: nowrap
+    }
+
+    .bt {
+      overflow-x: auto
+    }
+
+    .bu {
+      align-items: flex-start
+    }
+
+    .bv {
+      margin-top: 20px
+    }
+
+    .bw {
+      padding-top: 20px
+    }
+
+    .bx {
+      height: 80px
+    }
+
+    .by {
+      height: 20px
+    }
+
+    .bz {
+      margin-right: 15px
+    }
+
+    .ca {
+      margin-left: 15px
+    }
+
+    .cb:first-child {
+      margin-left: 0
+    }
+
+    .cc {
+      min-width: 1px
+    }
+
+    .cd {
+      background-color: rgba(168, 168, 168, 1)
+    }
+
+    .ce {
+      font-family: sohne, "Helvetica Neue", Helvetica, Arial, sans-serif
+    }
+
+    .cf {
+      font-size: 13px
+    }
+
+    .cg {
+      line-height: 20px
+    }
+
+    .ch {
+      color: rgba(117, 117, 117, 1)
+    }
+
+    .ci {
+      text-transform: uppercase
+    }
+
+    .cj {
+      letter-spacing: 1px
+    }
+
+    .ck {
+      color: inherit
+    }
+
+    .cl {
+      fill: inherit
+    }
+
+    .co:disabled {
+      color: rgba(117, 117, 117, 1)
+    }
+
+    .cp:disabled {
+      fill: rgba(117, 117, 117, 1)
+    }
+
+    .cq {
+      margin-bottom: 0px
+    }
+
+    .cr {
+      margin-top: 0px
+    }
+
+    .cs {
+      height: 119px
+    }
+
+    .cv {
+      padding-left: 24px
+    }
+
+    .cw {
+      padding-right: 24px
+    }
+
+    .cx {
+      margin-left: auto
+    }
+
+    .cy {
+      margin-right: auto
+    }
+
+    .cz {
+      max-width: 728px
+    }
+
+    .da {
+      box-sizing: border-box
+    }
+
+    .db {
+      background: rgba(255, 255, 255, 1)
+    }
+
+    .dc {
+      border: 1px solid rgba(230, 230, 230, 1)
+    }
+
+    .dd {
+      border-radius: 4px
+    }
+
+    .de {
+      box-shadow: 0 1px 4px rgba(230, 230, 230, 1)
+    }
+
+    .df {
+      max-height: 100vh
+    }
+
+    .dg {
+      overflow-y: auto
+    }
+
+    .dh {
+      top: calc(100vh + 100px)
+    }
+
+    .di {
+      bottom: calc(100vh + 100px)
+    }
+
+    .dj {
+      width: 10px
+    }
+
+    .dk {
+      pointer-events: none
+    }
+
+    .dl {
+      word-break: break-word
+    }
+
+    .dm {
+      word-wrap: break-word
+    }
+
+    .dn:after {
+      display: block
+    }
+
+    .do:after {
+      content: ""
+    }
+
+    .dp:after {
+      clear: both
+    }
+
+    .dq {
+      clear: both
+    }
+
+    .dz {
+      max-width: 4896px
+    }
+
+    .ef {
+      padding-bottom: 5px
+    }
+
+    .eg {
+      padding-top: 5px
+    }
+
+    .ei {
+      cursor: zoom-in
+    }
+
+    .ej {
+      position: relative
+    }
+
+    .ek {
+      z-index: auto
+    }
+
+    .em {
+      opacity: 0
+    }
+
+    .en {
+      transition: opacity 100ms 400ms
+    }
+
+    .eo {
+      height: 100%
+    }
+
+    .ep {
+      will-change: transform
+    }
+
+    .eq {
+      transform: translateZ(0)
+    }
+
+    .er {
+      margin: auto
+    }
+
+    .es {
+      background-color: rgba(242, 242, 242, 1)
+    }
+
+    .et {
+      padding-bottom: 66.66666666666667%
+    }
+
+    .eu {
+      height: 0
+    }
+
+    .ev {
+      filter: blur(20px)
+    }
+
+    .ew {
+      transform: scale(1.1)
+    }
+
+    .ex {
+      visibility: visible
+    }
+
+    .ey {
+      margin-top: 10px
+    }
+
+    .ez {
+      text-align: center
+    }
+
+    .fc {
+      font-size: 14px
+    }
+
+    .fd {
+      max-width: 680px
+    }
+
+    .fe {
+      line-height: 1.23
+    }
+
+    .ff {
+      letter-spacing: 0
+    }
+
+    .fg {
+      font-style: normal
+    }
+
+    .fh {
+      font-family: fell, Georgia, Cambria, "Times New Roman", Times, serif
+    }
+
+    .gc {
+      margin-bottom: -0.27em
+    }
+
+    .gd {
+      color: rgba(41, 41, 41, 1)
+    }
+
+    .ge {
+      line-height: 1.394
+    }
+
+    .gu {
+      margin-bottom: -0.42em
+    }
+
+    .gv {
+      margin-top: 32px
+    }
+
+    .gw {
+      justify-content: space-between
+    }
+
+    .ha {
+      border-radius: 50%
+    }
+
+    .hb {
+      height: 48px
+    }
+
+    .hc {
+      width: 48px
+    }
+
+    .hd {
+      margin-left: 12px
+    }
+
+    .he {
+      margin-bottom: 2px
+    }
+
+    .hg {
+      max-height: 20px
+    }
+
+    .hh {
+      text-overflow: ellipsis
+    }
+
+    .hi {
+      display: -webkit-box
+    }
+
+    .hj {
+      -webkit-line-clamp: 1
+    }
+
+    .hk {
+      -webkit-box-orient: vertical
+    }
+
+    .hn {
+      margin-left: 8px
+    }
+
+    .ho {
+      color: rgba(255, 255, 255, 1)
+    }
+
+    .hp {
+      padding: 0px 8px 1px
+    }
+
+    .hq {
+      fill: rgba(255, 255, 255, 1)
+    }
+
+    .hr {
+      background: rgba(132, 133, 133, 1)
+    }
+
+    .hs {
+      border-color: rgba(132, 133, 133, 1)
+    }
+
+    .hv:disabled {
+      cursor: inherit
+    }
+
+    .hw:disabled {
+      opacity: 0.3
+    }
+
+    .hx:disabled:hover {
+      background: rgba(132, 133, 133, 1)
+    }
+
+    .hy:disabled:hover {
+      border-color: rgba(132, 133, 133, 1)
+    }
+
+    .hz {
+      border-width: 1px
+    }
+
+    .ia {
+      border-style: solid
+    }
+
+    .ib {
+      display: inline-block
+    }
+
+    .ic {
+      text-decoration: none
+    }
+
+    .id {
+      align-items: flex-end
+    }
+
+    .il {
+      padding-right: 6px
+    }
+
+    .im {
+      fill: rgba(117, 117, 117, 1)
+    }
+
+    .in {
+      margin-right: 8px
+    }
+
+    .io {
+      line-height: 1.58
+    }
+
+    .ip {
+      letter-spacing: -0.004em
+    }
+
+    .iq {
+      font-family: charter, Georgia, Cambria, "Times New Roman", Times, serif
+    }
+
+    .jj {
+      margin-bottom: -0.46em
+    }
+
+    .jk {
+      font-weight: 700
+    }
+
+    .jl {
+      font-style: italic
+    }
+
+    .jm {
+      padding: 2px 4px
+    }
+
+    .jn {
+      font-size: 75%
+    }
+
+    .jo>strong {
+      font-family: inherit
+    }
+
+    .jp {
+      font-family: Menlo, Monaco, "Courier New", Courier, monospace
+    }
+
+    .jq {
+      margin-bottom: 14px
+    }
+
+    .jr {
+      padding-top: 24px
+    }
+
+    .js {
+      padding-bottom: 10px
+    }
+
+    .jt {
+      background-color: rgba(8, 8, 8, 1)
+    }
+
+    .ju {
+      height: 3px
+    }
+
+    .jv {
+      width: 3px
+    }
+
+    .jw {
+      margin-right: 20px
+    }
+
+    .jx {
+      line-height: 1.12
+    }
+
+    .jy {
+      letter-spacing: -0.022em
+    }
+
+    .jz {
+      font-weight: 500
+    }
+
+    .ks {
+      margin-bottom: -0.28em
+    }
+
+    .ky {
+      text-decoration: underline
+    }
+
+    .kz {
+      line-height: 1.18
+    }
+
+    .lh {
+      margin-bottom: -0.31em
+    }
+
+    .ln {
+      padding-bottom: 37%
+    }
+
+    .lo {
+      padding: 20px
+    }
+
+    .lp {
+      background: rgba(242, 242, 242, 1)
+    }
+
+    .lq {
+      font-size: 16px
+    }
+
+    .lr {
+      margin-top: -0.09em
+    }
+
+    .ls {
+      margin-bottom: -0.09em
+    }
+
+    .lt {
+      white-space: pre-wrap
+    }
+
+    .lu {
+      padding-bottom: NaN%
+    }
+
+    .lv {
+      list-style-type: disc
+    }
+
+    .lw {
+      margin-left: 30px
+    }
+
+    .lx {
+      padding-left: 0px
+    }
+
+    .md {
+      will-change: opacity
+    }
+
+    .me {
+      position: fixed
+    }
+
+    .mf {
+      width: 188px
+    }
+
+    .mg {
+      left: 50%
+    }
+
+    .mh {
+      transform: translateX(406px)
+    }
+
+    .mi {
+      top: calc(65px + 54px + 14px)
+    }
+
+    .ml {
+      will-change: opacity, transform
+    }
+
+    .mm {
+      transform: translateY(159px)
+    }
+
+    .mo {
+      width: 131px
+    }
+
+    .mp {
+      flex-direction: column
+    }
+
+    .mq {
+      padding-bottom: 28px
+    }
+
+    .mr {
+      border-bottom: 1px solid rgba(230, 230, 230, 1)
+    }
+
+    .ms {
+      padding-bottom: 20px
+    }
+
+    .mt {
+      padding-top: 2px
+    }
+
+    .mu {
+      max-height: 120px
+    }
+
+    .mv {
+      -webkit-line-clamp: 6
+    }
+
+    .mw {
+      padding: 7px 16px 9px
+    }
+
+    .mx {
+      flex-direction: row
+    }
+
+    .my {
+      padding-top: 28px
+    }
+
+    .mz {
+      margin-bottom: 19px
+    }
+
+    .na {
+      margin-left: -3px
+    }
+
+    .ng {
+      outline: 0
+    }
+
+    .nh {
+      border: 0
+    }
+
+    .ni {
+      user-select: none
+    }
+
+    .nj {
+      cursor: pointer
+    }
+
+    .nk>svg {
+      pointer-events: none
+    }
+
+    .nm {
+      -webkit-user-select: none
+    }
+
+    .nw button {
+      text-align: left
+    }
+
+    .nx {
+      opacity: 0.4
+    }
+
+    .ny {
+      cursor: not-allowed
+    }
+
+    .nz {
+      padding-right: 9px
+    }
+
+    .oi {
+      margin-top: 40px
+    }
+
+    .oj {
+      flex-wrap: wrap
+    }
+
+    .ok {
+      margin-top: 25px
+    }
+
+    .ol {
+      margin-bottom: 8px
+    }
+
+    .om {
+      line-height: 22px
+    }
+
+    .on {
+      border-radius: 3px
+    }
+
+    .oo {
+      padding: 5px 10px
+    }
+
+    .op {
+      max-width: 155px
+    }
+
+    .ot {
+      top: 1px
+    }
+
+    .ph {
+      margin-left: -1px
+    }
+
+    .pi {
+      margin-left: -4px
+    }
+
+    .pq {
+      padding-right: 8px
+    }
+
+    .pr {
+      padding-top: 32px
+    }
+
+    .ps {
+      margin-bottom: 25px
+    }
+
+    .pu {
+      margin-bottom: 32px
+    }
+
+    .pv {
+      min-height: 80px
+    }
+
+    .qa {
+      width: 80px
+    }
+
+    .qb {
+      padding-left: 102px
+    }
+
+    .qd {
+      line-height: 18px
+    }
+
+    .qe {
+      letter-spacing: 0.077em
+    }
+
+    .qf {
+      margin-bottom: 6px
+    }
+
+    .qg {
+      font-size: 22px
+    }
+
+    .qh {
+      line-height: 28px
+    }
+
+    .qi {
+      padding: 4px 12px 6px
+    }
+
+    .qj {
+      max-width: 555px
+    }
+
+    .qk {
+      max-width: 450px
+    }
+
+    .ql {
+      line-height: 24px
+    }
+
+    .qm {
+      display: none
+    }
+
+    .qo {
+      max-width: 550px
+    }
+
+    .qp {
+      margin-top: 5px
+    }
+
+    .qq {
+      height: 40px
+    }
+
+    .qr {
+      width: 40px
+    }
+
+    .qs {
+      font-size: 12px
+    }
+
+    .qt {
+      line-height: 16px
+    }
+
+    .qu {
+      letter-spacing: 0.083em
+    }
+
+    .qv {
+      padding-top: 8px
+    }
+
+    .qw {
+      margin-bottom: 40px
+    }
+
+    .qx {
+      margin-top: 24px
+    }
+
+    .qy {
+      padding-bottom: 16px
+    }
+
+    .qz {
+      margin-bottom: 24px
+    }
+
+    .sj {
+      flex-grow: 0
+    }
+
+    .sk {
+      padding-bottom: 24px
+    }
+
+    .sl {
+      max-width: 500px
+    }
+
+    .sp {
+      padding-bottom: 8px
+    }
+
+    .tc {
+      padding-bottom: 100%
+    }
+
+    .tn {
+      padding: 60px 0
+    }
+
+    .to {
+      background-color: rgba(0, 0, 0, 0.9)
+    }
+
+    .tq {
+      padding-bottom: 48px
+    }
+
+    .tr {
+      border-bottom: 1px solid rgba(255, 255, 255, 0.54)
+    }
+
+    .ts {
+      margin: 0 -12px
+    }
+
+    .tt {
+      margin: 0 12px
+    }
+
+    .tu {
+      flex: 1 1 0
+    }
+
+    .tx:disabled {
+      color: rgba(255, 255, 255, 0.7)
+    }
+
+    .ty:disabled {
+      fill: rgba(255, 255, 255, 0.7)
+    }
+
+    .tz {
+      font-size: 20px
+    }
+
+    .ua {
+      color: rgba(255, 255, 255, 0.98)
+    }
+
+    .ub {
+      color: rgba(255, 255, 255, 0.7)
+    }
+
+    .uc {
+      height: 22px
+    }
+
+    .ud {
+      width: 200px
+    }
+
+    .uj {
+      margin-right: 16px
+    }
+
+    .bb:hover {
+      cursor: pointer
+    }
+
+    .bc:hover {
+      color: rgba(113, 114, 114, 1)
+    }
+
+    .bd:hover {
+      fill: rgba(113, 114, 114, 1)
+    }
+
+    .cm:hover {
+      color: rgba(25, 25, 25, 1)
+    }
+
+    .cn:hover {
+      fill: rgba(25, 25, 25, 1)
+    }
+
+    .hm:hover {
+      text-decoration: underline
+    }
+
+    .ht:hover {
+      background: rgba(113, 114, 114, 1)
+    }
+
+    .hu:hover {
+      border-color: rgba(113, 114, 114, 1)
+    }
+
+    .no:hover {
+      fill: rgba(117, 117, 117, 1)
+    }
+
+    .tv:hover {
+      color: rgba(255, 255, 255, 0.99)
+    }
+
+    .tw:hover {
+      fill: rgba(255, 255, 255, 0.99)
+    }
+
+    .el:focus {
+      transform: scale(1.01)
+    }
+
+    .nn:focus {
+      fill: rgba(117, 117, 117, 1)
+    }
+
+    .nl:active {
+      border-style: none
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (min-width: 1080px)">
+    .d {
+      display: none
+    }
+
+    .ag {
+      margin: 0 64px
+    }
+
+    .dy {
+      max-width: 1192px
+    }
+
+    .ee {
+      margin-top: 32px
+    }
+
+    .fy {
+      font-size: 48px
+    }
+
+    .fz {
+      margin-top: 0.55em
+    }
+
+    .ga {
+      line-height: 60px
+    }
+
+    .gb {
+      letter-spacing: -0.011em
+    }
+
+    .gr {
+      font-size: 22px
+    }
+
+    .gs {
+      margin-top: 0.92em
+    }
+
+    .gt {
+      line-height: 28px
+    }
+
+    .ik {
+      margin-left: 30px
+    }
+
+    .jf {
+      font-size: 21px
+    }
+
+    .jg {
+      margin-top: 2em
+    }
+
+    .jh {
+      line-height: 32px
+    }
+
+    .ji {
+      letter-spacing: -0.003em
+    }
+
+    .ko {
+      font-size: 30px
+    }
+
+    .kp {
+      margin-top: 1.95em
+    }
+
+    .kq {
+      line-height: 36px
+    }
+
+    .kr {
+      letter-spacing: 0
+    }
+
+    .kx {
+      margin-top: 0.86em
+    }
+
+    .lg {
+      margin-top: 1.72em
+    }
+
+    .lm {
+      margin-top: 56px
+    }
+
+    .mc {
+      margin-top: 1.05em
+    }
+
+    .nf {
+      margin-right: 5px
+    }
+
+    .nv {
+      margin-top: 5px
+    }
+
+    .oh {
+      padding-left: 6px
+    }
+
+    .ov {
+      display: inline-block
+    }
+
+    .pa {
+      margin-left: 7px
+    }
+
+    .pb {
+      margin-top: 8px
+    }
+
+    .pg {
+      width: 25px
+    }
+
+    .po {
+      padding-left: 7px
+    }
+
+    .pp {
+      top: 3px
+    }
+
+    .ro {
+      width: calc(100% + 32px)
+    }
+
+    .rp {
+      margin-left: -16px
+    }
+
+    .rq {
+      margin-right: -16px
+    }
+
+    .sf {
+      padding-left: 16px
+    }
+
+    .sg {
+      padding-right: 16px
+    }
+
+    .sh {
+      flex-basis: 25%
+    }
+
+    .si {
+      max-width: 25%
+    }
+
+    .sy {
+      font-size: 16px
+    }
+
+    .sz {
+      line-height: 20px
+    }
+
+    .tl {
+      min-width: 70px
+    }
+
+    .tm {
+      min-height: 70px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (max-width: 1079.98px)">
+    .e {
+      display: none
+    }
+
+    .fa {
+      margin-left: auto
+    }
+
+    .fb {
+      text-align: center
+    }
+
+    .ij {
+      margin-left: 30px
+    }
+
+    .ne {
+      margin-right: 5px
+    }
+
+    .nu {
+      margin-top: 5px
+    }
+
+    .og {
+      padding-left: 6px
+    }
+
+    .ou {
+      display: inline-block
+    }
+
+    .oy {
+      margin-left: 7px
+    }
+
+    .oz {
+      margin-top: 8px
+    }
+
+    .pf {
+      width: 25px
+    }
+
+    .pm {
+      padding-left: 7px
+    }
+
+    .pn {
+      top: 3px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (max-width: 903.98px)">
+    .f {
+      display: none
+    }
+
+    .ii {
+      margin-left: 30px
+    }
+
+    .nd {
+      margin-right: 5px
+    }
+
+    .nt {
+      margin-top: 5px
+    }
+
+    .oe {
+      padding-left: 6px
+    }
+
+    .of {
+      top: 3px
+    }
+
+    .os {
+      display: inline-block
+    }
+
+    .ow {
+      margin-left: 7px
+    }
+
+    .ox {
+      margin-top: 8px
+    }
+
+    .pe {
+      width: 15px
+    }
+
+    .pl {
+      padding-left: 3px
+    }
+
+    .so {
+      margin-right: 16px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (max-width: 727.98px)">
+    .g {
+      display: none
+    }
+
+    .al {
+      height: 56px
+    }
+
+    .am {
+      display: flex
+    }
+
+    .bi {
+      display: block
+    }
+
+    .ct {
+      margin-bottom: 0px
+    }
+
+    .cu {
+      height: 110px
+    }
+
+    .gy {
+      margin-top: 32px
+    }
+
+    .gz {
+      flex-direction: column-reverse
+    }
+
+    .ig {
+      margin-bottom: 30px
+    }
+
+    .ih {
+      margin-left: 0px
+    }
+
+    .nc {
+      margin-left: 8px
+    }
+
+    .nr {
+      margin-top: 2px
+    }
+
+    .ns {
+      margin-right: 8px
+    }
+
+    .oc {
+      padding-left: 6px
+    }
+
+    .od {
+      top: 3px
+    }
+
+    .or {
+      display: inline-block
+    }
+
+    .pd {
+      width: 15px
+    }
+
+    .pk {
+      padding-left: 3px
+    }
+
+    .pt {
+      padding-top: 0
+    }
+
+    .pw {
+      margin-bottom: 24px
+    }
+
+    .px {
+      align-items: center
+    }
+
+    .py {
+      width: 102px
+    }
+
+    .pz {
+      position: relative
+    }
+
+    .qc {
+      padding-left: 0
+    }
+
+    .qn {
+      margin-top: 24px
+    }
+
+    .ra {
+      padding-bottom: 12px
+    }
+
+    .rb {
+      margin-top: 16px
+    }
+
+    .sn {
+      margin-right: 16px
+    }
+
+    .ta {
+      margin-left: 16px
+    }
+
+    .tb {
+      margin-right: 0px
+    }
+
+    .tp {
+      padding: 32px 0
+    }
+
+    .ue {
+      width: 140px
+    }
+
+    .uf {
+      margin-bottom: 16px
+    }
+
+    .ug {
+      margin-top: 30px
+    }
+
+    .uh {
+      width: 100%
+    }
+
+    .ui {
+      flex-direction: row
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (max-width: 551.98px)">
+    .h {
+      display: none
+    }
+
+    .ab {
+      margin: 0 24px
+    }
+
+    .dr {
+      margin: 0
+    }
+
+    .ds {
+      max-width: 100%
+    }
+
+    .ea {
+      margin-top: 24px
+    }
+
+    .fi {
+      font-size: 34px
+    }
+
+    .fj {
+      margin-top: 0.56em
+    }
+
+    .fk {
+      line-height: 42px
+    }
+
+    .fl {
+      letter-spacing: -0.016em
+    }
+
+    .gf {
+      font-size: 18px
+    }
+
+    .gg {
+      margin-top: 0.79em
+    }
+
+    .gh {
+      line-height: 24px
+    }
+
+    .gx {
+      margin-top: 32px
+    }
+
+    .hf {
+      margin-bottom: 0px
+    }
+
+    .ie {
+      margin-bottom: 30px
+    }
+
+    .if {
+      margin-left: 0px
+    }
+
+    .ir {
+      margin-top: 1.56em
+    }
+
+    .is {
+      line-height: 28px
+    }
+
+    .it {
+      letter-spacing: -0.003em
+    }
+
+    .ka {
+      font-size: 22px
+    }
+
+    .kb {
+      margin-top: 1.2em
+    }
+
+    .kc {
+      letter-spacing: 0
+    }
+
+    .kt {
+      margin-top: 0.67em
+    }
+
+    .la {
+      font-size: 20px
+    }
+
+    .lb {
+      margin-top: 1.23em
+    }
+
+    .li {
+      margin-top: 40px
+    }
+
+    .ly {
+      margin-top: 1.34em
+    }
+
+    .nb {
+      margin-left: 8px
+    }
+
+    .np {
+      margin-top: 2px
+    }
+
+    .nq {
+      margin-right: 8px
+    }
+
+    .oa {
+      padding-left: 6px
+    }
+
+    .ob {
+      top: 3px
+    }
+
+    .oq {
+      display: inline-block
+    }
+
+    .pc {
+      width: 15px
+    }
+
+    .pj {
+      padding-left: 3px
+    }
+
+    .rc {
+      width: calc(100% + 24px)
+    }
+
+    .rd {
+      margin-left: -12px
+    }
+
+    .re {
+      margin-right: -12px
+    }
+
+    .rr {
+      padding-left: 12px
+    }
+
+    .rs {
+      padding-right: 12px
+    }
+
+    .rt {
+      flex-basis: 100%
+    }
+
+    .sm {
+      margin-right: 16px
+    }
+
+    .sq {
+      font-size: 16px
+    }
+
+    .sr {
+      line-height: 20px
+    }
+
+    .td {
+      min-width: 48px
+    }
+
+    .te {
+      min-height: 48px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE"
+    media="all and (min-width: 904px) and (max-width: 1079.98px)">
+    .i {
+      display: none
+    }
+
+    .af {
+      margin: 0 64px
+    }
+
+    .dx {
+      max-width: 1192px
+    }
+
+    .ed {
+      margin-top: 32px
+    }
+
+    .fu {
+      font-size: 48px
+    }
+
+    .fv {
+      margin-top: 0.55em
+    }
+
+    .fw {
+      line-height: 60px
+    }
+
+    .fx {
+      letter-spacing: -0.011em
+    }
+
+    .go {
+      font-size: 22px
+    }
+
+    .gp {
+      margin-top: 0.92em
+    }
+
+    .gq {
+      line-height: 28px
+    }
+
+    .jb {
+      font-size: 21px
+    }
+
+    .jc {
+      margin-top: 2em
+    }
+
+    .jd {
+      line-height: 32px
+    }
+
+    .je {
+      letter-spacing: -0.003em
+    }
+
+    .kk {
+      font-size: 30px
+    }
+
+    .kl {
+      margin-top: 1.95em
+    }
+
+    .km {
+      line-height: 36px
+    }
+
+    .kn {
+      letter-spacing: 0
+    }
+
+    .kw {
+      margin-top: 0.86em
+    }
+
+    .lf {
+      margin-top: 1.72em
+    }
+
+    .ll {
+      margin-top: 56px
+    }
+
+    .mb {
+      margin-top: 1.05em
+    }
+
+    .rl {
+      width: calc(100% + 32px)
+    }
+
+    .rm {
+      margin-left: -16px
+    }
+
+    .rn {
+      margin-right: -16px
+    }
+
+    .sb {
+      padding-left: 16px
+    }
+
+    .sc {
+      padding-right: 16px
+    }
+
+    .sd {
+      flex-basis: 25%
+    }
+
+    .se {
+      max-width: 25%
+    }
+
+    .sw {
+      font-size: 16px
+    }
+
+    .sx {
+      line-height: 20px
+    }
+
+    .tj {
+      min-width: 70px
+    }
+
+    .tk {
+      min-height: 70px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE"
+    media="all and (min-width: 728px) and (max-width: 903.98px)">
+    .j {
+      display: none
+    }
+
+    .ae {
+      margin: 0 48px
+    }
+
+    .dv {
+      margin: 0
+    }
+
+    .dw {
+      max-width: 100%
+    }
+
+    .ec {
+      margin-top: 32px
+    }
+
+    .fq {
+      font-size: 48px
+    }
+
+    .fr {
+      margin-top: 0.55em
+    }
+
+    .fs {
+      line-height: 60px
+    }
+
+    .ft {
+      letter-spacing: -0.011em
+    }
+
+    .gl {
+      font-size: 22px
+    }
+
+    .gm {
+      margin-top: 0.92em
+    }
+
+    .gn {
+      line-height: 28px
+    }
+
+    .ix {
+      font-size: 21px
+    }
+
+    .iy {
+      margin-top: 2em
+    }
+
+    .iz {
+      line-height: 32px
+    }
+
+    .ja {
+      letter-spacing: -0.003em
+    }
+
+    .kg {
+      font-size: 30px
+    }
+
+    .kh {
+      margin-top: 1.95em
+    }
+
+    .ki {
+      line-height: 36px
+    }
+
+    .kj {
+      letter-spacing: 0
+    }
+
+    .kv {
+      margin-top: 0.86em
+    }
+
+    .le {
+      margin-top: 1.72em
+    }
+
+    .lk {
+      margin-top: 56px
+    }
+
+    .ma {
+      margin-top: 1.05em
+    }
+
+    .ri {
+      width: calc(100% + 28px)
+    }
+
+    .rj {
+      margin-left: -14px
+    }
+
+    .rk {
+      margin-right: -14px
+    }
+
+    .rx {
+      padding-left: 14px
+    }
+
+    .ry {
+      padding-right: 14px
+    }
+
+    .rz {
+      flex-basis: 50%
+    }
+
+    .sa {
+      max-width: 50%
+    }
+
+    .su {
+      font-size: 16px
+    }
+
+    .sv {
+      line-height: 20px
+    }
+
+    .th {
+      min-width: 48px
+    }
+
+    .ti {
+      min-height: 48px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE"
+    media="all and (min-width: 552px) and (max-width: 727.98px)">
+    .k {
+      display: none
+    }
+
+    .ac {
+      margin: 0 24px
+    }
+
+    .dt {
+      margin: 0
+    }
+
+    .du {
+      max-width: 100%
+    }
+
+    .eb {
+      margin-top: 24px
+    }
+
+    .fm {
+      font-size: 34px
+    }
+
+    .fn {
+      margin-top: 0.56em
+    }
+
+    .fo {
+      line-height: 42px
+    }
+
+    .fp {
+      letter-spacing: -0.016em
+    }
+
+    .gi {
+      font-size: 18px
+    }
+
+    .gj {
+      margin-top: 0.79em
+    }
+
+    .gk {
+      line-height: 24px
+    }
+
+    .iu {
+      margin-top: 1.56em
+    }
+
+    .iv {
+      line-height: 28px
+    }
+
+    .iw {
+      letter-spacing: -0.003em
+    }
+
+    .kd {
+      font-size: 22px
+    }
+
+    .ke {
+      margin-top: 1.2em
+    }
+
+    .kf {
+      letter-spacing: 0
+    }
+
+    .ku {
+      margin-top: 0.67em
+    }
+
+    .lc {
+      font-size: 20px
+    }
+
+    .ld {
+      margin-top: 1.23em
+    }
+
+    .lj {
+      margin-top: 40px
+    }
+
+    .lz {
+      margin-top: 1.34em
+    }
+
+    .rf {
+      width: calc(100% + 24px)
+    }
+
+    .rg {
+      margin-left: -12px
+    }
+
+    .rh {
+      margin-right: -12px
+    }
+
+    .ru {
+      padding-left: 12px
+    }
+
+    .rv {
+      padding-right: 12px
+    }
+
+    .rw {
+      flex-basis: 100%
+    }
+
+    .ss {
+      font-size: 16px
+    }
+
+    .st {
+      line-height: 20px
+    }
+
+    .tf {
+      min-width: 48px
+    }
+
+    .tg {
+      min-height: 48px
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="print">
+    .z {
+      display: none
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE"
+    media="(prefers-reduced-motion: no-preference)">
+    .eh {
+      transition: transform 300ms cubic-bezier(0.2, 0, 0.2, 1)
+    }
+
+    .mj {
+      transition: opacity 200ms
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE"
+    media="(orientation: landscape) and (max-width: 903.98px)">
+    .hl {
+      max-height: none
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (max-width: 1230px)">
+    .mk {
+      display: none
+    }
+  </style>
+  <style type="text/css" data-fela-rehydration="555" data-fela-type="RULE" media="all and (max-width: 1198px)">
+    .mn {
+      display: none
+    }
+  </style>
+</head>
+
+<body>
+  <div id="root">
+    <div class="a b c">
+      <div class="d e f g h i j k"></div>
+      <script>document.domain = document.domain;</script>
+      <div>
+        <script>if (window.self !== window.top) window.location = "about:blank"</script>
+      </div>
+      <script>window.PARSELY = window.PARSELY || { autotrack: false }</script>
+      <div class="s">
+        <nav class="s t u v w c x y z">
+          <div>
+            <div class="s c">
+              <div class="n p">
+                <div class="ab ac ae af ag ah ai aj">
+                  <div class="ak n o al am">
+                    <div class="n o an x"><a rel="noopener"
+                        href="/?source=post_page-----15fd2dd8f07b--------------------------------"><svg
+                          viewBox="0 0 1043.63 592.71" class="q ao">
+                          <g data-name="Layer 2">
+                            <g data-name="Layer 1">
+                              <path
+                                d="M588.67 296.36c0 163.67-131.78 296.35-294.33 296.35S0 460 0 296.36 131.78 0 294.34 0s294.33 132.69 294.33 296.36M911.56 296.36c0 154.06-65.89 279-147.17 279s-147.17-124.94-147.17-279 65.88-279 147.16-279 147.17 124.9 147.17 279M1043.63 296.36c0 138-23.17 249.94-51.76 249.94s-51.75-111.91-51.75-249.94 23.17-249.94 51.75-249.94 51.76 111.9 51.76 249.94">
+                              </path>
+                            </g>
+                          </g>
+                        </svg></a></div>
+                    <div class="s ap x">
+                      <div class="n o">
+                        <div class="n o g">
+                          <div class="aq" id="lo-post-page-navbar-sign-in-link">
+                            <div class="ar s"><span><a
+                                  href="https://medium.com/m/signin?operation=login&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_page-----15fd2dd8f07b---------------------nav_reg-----------"
+                                  class="as at au av aw ax ay az ba bb bc bd be bf bg" rel="noopener">Sign in</a></span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="bh s c bi">
+              <div class="n p">
+                <div class="ab ac ae af ag ah ai aj">
+                  <div class="bj bk n o">
+                    <div class="bl s ap"><a
+                        href="/webpack?source=post_page-----15fd2dd8f07b--------------------------------"
+                        rel="noopener">
+                        <div class="bm bn s"><img alt="webpack" class=""
+                            src="https://miro.medium.com/max/186/1*gdoQ1_5OID90wf1eLTFvWw.png" width="93" height="36" />
+                        </div>
+                      </a></div>
+                    <div class="bo s bp">
+                      <ul class="bq ba br bs bt n bu g bv bw bx">
+                        <li class="n o by bz ca cb"><span class="ce b cf cg ch ci cj"><a
+                              href="https://medium.com/webpack/announcements/home?source=post_page-----15fd2dd8f07b--------------------------------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                              rel="noopener">Announcements</a></span></li>
+                        <li class="n o by bz ca cb"><span class="ce b cf cg ch ci cj"><a
+                              href="https://medium.com/webpack/gsoc/home?source=post_page-----15fd2dd8f07b--------------------------------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">Google Summer of
+                              Code</a></span></li>
+                        <li class="n o by bz ca cb"><span class="ce b cf cg ch ci cj"><a
+                              href="https://medium.com/webpack/contributors-guide/home?source=post_page-----15fd2dd8f07b--------------------------------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">Contributors
+                              Guide</a></span></li>
+                        <li class="n o by bz ca cb"><span class="ce b cf cg ch ci cj"><a
+                              href="https://medium.com/webpack/tips-and-tricks/home?source=post_page-----15fd2dd8f07b--------------------------------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">Tips and
+                              Tricks</a></span></li>
+                        <li class="n o by bz ca cb"><span class="ce b cf cg ch ci cj"><a
+                              href="https://medium.com/webpack/about?source=post_page-----15fd2dd8f07b--------------------------------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">About Us</a></span>
+                        </li><span class="by cc cd"></span>
+                        <li class="n o by bz ca cb"><span class="ce b cf cg ch ci cj"><a
+                              href="http://webpack.js.org/?source=post_page-----15fd2dd8f07b--------------------------------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener nofollow">Official
+                              Documentation</a></span></li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </nav>
+        <div class="cq cr cs s ct cu"></div>
+        <article>
+          <section class="cv cw cx cy aj cz da s"></section><span class="s"></span>
+          <div>
+            <div class="t v dh di dj dk"></div>
+            <section class="dl dm dn do dp">
+              <div class="dq">
+                <div class="n p">
+                  <div class="dr ds dt du dv dw af dx ag dy ai aj">
+                    <figure class="ea eb ec ed ee dq ef eg paragraph-image">
+                      <div role="button" tabindex="0" class="eh ei ej ek aj el">
+                        <div class="cx cy dz">
+                          <div class="er s ej es">
+                            <div class="et eu s">
+                              <div class="em en t u v eo aj bk ep eq"><img alt="Image for post"
+                                  class="t u v eo aj ev ew ex"
+                                  src="https://miro.medium.com/max/60/1*Ac4K68j43uSbvHnKZKfXPw.jpeg?q=20" width="4896"
+                                  height="3264" /></div><img alt="Image for post" class="em en t u v eo aj c"
+                                width="4896" height="3264" /><noscript><img alt="Image for post" class="t u v eo aj"
+                                  src="https://miro.medium.com/max/9792/1*Ac4K68j43uSbvHnKZKfXPw.jpeg" width="4896"
+                                  height="3264"
+                                  srcSet="https://miro.medium.com/max/552/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 276w, https://miro.medium.com/max/1104/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 552w, https://miro.medium.com/max/1280/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 640w, https://miro.medium.com/max/1456/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 728w, https://miro.medium.com/max/1632/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 816w, https://miro.medium.com/max/1808/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 904w, https://miro.medium.com/max/1984/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 992w, https://miro.medium.com/max/2000/1*Ac4K68j43uSbvHnKZKfXPw.jpeg 1000w"
+                                  sizes="1000px" /></noscript>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <figcaption class="ey ez cz cx cy fa fb ce b fc cg ch">It’s finally here. And it’s beautiful.
+                      </figcaption>
+                    </figure>
+                  </div>
+                </div>
+              </div>
+              <div class="n p">
+                <div class="ab ac ae af ag fd ai aj">
+                  <div class="">
+                    <h1 id="ea51"
+                      class="fe ff fg fh b fi fj fk fl fm fn fo fp fq fr fs ft fu fv fw fx fy fz ga gb gc gd">🍾🚀
+                      webpack 3: Official Release!! 🚀🍾</h1>
+                  </div>
+                  <div class="">
+                    <h2 id="8fe8" class="ge ff fg ce b gf gg gh gi gj gk gl gm gn go gp gq gr gs gt gu ch">Scope
+                      Hoisting, “magic comments”, and more!</h2>
+                    <div class="gv">
+                      <div class="n gw gx gy gz">
+                        <div class="o n">
+                          <div><a rel="noopener"
+                              href="/@TheLarkInn?source=post_page-----15fd2dd8f07b--------------------------------"><img
+                                alt="Sean T. Larkin" class="s ha hb hc"
+                                src="https://miro.medium.com/fit/c/96/96/1*AtcF5LLmMnXgwTpBMeos-w.jpeg" width="48"
+                                height="48" /></a></div>
+                          <div class="hd aj s">
+                            <div class="n">
+                              <div style="flex:1"><span class="ce b fc cg gd">
+                                  <div class="he n o hf"><span class="ce b fc cg bk hg hh hi hj hk hl gd"><a
+                                        class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener"
+                                        href="/@TheLarkInn?source=post_page-----15fd2dd8f07b--------------------------------">Sean
+                                        T. Larkin</a></span>
+                                    <div class="hn s ap h"><span><button
+                                          class="ce b cf cg ho hp hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">Follow</button></span>
+                                    </div>
+                                  </div>
+                                </span></div>
+                            </div><span class="ce b fc cg ch"><span class="ce b fc cg bk hg hh hi hj hk hl ch">
+                                <div><a class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener"
+                                    href="/webpack/webpack-3-official-release-15fd2dd8f07b?source=post_page-----15fd2dd8f07b--------------------------------">Jun
+                                    19, 2017</a> <!-- -->·
+                                  <!-- -->
+                                  <!-- -->3
+                                  <!-- --> min read
+                                </div>
+                              </span></span>
+                          </div>
+                        </div>
+                        <div class="n id ie if ig ih ii ij ik z">
+                          <div class="n o">
+                            <div class="il s ap"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                                aria-label="Share on twitter"><svg width="29" height="29" class="im">
+                                  <path
+                                    d="M22.05 7.54a4.47 4.47 0 0 0-3.3-1.46 4.53 4.53 0 0 0-4.53 4.53c0 .35.04.7.08 1.05A12.9 12.9 0 0 1 5 6.89a5.1 5.1 0 0 0-.65 2.26c.03 1.6.83 2.99 2.02 3.79a4.3 4.3 0 0 1-2.02-.57v.08a4.55 4.55 0 0 0 3.63 4.44c-.4.08-.8.13-1.21.16l-.81-.08a4.54 4.54 0 0 0 4.2 3.15 9.56 9.56 0 0 1-5.66 1.94l-1.05-.08c2 1.27 4.38 2.02 6.94 2.02 8.3 0 12.86-6.9 12.84-12.85.02-.24 0-.43 0-.65a8.68 8.68 0 0 0 2.26-2.34c-.82.38-1.7.62-2.6.72a4.37 4.37 0 0 0 1.95-2.51c-.84.53-1.81.9-2.83 1.13z">
+                                  </path>
+                                </svg></button></div>
+                            <div class="il s ap"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                                aria-label="Share on linkedin"><svg width="29" height="29" viewBox="0 0 29 29"
+                                  fill="none" class="im">
+                                  <path
+                                    d="M5 6.36C5 5.61 5.63 5 6.4 5h16.2c.77 0 1.4.61 1.4 1.36v16.28c0 .75-.63 1.36-1.4 1.36H6.4c-.77 0-1.4-.6-1.4-1.36V6.36z">
+                                  </path>
+                                  <path fill-rule="evenodd" clip-rule="evenodd"
+                                    d="M10.76 20.9v-8.57H7.89v8.58h2.87zm-1.44-9.75c1 0 1.63-.65 1.63-1.48-.02-.84-.62-1.48-1.6-1.48-.99 0-1.63.64-1.63 1.48 0 .83.62 1.48 1.59 1.48h.01zM12.35 20.9h2.87v-4.79c0-.25.02-.5.1-.7.2-.5.67-1.04 1.46-1.04 1.04 0 1.46.8 1.46 1.95v4.59h2.87v-4.92c0-2.64-1.42-3.87-3.3-3.87-1.55 0-2.23.86-2.61 1.45h.02v-1.24h-2.87c.04.8 0 8.58 0 8.58z"
+                                    fill="#fff"></path>
+                                </svg></button></div>
+                            <div class="il s ap"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                                aria-label="Share on facebook"><svg width="29" height="29" class="im">
+                                  <path
+                                    d="M23.2 5H5.8a.8.8 0 0 0-.8.8V23.2c0 .44.35.8.8.8h9.3v-7.13h-2.38V13.9h2.38v-2.38c0-2.45 1.55-3.66 3.74-3.66 1.05 0 1.95.08 2.2.11v2.57h-1.5c-1.2 0-1.48.57-1.48 1.4v1.96h2.97l-.6 2.97h-2.37l.05 7.12h5.1a.8.8 0 0 0 .79-.8V5.8a.8.8 0 0 0-.8-.79">
+                                  </path>
+                                </svg></button></div>
+                            <div class="in s">
+                              <div class="im"><span><a
+                                    href="https://medium.com/m/signin?actionUrl=https%3A%2F%2Fmedium.com%2F_%2Fbookmark%2Fp%2F15fd2dd8f07b&amp;operation=register&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_actions_header--------------------------bookmark_preview-----------"
+                                    class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener"><svg width="25"
+                                      height="25" viewBox="0 0 25 25">
+                                      <path
+                                        d="M19 6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v14.66h.01c.01.1.05.2.12.28a.5.5 0 0 0 .7.03l5.67-4.12 5.66 4.13a.5.5 0 0 0 .71-.03.5.5 0 0 0 .12-.29H19V6zm-6.84 9.97L7 19.64V6a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v13.64l-5.16-3.67a.49.49 0 0 0-.68 0z"
+                                        fill-rule="evenodd"></path>
+                                    </svg></a></span></div>
+                            </div>
+                            <div class="s an"></div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <p id="927b"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">After we
+                    released webpack v2, we made some promises to the community. We promised that we would deliver the
+                    features you voted for. Moreover, we promised to deliver them in a <strong class="iq jk"><em
+                        class="jl">faster</em></strong>, <strong class="iq jk"><em class="jl">more stable</em></strong>
+                    release cycle.</p>
+                  <p id="efac"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">No more
+                    year-long betas, no breaking changes between release candidates. We promised to do you right by<em
+                      class="jl"> </em><strong class="iq jk"><em class="jl">you,</em></strong><em class="jl"> the
+                      community that makes webpack thrive.</em></p>
+                  <p id="ca2d"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">The
+                    webpack team is proud to announce that today we have released webpack 3.0.0!!! You can download or
+                    upgrade to it today!!</p>
+                  <p id="549b"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd"><code
+                      class="es jm jn jo jp b">npm install webpack@3.0.0 --save-dev</code></p>
+                  <p id="69df"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">or with
+                  </p>
+                  <p id="4ef7"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd"><code
+                      class="es jm jn jo jp b">yarn add webpack@3.0.0 --dev</code></p>
+                </div>
+              </div>
+            </section>
+            <div class="n p gv jq jr js" role="separator"><span class="jt ha ib ju jv jw"></span><span
+                class="jt ha ib ju jv jw"></span><span class="jt ha ib ju jv"></span></div>
+            <section class="dl dm dn do dp">
+              <div class="n p">
+                <div class="ab ac ae af ag fd ai aj">
+                  <p id="17f8"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">Migrating
+                    from webpack 2 to 3, should involve <strong class="iq jk"><em class="jl">no effort beyond running
+                        the upgrade commands in your terminal.</em></strong> We marked this as a Major change because of
+                    internal breaking changes that could affect some plugins.</p>
+                  <p id="2878"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd"><strong
+                      class="iq jk"><em class="jl">So far we’ve seen 98% of users upgrade with no breaking functionality
+                        at all!!!</em></strong></p>
+                  <h1 id="3750"
+                    class="jx jy fg ce jz ka kb is kc kd ke iv kf kg kh ki kj kk kl km kn ko kp kq kr ks gd">What’s new?
+                  </h1>
+                  <p id="3c03"
+                    class="io ip fg iq b gf kt is it gi ku iv iw ix kv iz ja jb kw jd je jf kx jh ji jj dl gd">As we
+                    mentioned, we aimed to deliver the features that you <a href="https://webpack.js.org/vote"
+                      class="ck ky" rel="noopener nofollow">voted for</a>! Because of the overwhelming GitHub
+                    contributions, <a href="http://opencollective.com/webpack" class="ck ky"
+                      rel="noopener nofollow">support from our backers and sponsors</a>, we have been able to hit each
+                    one. 😍</p>
+                  <h2 id="c11e"
+                    class="kz jy fg ce jz la lb gh kc lc ld gk kf gl le gn kj go lf gq kn gr lg gt kr lh gd">🔬 Scope
+                    Hoisting 🔬</h2>
+                  <p id="0014"
+                    class="io ip fg iq b gf kt is it gi ku iv iw ix kv iz ja jb kw jd je jf kx jh ji jj dl gd">Scope
+                    Hoisting is the flagship feature of webpack 3. One of webpack’s trade-offs when bundling was that
+                    each module in your bundle would be wrapped in individual function closures. These wrapper functions
+                    made it slower for your JavaScript to execute in the browser. In comparison, tools like Closure
+                    Compiler and RollupJS ‘hoist’ or concatenate the scope of all your modules into one closure and
+                    allow for your code to have a faster execution time in the browser.</p>
+                  <figure class="li lj lk ll lm dq">
+                    <div class="er s ej">
+                      <div class="ln eu s"></div>
+                    </div>
+                  </figure>
+                  <p id="4965"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">As of
+                    today, with webpack 3, you can <strong class="iq jk">now add the following plugin to your
+                      configuration to enable scope hoisting:</strong></p>
+                  <pre
+                    class="li lj lk ll lm lo lp bt"><span id="7078" class="gd kz jy fg jp b lq lr ls s lt">module.exports = {  <br/>  plugins: [<br/>    new webpack.optimize.ModuleConcatenationPlugin()<br/>  ]<br/>};</span></pre>
+                  <p id="95b8"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">Scope
+                    Hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this
+                    webpack may fallback to normal bundling based on what kind of modules you are using, and <a
+                      class="ck ky" rel="noopener"
+                      href="/webpack/webpack-freelancing-log-book-week-5-7-4764be3266f5">other conditions</a>.</p>
+                  <p id="40b6"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">To stay
+                    informed on what triggers these fallbacks, we’ve added a <code
+                      class="es jm jn jo jp b">--display-optimization-bailout</code> cli flag that will tell you what
+                    caused the fallback.</p>
+                  <figure class="li lj lk ll lm dq">
+                    <div class="er s ej">
+                      <div class="ln eu s"></div>
+                    </div>
+                  </figure>
+                  <p id="f203"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">Because
+                    scope hoisting will remove function wrappers around your modules, you may see some small size
+                    improvements. However, the significant improvement will be how fast the JavaScript loads in the
+                    browser. If you have awesome before and after comparisons, feel free to respond with some data as
+                    we’d be honored to share it!</p>
+                  <h2 id="ea65"
+                    class="kz jy fg ce jz la lb gh kc lc ld gk kf gl le gn kj go lf gq kn gr lg gt kr lh gd">🔮 ”Magic
+                    Comments” 🔮</h2>
+                  <p id="b50c"
+                    class="io ip fg iq b gf kt is it gi ku iv iw ix kv iz ja jb kw jd je jf kx jh ji jj dl gd">When we
+                    introduced in webpack 2 the ability to use the dynamic import syntax ( <code
+                      class="es jm jn jo jp b">import()</code> ), users expressed their concerns that they could not
+                    create named chunks like they were able to with <code
+                      class="es jm jn jo jp b">require.ensure</code>.</p>
+                  <p id="b465"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">We have
+                    now introduced what the community has coined “magic comments”, the ability to pass chunk name, <a
+                      class="ck ky" rel="noopener"
+                      href="/webpack/how-to-use-webpacks-new-magic-comment-feature-with-react-universal-component-ssr-a38fd3e296a">and
+                      more</a> as an inline comment to your <code class="es jm jn jo jp b">import()</code> statements.
+                  </p>
+                  <figure class="li lj lk ll lm dq">
+                    <div class="er s ej">
+                      <div class="lu eu s"></div>
+                    </div>
+                    <figcaption class="ey ez cz cx cy fa fb ce b fc cg ch">By using comments, we are able to stay true
+                      to the load specification, and still give you the great chunk naming features you love.
+                    </figcaption>
+                  </figure>
+                  <p id="f813"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">Although
+                    these are technically features we released in v2.4 and v2.6, we worked to stabilize and fix bugs for
+                    these features that have landed in v3. This now allows the dynamic import syntax to have the same
+                    flexibility as <code class="es jm jn jo jp b">require.ensure</code>.</p>
+                  <figure class="li lj lk ll lm dq">
+                    <div class="er s ej">
+                      <div class="ln eu s"></div>
+                    </div>
+                  </figure>
+                  <p id="a2af"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">To learn
+                    more information, see our <a href="https://webpack.js.org/guides/code-splitting-async" class="ck ky"
+                      rel="noopener nofollow">newest documentation guide on code-splitting</a> that highlights these
+                    features!!!</p>
+                  <h1 id="5371"
+                    class="jx jy fg ce jz ka kb is kc kd ke iv kf kg kh ki kj kk kl km kn ko kp kq kr ks gd">😍 What’s
+                    next? 😍</h1>
+                  <p id="4f06"
+                    class="io ip fg iq b gf kt is it gi ku iv iw ix kv iz ja jb kw jd je jf kx jh ji jj dl gd">We have
+                    quite a few features and enhancements that we are hoping to bring you!!! But to take control of the
+                    ones we should be working one, stop by our<a href="http://webpack.js.org/vote" class="ck ky"
+                      rel="noopener nofollow"><em class="jl"> vote page, and upvote the features you would like to
+                        see!</em></a></p>
+                  <p id="92e2"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">Here are
+                    some of those things we are hoping to bring you still:</p>
+                  <ul class="">
+                    <li id="b1a0"
+                      class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj lv lw lx gd">
+                      Better Build Caching</li>
+                    <li id="e784"
+                      class="io ip fg iq b gf ly is it gi lz iv iw ix ma iz ja jb mb jd je jf mc jh ji jj lv lw lx gd">
+                      Faster initial and incremental builds</li>
+                    <li id="9ec9"
+                      class="io ip fg iq b gf ly is it gi lz iv iw ix ma iz ja jb mb jd je jf mc jh ji jj lv lw lx gd">
+                      Better TypeScript experience</li>
+                    <li id="98e6"
+                      class="io ip fg iq b gf ly is it gi lz iv iw ix ma iz ja jb mb jd je jf mc jh ji jj lv lw lx gd">
+                      Revamped Long term caching</li>
+                    <li id="8e9d"
+                      class="io ip fg iq b gf ly is it gi lz iv iw ix ma iz ja jb mb jd je jf mc jh ji jj lv lw lx gd">
+                      WASM Module Support</li>
+                    <li id="8948"
+                      class="io ip fg iq b gf ly is it gi lz iv iw ix ma iz ja jb mb jd je jf mc jh ji jj lv lw lx gd">
+                      Improve User Experience</li>
+                  </ul>
+                  <h1 id="f87b"
+                    class="jx jy fg ce jz ka kb is kc kd ke iv kf kg kh ki kj kk kl km kn ko kp kq kr ks gd">🙇Thank you
+                    🙇</h1>
+                  <p id="48ea"
+                    class="io ip fg iq b gf kt is it gi ku iv iw ix kv iz ja jb kw jd je jf kx jh ji jj dl gd">All of
+                    our users, contributors, documentation writers, bloggers, sponsors, backers, and maintainers are all
+                    shareholders in helping us ensure webpack is successful for years to come.</p>
+                  <p id="9f50"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd">For this,
+                    we thank you all. It is not possible without you and we can’t wait to share what is in store for the
+                    future!!</p>
+                </div>
+              </div>
+            </section>
+            <div class="n p gv jq jr js" role="separator"><span class="jt ha ib ju jv jw"></span><span
+                class="jt ha ib ju jv jw"></span><span class="jt ha ib ju jv"></span></div>
+            <section class="dl dm dn do dp">
+              <div class="n p">
+                <div class="ab ac ae af ag fd ai aj">
+                  <p id="d2ed"
+                    class="io ip fg iq b gf ir is it gi iu iv iw ix iy iz ja jb jc jd je jf jg jh ji jj dl gd"><em
+                      class="jl">No time to help contribute? Want to give back in other ways? </em><strong
+                      class="iq jk"><em class="jl">Become a Backer or Sponsor to webpack by donating to our
+                      </em></strong><a href="http://opencollective.com/webpack" class="ck ky"
+                      rel="noopener nofollow"><strong class="iq jk"><em class="jl">open
+                          collective</em></strong></a><strong class="iq jk"><em class="jl">.</em></strong><em
+                      class="jl"> Open Collective not only helps support the Core Team, but also supports contributors
+                      who have spent significant time improving our organization on their free time! ❤</em></p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </article>
+        <div class="em dk me ml aj mm u mj mn" data-test-id="post-sidebar">
+          <div class="n p">
+            <div class="ab ac ae af ag ah ai aj">
+              <div class="mo n mp">
+                <div class="dk">
+                  <div>
+                    <div class="mq mr s"><a
+                        href="/webpack?source=post_sidebar--------------------------post_sidebar-----------"
+                        class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">
+                        <h2 class="ce jz lq cg ff gd dl">webpack</h2>
+                      </a>
+                      <div class="ms mt s">
+                        <p class="ce b fc cg bk mu hh hi mv hk hl ch">The official Medium publication for the webpack
+                          open source…</p>
+                      </div>
+                      <div class="ib" aria-hidden="false" aria-describedby="collectionFollowPopover"
+                        aria-labelledby="collectionFollowPopover"><span><button
+                            class="ce b fc cg ho mw hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">
+                            <div class="n mx">Follow</div>
+                          </button></span></div>
+                    </div>
+                    <div class="my mz na n">
+                      <div class="n o">
+                        <div class="s ej nb nc nd ne nf"><span><a
+                              href="https://medium.com/m/signin?actionUrl=https%3A%2F%2Fmedium.com%2F_%2Fvote%2Fwebpack%2F15fd2dd8f07b&amp;operation=register&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_sidebar-----15fd2dd8f07b---------------------clap_sidebar-----------"
+                              class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">
+                              <div class="az ng nh ni nj nk nl nm r nn no"><svg width="29" height="29"
+                                  aria-label="clap">
+                                  <g fill-rule="evenodd">
+                                    <path
+                                      d="M13.74 1l.76 2.97.76-2.97zM16.82 4.78l1.84-2.56-1.43-.47zM10.38 2.22l1.84 2.56-.41-3.03zM22.38 22.62a5.11 5.11 0 0 1-3.16 1.61l.49-.45c2.88-2.89 3.45-5.98 1.69-9.21l-1.1-1.94-.96-2.02c-.31-.67-.23-1.18.25-1.55a.84.84 0 0 1 .66-.16c.34.05.66.28.88.6l2.85 5.02c1.18 1.97 1.38 5.12-1.6 8.1M9.1 22.1l-5.02-5.02a1 1 0 0 1 .7-1.7 1 1 0 0 1 .72.3l2.6 2.6a.44.44 0 0 0 .63-.62L6.1 15.04l-1.75-1.75a1 1 0 1 1 1.41-1.41l4.15 4.15a.44.44 0 0 0 .63 0 .44.44 0 0 0 0-.62L6.4 11.26l-1.18-1.18a1 1 0 0 1 0-1.4 1.02 1.02 0 0 1 1.41 0l1.18 1.16L11.96 14a.44.44 0 0 0 .62 0 .44.44 0 0 0 0-.63L8.43 9.22a.99.99 0 0 1-.3-.7.99.99 0 0 1 .3-.7 1 1 0 0 1 1.41 0l7 6.98a.44.44 0 0 0 .7-.5l-1.35-2.85c-.31-.68-.23-1.19.25-1.56a.85.85 0 0 1 .66-.16c.34.06.66.28.88.6L20.63 15c1.57 2.88 1.07 5.54-1.55 8.16a5.62 5.62 0 0 1-5.06 1.65 9.35 9.35 0 0 1-4.93-2.72zM13 6.98l2.56 2.56c-.5.6-.56 1.41-.15 2.28l.26.56-4.25-4.25a.98.98 0 0 1-.12-.45 1 1 0 0 1 .29-.7 1.02 1.02 0 0 1 1.41 0zm8.89 2.06c-.38-.56-.9-.92-1.49-1.01a1.74 1.74 0 0 0-1.34.33c-.38.29-.61.65-.71 1.06a2.1 2.1 0 0 0-1.1-.56 1.78 1.78 0 0 0-.99.13l-2.64-2.64a1.88 1.88 0 0 0-2.65 0 1.86 1.86 0 0 0-.48.85 1.89 1.89 0 0 0-2.67-.01 1.87 1.87 0 0 0-.5.9c-.76-.75-2-.75-2.7-.04a1.88 1.88 0 0 0 0 2.66c-.3.12-.61.29-.87.55a1.88 1.88 0 0 0 0 2.66l.62.62a1.88 1.88 0 0 0-.9 3.16l5.01 5.02c1.6 1.6 3.52 2.64 5.4 2.96a7.16 7.16 0 0 0 1.18.1c1.03 0 2-.25 2.9-.7A5.9 5.9 0 0 0 23 23.24c3.34-3.34 3.08-6.93 1.74-9.17l-2.87-5.04z">
+                                    </path>
+                                  </g>
+                                </svg></div>
+                            </a></span></div>
+                        <div class="s np nq nr ns nt nu nv">
+                          <div class="nw">
+                            <p class="ce b fc cg ch"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp">4K
+                                <!-- -->
+                              </button></p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="mz s"><button class="nj nh az">
+                        <div class="nz n o mx"><svg width="25" height="25" class="r" aria-label="responses">
+                            <path
+                              d="M19.07 21.12a6.33 6.33 0 0 1-3.53-1.1 7.8 7.8 0 0 1-.7-.52c-.77.21-1.57.32-2.38.32-4.67 0-8.46-3.5-8.46-7.8C4 7.7 7.79 4.2 12.46 4.2c4.66 0 8.46 3.5 8.46 7.8 0 2.06-.85 3.99-2.4 5.45a6.28 6.28 0 0 0 1.14 2.59c.15.21.17.48.06.7a.69.69 0 0 1-.62.38h-.03zm0-1v.5l.03-.5h-.03zm-3.92-1.64l.21.2a6.09 6.09 0 0 0 3.24 1.54 7.14 7.14 0 0 1-.83-1.84 5.15 5.15 0 0 1-.16-.75 2.4 2.4 0 0 1-.02-.29v-.23l.18-.15a6.6 6.6 0 0 0 2.3-4.96c0-3.82-3.4-6.93-7.6-6.93-4.19 0-7.6 3.11-7.6 6.93 0 3.83 3.41 6.94 7.6 6.94.83 0 1.64-.12 2.41-.35l.28-.08z"
+                              fill-rule="evenodd"></path>
+                          </svg>
+                          <div class="s ej oa ob oc od oe of og oh">
+                            <p class="ce b fc cg ch">51
+                              <!-- -->
+                            </p>
+                          </div>
+                        </div>
+                      </button></div>
+                    <div class="im"><span><a
+                          href="https://medium.com/m/signin?actionUrl=https%3A%2F%2Fmedium.com%2F_%2Fbookmark%2Fp%2F15fd2dd8f07b&amp;operation=register&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_sidebar-----15fd2dd8f07b---------------------bookmark_sidebar-----------"
+                          class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener"><svg width="25"
+                            height="25" viewBox="0 0 25 25">
+                            <path
+                              d="M19 6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v14.66h.01c.01.1.05.2.12.28a.5.5 0 0 0 .7.03l5.67-4.12 5.66 4.13a.5.5 0 0 0 .71-.03.5.5 0 0 0 .12-.29H19V6zm-6.84 9.97L7 19.64V6a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v13.64l-5.16-3.67a.49.49 0 0 0-.68 0z"
+                              fill-rule="evenodd"></path>
+                          </svg></a></span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="em dk md me mf mg mh mi mj mk"></div>
+        <div>
+          <div class="oi dq n mp p">
+            <div class="n p">
+              <div class="ab ac ae af ag fd ai aj">
+                <div class="n oj"></div>
+                <div class="n o oj"></div>
+                <div class="ok s">
+                  <ul class="az ba">
+                    <li class="ib bq in ol"><a href="https://medium.com/webpack/tagged/javascript"
+                        class="ce b cf om ch on oo ic s lp">JavaScript</a></li>
+                    <li class="ib bq in ol"><a href="https://medium.com/webpack/tagged/webpack"
+                        class="ce b cf om ch on oo ic s lp">Webpack</a></li>
+                    <li class="ib bq in ol"><a href="https://medium.com/webpack/tagged/tech"
+                        class="ce b cf om ch on oo ic s lp">Tech</a></li>
+                    <li class="ib bq in ol"><a href="https://medium.com/webpack/tagged/technology"
+                        class="ce b cf om ch on oo ic s lp">Technology</a></li>
+                    <li class="ib bq in ol"><a href="https://medium.com/webpack/tagged/web-development"
+                        class="ce b cf om ch on oo ic s lp">Web Development</a></li>
+                  </ul>
+                </div>
+                <div class="ok n gw z">
+                  <div class="n mx">
+                    <div class="op s"><span class="s oq or os e d">
+                        <div class="n o">
+                          <div class="s ej nb nc nd ne nf"><span><a
+                                href="https://medium.com/m/signin?actionUrl=https%3A%2F%2Fmedium.com%2F_%2Fvote%2Fwebpack%2F15fd2dd8f07b&amp;operation=register&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_actions_footer-----15fd2dd8f07b---------------------clap_footer-----------"
+                                class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">
+                                <div class="az ng nh ni nj nk nl nm r nn no"><svg width="25" height="25"
+                                    viewBox="0 0 25 25" aria-label="clap">
+                                    <g fill-rule="evenodd">
+                                      <path
+                                        d="M11.74 0l.76 2.97.76-2.97zM14.81 3.78l1.84-2.56-1.42-.47zM8.38 1.22l1.84 2.56L9.8.75zM20.38 21.62a5.11 5.11 0 0 1-3.16 1.61l.49-.45c2.88-2.89 3.45-5.98 1.69-9.21l-1.1-1.94-.96-2.02c-.31-.67-.23-1.18.25-1.55a.84.84 0 0 1 .66-.16c.34.05.66.28.88.6l2.85 5.02c1.18 1.97 1.38 5.12-1.6 8.1M7.1 21.1l-5.02-5.02a1 1 0 0 1 .7-1.7 1 1 0 0 1 .72.3l2.6 2.6a.44.44 0 0 0 .63-.62L4.1 14.04l-1.75-1.75a1 1 0 1 1 1.41-1.41l4.15 4.15a.44.44 0 0 0 .63 0 .44.44 0 0 0 0-.62L4.4 10.26 3.22 9.08a1 1 0 0 1 0-1.4 1.02 1.02 0 0 1 1.41 0l1.18 1.16L9.96 13a.44.44 0 0 0 .62 0 .44.44 0 0 0 0-.63L6.43 8.22a.99.99 0 0 1-.3-.7.99.99 0 0 1 .3-.7 1 1 0 0 1 1.41 0l7 6.98a.44.44 0 0 0 .7-.5l-1.35-2.85c-.31-.68-.23-1.19.25-1.56a.85.85 0 0 1 .66-.16c.34.06.66.28.88.6L18.63 14c1.57 2.88 1.07 5.54-1.55 8.16a5.62 5.62 0 0 1-5.06 1.65 9.35 9.35 0 0 1-4.93-2.72zM11 5.98l2.56 2.56c-.5.6-.56 1.41-.15 2.28l.26.56-4.25-4.25a.98.98 0 0 1-.12-.45 1 1 0 0 1 .29-.7 1.02 1.02 0 0 1 1.41 0zm8.89 2.06c-.38-.56-.9-.92-1.49-1.01a1.74 1.74 0 0 0-1.34.33c-.38.29-.61.65-.71 1.06a2.1 2.1 0 0 0-1.1-.56 1.78 1.78 0 0 0-.99.13l-2.64-2.64a1.88 1.88 0 0 0-2.65 0 1.86 1.86 0 0 0-.48.85 1.89 1.89 0 0 0-2.67-.01 1.87 1.87 0 0 0-.5.9c-.76-.75-2-.75-2.7-.04a1.88 1.88 0 0 0 0 2.66c-.3.12-.61.29-.87.55a1.88 1.88 0 0 0 0 2.66l.62.62a1.88 1.88 0 0 0-.9 3.16l5.01 5.02c1.6 1.6 3.52 2.64 5.4 2.96a7.16 7.16 0 0 0 1.18.1c1.03 0 2-.25 2.9-.7A5.9 5.9 0 0 0 21 22.24c3.34-3.34 3.08-6.93 1.74-9.17l-2.87-5.04z">
+                                      </path>
+                                    </g>
+                                  </svg></div>
+                              </a></span></div>
+                          <div class="s np nq nr ns nt nu nv">
+                            <div class="ej ot nw">
+                              <p class="ce b fc cg gd"><button
+                                  class="ck cl au av aw ax ay az ba bb cm cn be co cp">4K<span class="s h g f ou ov"> 
+                                    <!-- -->claps
+                                  </span></button><span class="s h g f ou ov"></span></p>
+                            </div>
+                          </div>
+                        </div>
+                      </span><span class="s h g f ou ov">
+                        <div class="n bu">
+                          <div class="s ej nb nc"><span><a
+                                href="https://medium.com/m/signin?actionUrl=https%3A%2F%2Fmedium.com%2F_%2Fvote%2Fwebpack%2F15fd2dd8f07b&amp;operation=register&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_actions_footer-----15fd2dd8f07b---------------------clap_footer-----------"
+                                class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">
+                                <div class="az ng nh ni nj nk nl nm r nn no"><svg width="33" height="33"
+                                    viewBox="0 0 33 33" aria-label="clap">
+                                    <path
+                                      d="M28.86 17.34l-3.64-6.4c-.3-.43-.71-.73-1.16-.8a1.12 1.12 0 0 0-.9.21c-.62.5-.73 1.18-.32 2.06l1.22 2.6 1.4 2.45c2.23 4.09 1.51 8-2.15 11.66a9.6 9.6 0 0 1-.8.71 6.53 6.53 0 0 0 4.3-2.1c3.82-3.82 3.57-7.87 2.05-10.39zm-6.25 11.08c3.35-3.35 4-6.78 1.98-10.47L21.2 12c-.3-.43-.71-.72-1.16-.8a1.12 1.12 0 0 0-.9.22c-.62.49-.74 1.18-.32 2.06l1.72 3.63a.5.5 0 0 1-.81.57l-8.91-8.9a1.33 1.33 0 0 0-1.89 1.88l5.3 5.3a.5.5 0 0 1-.71.7l-5.3-5.3-1.49-1.49c-.5-.5-1.38-.5-1.88 0a1.34 1.34 0 0 0 0 1.89l1.49 1.5 5.3 5.28a.5.5 0 0 1-.36.86.5.5 0 0 1-.36-.15l-5.29-5.29a1.34 1.34 0 0 0-1.88 0 1.34 1.34 0 0 0 0 1.89l2.23 2.23L9.3 21.4a.5.5 0 0 1-.36.85.5.5 0 0 1-.35-.14l-3.32-3.33a1.33 1.33 0 0 0-1.89 0 1.32 1.32 0 0 0-.39.95c0 .35.14.69.4.94l6.39 6.4c3.53 3.53 8.86 5.3 12.82 1.35zM12.73 9.26l5.68 5.68-.49-1.04c-.52-1.1-.43-2.13.22-2.89l-3.3-3.3a1.34 1.34 0 0 0-1.88 0 1.33 1.33 0 0 0-.4.94c0 .22.07.42.17.61zm14.79 19.18a7.46 7.46 0 0 1-6.41 2.31 7.92 7.92 0 0 1-3.67.9c-3.05 0-6.12-1.63-8.36-3.88l-6.4-6.4A2.31 2.31 0 0 1 2 19.72a2.33 2.33 0 0 1 1.92-2.3l-.87-.87a2.34 2.34 0 0 1 0-3.3 2.33 2.33 0 0 1 1.24-.64l-.14-.14a2.34 2.34 0 0 1 0-3.3 2.39 2.39 0 0 1 3.3 0l.14.14a2.33 2.33 0 0 1 3.95-1.24l.09.09c.09-.42.29-.83.62-1.16a2.34 2.34 0 0 1 3.3 0l3.38 3.39a2.17 2.17 0 0 1 1.27-.17c.54.08 1.03.35 1.45.76.1-.55.41-1.03.9-1.42a2.12 2.12 0 0 1 1.67-.4 2.8 2.8 0 0 1 1.85 1.25l3.65 6.43c1.7 2.83 2.03 7.37-2.2 11.6zM13.22.48l-1.92.89 2.37 2.83-.45-3.72zm8.48.88L19.78.5l-.44 3.7 2.36-2.84zM16.5 3.3L15.48 0h2.04L16.5 3.3z"
+                                      fill-rule="evenodd"></path>
+                                  </svg></div>
+                              </a></span></div>
+                          <div class="s np nq nr ns ow ox oy oz pa pb">
+                            <div class="ej ot nw">
+                              <p class="ce b fc cg gd"><button
+                                  class="ck cl au av aw ax ay az ba bb cm cn be co cp">4K<span class="s h g f ou ov"> 
+                                    <!-- -->claps
+                                  </span></button><span class="s h g f ou ov"></span></p>
+                            </div>
+                          </div>
+                        </div>
+                      </span></div>
+                    <div class="s pc pd pe pf pg"></div><button class="nj nh az">
+                      <div class="nz n o mx"><span class="ph s h g f ou ov"><svg width="33" height="33"
+                            viewBox="0 0 33 33" fill="none" class="r" aria-label="responses">
+                            <path clip-rule="evenodd"
+                              d="M24.28 25.5l.32-.29c2.11-1.94 3.4-4.61 3.4-7.56C28 11.83 22.92 7 16.5 7S5 11.83 5 17.65s5.08 10.66 11.5 10.66c1.22 0 2.4-.18 3.5-.5l.5-.15.41.33a8.86 8.86 0 0 0 4.68 2.1 7.34 7.34 0 0 1-1.3-4.15v-.43zm1 .45c0 1.5.46 2.62 1.69 4.44.22.32.01.75-.38.75a9.69 9.69 0 0 1-6.31-2.37c-1.2.35-2.46.54-3.78.54C9.6 29.3 4 24.09 4 17.65 4 11.22 9.6 6 16.5 6S29 11.22 29 17.65c0 3.25-1.42 6.18-3.72 8.3z">
+                            </path>
+                          </svg></span><span class="pi s oq or os e d"><svg width="25" height="25" class="r"
+                            aria-label="responses">
+                            <path
+                              d="M19.07 21.12a6.33 6.33 0 0 1-3.53-1.1 7.8 7.8 0 0 1-.7-.52c-.77.21-1.57.32-2.38.32-4.67 0-8.46-3.5-8.46-7.8C4 7.7 7.79 4.2 12.46 4.2c4.66 0 8.46 3.5 8.46 7.8 0 2.06-.85 3.99-2.4 5.45a6.28 6.28 0 0 0 1.14 2.59c.15.21.17.48.06.7a.69.69 0 0 1-.62.38h-.03zm0-1v.5l.03-.5h-.03zm-3.92-1.64l.21.2a6.09 6.09 0 0 0 3.24 1.54 7.14 7.14 0 0 1-.83-1.84 5.15 5.15 0 0 1-.16-.75 2.4 2.4 0 0 1-.02-.29v-.23l.18-.15a6.6 6.6 0 0 0 2.3-4.96c0-3.82-3.4-6.93-7.6-6.93-4.19 0-7.6 3.11-7.6 6.93 0 3.83 3.41 6.94 7.6 6.94.83 0 1.64-.12 2.41-.35l.28-.08z"
+                              fill-rule="evenodd"></path>
+                          </svg></span>
+                        <div class="s ej pj ob pk od pl of pm pn po pp">
+                          <p class="ce b fc cg gd">51
+                            <!-- --> <span class="s h g f ou ov">response
+                              <!-- -->s
+                            </span>
+                          </p>
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                  <div class="n o">
+                    <div class="il s ap"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                        aria-label="Share on twitter"><svg width="29" height="29" class="im">
+                          <path
+                            d="M22.05 7.54a4.47 4.47 0 0 0-3.3-1.46 4.53 4.53 0 0 0-4.53 4.53c0 .35.04.7.08 1.05A12.9 12.9 0 0 1 5 6.89a5.1 5.1 0 0 0-.65 2.26c.03 1.6.83 2.99 2.02 3.79a4.3 4.3 0 0 1-2.02-.57v.08a4.55 4.55 0 0 0 3.63 4.44c-.4.08-.8.13-1.21.16l-.81-.08a4.54 4.54 0 0 0 4.2 3.15 9.56 9.56 0 0 1-5.66 1.94l-1.05-.08c2 1.27 4.38 2.02 6.94 2.02 8.3 0 12.86-6.9 12.84-12.85.02-.24 0-.43 0-.65a8.68 8.68 0 0 0 2.26-2.34c-.82.38-1.7.62-2.6.72a4.37 4.37 0 0 0 1.95-2.51c-.84.53-1.81.9-2.83 1.13z">
+                          </path>
+                        </svg></button></div>
+                    <div class="il s ap"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                        aria-label="Share on linkedin"><svg width="29" height="29" viewBox="0 0 29 29" fill="none"
+                          class="im">
+                          <path
+                            d="M5 6.36C5 5.61 5.63 5 6.4 5h16.2c.77 0 1.4.61 1.4 1.36v16.28c0 .75-.63 1.36-1.4 1.36H6.4c-.77 0-1.4-.6-1.4-1.36V6.36z">
+                          </path>
+                          <path fill-rule="evenodd" clip-rule="evenodd"
+                            d="M10.76 20.9v-8.57H7.89v8.58h2.87zm-1.44-9.75c1 0 1.63-.65 1.63-1.48-.02-.84-.62-1.48-1.6-1.48-.99 0-1.63.64-1.63 1.48 0 .83.62 1.48 1.59 1.48h.01zM12.35 20.9h2.87v-4.79c0-.25.02-.5.1-.7.2-.5.67-1.04 1.46-1.04 1.04 0 1.46.8 1.46 1.95v4.59h2.87v-4.92c0-2.64-1.42-3.87-3.3-3.87-1.55 0-2.23.86-2.61 1.45h.02v-1.24h-2.87c.04.8 0 8.58 0 8.58z"
+                            fill="#fff"></path>
+                        </svg></button></div>
+                    <div class="il s ap"><button class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                        aria-label="Share on facebook"><svg width="29" height="29" class="im">
+                          <path
+                            d="M23.2 5H5.8a.8.8 0 0 0-.8.8V23.2c0 .44.35.8.8.8h9.3v-7.13h-2.38V13.9h2.38v-2.38c0-2.45 1.55-3.66 3.74-3.66 1.05 0 1.95.08 2.2.11v2.57h-1.5c-1.2 0-1.48.57-1.48 1.4v1.96h2.97l-.6 2.97h-2.37l.05 7.12h5.1a.8.8 0 0 0 .79-.8V5.8a.8.8 0 0 0-.8-.79">
+                          </path>
+                        </svg></button></div>
+                    <div class="pq s ap">
+                      <div class="im"><span><a
+                            href="https://medium.com/m/signin?actionUrl=https%3A%2F%2Fmedium.com%2F_%2Fbookmark%2Fp%2F15fd2dd8f07b&amp;operation=register&amp;redirect=https%3A%2F%2Fmedium.com%2Fwebpack%2Fwebpack-3-official-release-15fd2dd8f07b&amp;source=post_actions_footer--------------------------bookmark_footer-----------"
+                            class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener"><svg width="25"
+                              height="25" viewBox="0 0 25 25">
+                              <path
+                                d="M19 6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v14.66h.01c.01.1.05.2.12.28a.5.5 0 0 0 .7.03l5.67-4.12 5.66 4.13a.5.5 0 0 0 .71-.03.5.5 0 0 0 .12-.29H19V6zm-6.84 9.97L7 19.64V6a1 1 0 0 1 1-1h9a1 1 0 0 1 1 1v13.64l-5.16-3.67a.49.49 0 0 0-.68 0z"
+                                fill-rule="evenodd"></path>
+                            </svg></a></span></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <div class="n p">
+                <div class="ab ac ae af ag fd ai aj">
+                  <div class="pr bh ps ok s pt z">
+                    <div class="s g">
+                      <div class="pu pv s ej"><span class="s pw am px">
+                          <div class="s t py pz"><a rel="noopener"
+                              href="/@TheLarkInn?source=follow_footer-------------------------------------"><img
+                                alt="Sean T. Larkin" class="s ha bx qa"
+                                src="https://miro.medium.com/fit/c/160/160/1*AtcF5LLmMnXgwTpBMeos-w.jpeg" width="80"
+                                height="80" /></a></div><span class="s">
+                            <div class="qb s qc">
+                              <p class="ce b cf qd qe ch ci">Written by</p>
+                            </div>
+                            <div class="qb qf n qc">
+                              <div class="aj n o gw">
+                                <h2 class="ce jz qg qh ff gd"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                                    rel="noopener"
+                                    href="/@TheLarkInn?source=follow_footer-------------------------------------">Sean
+                                    T. Larkin</a></h2>
+                                <div class="s g"><span><button
+                                      class="ce b fc cg ho qi hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">Follow</button></span>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </span>
+                        <div class="qb qj s qc bi">
+                          <div class="qk s">
+                            <p class="ce b lq ql ch">@Webpack Core team &amp; AngularCLI team. Program Manager
+                              @Microsoft @EdgeDevTools. Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and
+                              Gardener!</p>
+                          </div>
+                          <div class="qm qn bi"><span><button
+                                class="ce b fc cg ho qi hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">Follow</button></span>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="pr s"></div>
+                      <div class="pu pv s ej"><span class="s pw am px">
+                          <div class="s t py pz"><a
+                              href="/webpack?source=follow_footer-------------------------------------"
+                              rel="noopener"><img alt="webpack" class="dd qa bx"
+                                src="https://miro.medium.com/fit/c/160/160/1*Wx82vEGrMfW4AdSLodZXgQ.png" width="80"
+                                height="80" /></a></div><span class="s">
+                            <div class="qb qf n qc">
+                              <div class="aj n o gw">
+                                <h2 class="ce jz qg qh ff gd"><a
+                                    href="/webpack?source=follow_footer-------------------------------------"
+                                    class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">webpack</a></h2>
+                                <div class="s g">
+                                  <div class="ib" aria-hidden="false" aria-describedby="collectionFollowPopover"
+                                    aria-labelledby="collectionFollowPopover"><span><button
+                                        class="ce b fc cg ho qi hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">
+                                        <div class="n mx">Follow</div>
+                                      </button></span></div>
+                                </div>
+                              </div>
+                            </div>
+                          </span>
+                        </span>
+                        <div class="qb qo s qc bi">
+                          <div class="qk s">
+                            <p class="ce b lq ql ch">The official Medium publication for the webpack open source
+                              project!</p>
+                          </div>
+                          <div class="qm qn bi">
+                            <div class="ib" aria-hidden="false" aria-describedby="collectionFollowPopover"
+                              aria-labelledby="collectionFollowPopover"><span><button
+                                  class="ce b fc cg ho qi hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">
+                                  <div class="n mx">Follow</div>
+                                </button></span></div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="qm bi">
+                      <div class="jr s">
+                        <div class="n mx">
+                          <div class="qp s"><a rel="noopener"
+                              href="/@TheLarkInn?source=follow_footer-------------------------------------"><img
+                                alt="Sean T. Larkin" class="s ha qq qr"
+                                src="https://miro.medium.com/fit/c/80/80/1*AtcF5LLmMnXgwTpBMeos-w.jpeg" width="40"
+                                height="40" /></a></div>
+                          <div class="hd s">
+                            <p class="ce b qs qt qu ch ci">Written by</p>
+                            <div class="n mx">
+                              <h2 class="ce jz lq cg ff gd"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp"
+                                  rel="noopener"
+                                  href="/@TheLarkInn?source=follow_footer-------------------------------------">Sean T.
+                                  Larkin</a></h2>
+                              <div class="hd s"><span><button
+                                    class="ce b cf cg ho hp hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">Follow</button></span>
+                              </div>
+                            </div>
+                            <div class="qv s">
+                              <p class="ce b fc cg ch">@Webpack Core team &amp; AngularCLI team. Program Manager
+                                @Microsoft @EdgeDevTools. Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and
+                                Gardener!</p>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="jr s">
+                          <div class="n mx"><a href="/webpack?source=follow_footer-------------------------------------"
+                              rel="noopener"><img alt="webpack" class="dd qr qq"
+                                src="https://miro.medium.com/fit/c/80/80/1*Wx82vEGrMfW4AdSLodZXgQ.png" width="40"
+                                height="40" /></a>
+                            <div class="hd s">
+                              <div class="n mx">
+                                <h2 class="ce jz lq cg ff gd"><a
+                                    href="/webpack?source=follow_footer-------------------------------------"
+                                    class="ck cl au av aw ax ay az ba bb cm cn be co cp" rel="noopener">webpack</a></h2>
+                                <div class="hd s">
+                                  <div class="ib" aria-hidden="false" aria-describedby="collectionFollowPopover"
+                                    aria-labelledby="collectionFollowPopover"><span><button
+                                        class="ce b cf cg ho hp hq hr hs ht hu bb hv hw hx hy dd hz ia da ib ic">
+                                        <div class="n mx">Follow</div>
+                                      </button></span></div>
+                                </div>
+                              </div>
+                              <div class="qv s">
+                                <p class="ce b fc cg ch">The official Medium publication for the webpack open source
+                                  project!</p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="s db z">
+                <div class="n p">
+                  <div class="ab ac ae af ag ah ai aj">
+                    <div class="qw qx s">
+                      <div class="qy mr qz qx s ra rb">
+                        <h2 class="ce jz la gh kc lc gk kf gl gn kj go gq kn gr gt kr gd">More From Medium</h2>
+                      </div>
+                      <div class="bu n mx oj rc rd re rf rg rh ri rj rk rl rm rn ro rp rq">
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a rel="noopener"
+                                        href="/webpack/better-tree-shaking-with-deep-scope-analysis-a0b788c0ce77?source=post_internal_links---------0----------------------------">Better
+                                        tree shaking with deep scope analysis</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://okcdz.medium.com/?source=post_internal_links---------0----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp"
+                                                  rel="noopener">Vincent Chan</a><span>
+                                                  <!-- -->in
+                                                  <!-- --> <a
+                                                    href="/webpack?source=post_internal_links---------0----------------------------"
+                                                    class="ck cl au av aw ax ay az ba bb hm be co cp"
+                                                    rel="noopener">webpack</a>
+                                                </span></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp s"
+                                    rel="noopener"
+                                    href="/webpack/better-tree-shaking-with-deep-scope-analysis-a0b788c0ce77?source=post_internal_links---------0----------------------------">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/1*LF_LYj06_VWwk-q6WEH0-w.png?q=20"
+                                            width="70" height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/1*LF_LYj06_VWwk-q6WEH0-w.png"
+                                            width="70" height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/1*LF_LYj06_VWwk-q6WEH0-w.png 48w, https://miro.medium.com/fit/c/140/140/1*LF_LYj06_VWwk-q6WEH0-w.png 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a rel="noopener"
+                                        href="/swlh/intro-to-recoil-d689a77c5f04?source=post_internal_links---------1----------------------------">Intro
+                                        to Recoil</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener"
+                                                  href="/@TRomesh?source=post_internal_links---------1----------------------------">Tharaka
+                                                  Romesh</a><span>
+                                                  <!-- -->in
+                                                  <!-- --> <a
+                                                    href="/swlh?source=post_internal_links---------1----------------------------"
+                                                    class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">The
+                                                    Startup</a>
+                                                </span></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp s"
+                                    rel="noopener"
+                                    href="/swlh/intro-to-recoil-d689a77c5f04?source=post_internal_links---------1----------------------------">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/1*wNaUljI2sG7HeDKQMJwqHQ.png?q=20"
+                                            width="70" height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/1*wNaUljI2sG7HeDKQMJwqHQ.png"
+                                            width="70" height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/1*wNaUljI2sG7HeDKQMJwqHQ.png 48w, https://miro.medium.com/fit/c/140/140/1*wNaUljI2sG7HeDKQMJwqHQ.png 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a rel="noopener"
+                                        href="/swlh/what-if-chrome-os-was-a-phone-operating-system-212d813b2798?source=post_internal_links---------2----------------------------">What
+                                        If Chrome OS Was a Phone Operating System?</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://omarzahran.medium.com/?source=post_internal_links---------2----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">Omar
+                                                  Zahran</a><span>
+                                                  <!-- -->in
+                                                  <!-- --> <a
+                                                    href="/swlh?source=post_internal_links---------2----------------------------"
+                                                    class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">The
+                                                    Startup</a>
+                                                </span></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp s"
+                                    rel="noopener"
+                                    href="/swlh/what-if-chrome-os-was-a-phone-operating-system-212d813b2798?source=post_internal_links---------2----------------------------">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/0*fvLeveZAwD-r-UXc?q=20" width="70"
+                                            height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/0*fvLeveZAwD-r-UXc" width="70"
+                                            height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/0*fvLeveZAwD-r-UXc 48w, https://miro.medium.com/fit/c/140/140/0*fvLeveZAwD-r-UXc 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a rel="noopener"
+                                        href="/the-guild/this-is-how-i-build-babel-plug-ins-b0a13dcd0352?source=post_internal_links---------3----------------------------">This
+                                        is how I build Babel plug-ins</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://eytanmanor.medium.com/?source=post_internal_links---------3----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">Eytan
+                                                  Manor</a><span>
+                                                  <!-- -->in
+                                                  <!-- --> <a
+                                                    href="/the-guild?source=post_internal_links---------3----------------------------"
+                                                    class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">The
+                                                    Guild</a>
+                                                </span></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp s"
+                                    rel="noopener"
+                                    href="/the-guild/this-is-how-i-build-babel-plug-ins-b0a13dcd0352?source=post_internal_links---------3----------------------------">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/1*cW9IvHMO5fBRNbjw2NW44Q.png?q=20"
+                                            width="70" height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/1*cW9IvHMO5fBRNbjw2NW44Q.png"
+                                            width="70" height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/1*cW9IvHMO5fBRNbjw2NW44Q.png 48w, https://miro.medium.com/fit/c/140/140/1*cW9IvHMO5fBRNbjw2NW44Q.png 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a
+                                        href="https://premeena.medium.com/webpack-react-optimised-from-scratch-da8f75024ba4?source=post_internal_links---------4----------------------------"
+                                        rel="noopener">Webpack + React Optimised from scratch</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://premeena.medium.com/?source=post_internal_links---------4----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp"
+                                                  rel="noopener">Shailesh Jha</a></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a
+                                    href="https://premeena.medium.com/webpack-react-optimised-from-scratch-da8f75024ba4?source=post_internal_links---------4----------------------------"
+                                    class="ck cl au av aw ax ay az ba bb cm cn be co cp s" rel="noopener">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/0*nBNPobrQPLNmVp_a?q=20" width="70"
+                                            height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/0*nBNPobrQPLNmVp_a" width="70"
+                                            height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/0*nBNPobrQPLNmVp_a 48w, https://miro.medium.com/fit/c/140/140/0*nBNPobrQPLNmVp_a 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a rel="noopener"
+                                        href="/dooboolab/how-to-update-relay-cache-d04ee074eb98?source=post_internal_links---------5----------------------------">How
+                                        to Update Relay Cache</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://0916dhkim.medium.com/?source=post_internal_links---------5----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp"
+                                                  rel="noopener">Donghyeon Kim</a><span>
+                                                  <!-- -->in
+                                                  <!-- --> <a
+                                                    href="/dooboolab?source=post_internal_links---------5----------------------------"
+                                                    class="ck cl au av aw ax ay az ba bb hm be co cp"
+                                                    rel="noopener">dooboolab</a>
+                                                </span></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a class="ck cl au av aw ax ay az ba bb cm cn be co cp s"
+                                    rel="noopener"
+                                    href="/dooboolab/how-to-update-relay-cache-d04ee074eb98?source=post_internal_links---------5----------------------------">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/0*R7W2uXa4tMUvJrqS?q=20" width="70"
+                                            height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/0*R7W2uXa4tMUvJrqS" width="70"
+                                            height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/0*R7W2uXa4tMUvJrqS 48w, https://miro.medium.com/fit/c/140/140/0*R7W2uXa4tMUvJrqS 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a
+                                        href="https://toastui.medium.com/improving-the-reactivity-system-feat-toast-ui-grid-26ffc025864d?source=post_internal_links---------6----------------------------"
+                                        rel="noopener">Improving the Reactivity System (feat. TOAST UI Grid)</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://toastui.medium.com/?source=post_internal_links---------6----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">TOAST
+                                                  UI</a></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a
+                                    href="https://toastui.medium.com/improving-the-reactivity-system-feat-toast-ui-grid-26ffc025864d?source=post_internal_links---------6----------------------------"
+                                    class="ck cl au av aw ax ay az ba bb cm cn be co cp s" rel="noopener">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/max/60/1*9p8FLpoYHEOc_8bdG0J08A.png?q=20"
+                                            width="70" height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/1*9p8FLpoYHEOc_8bdG0J08A.png"
+                                            width="70" height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/1*9p8FLpoYHEOc_8bdG0J08A.png 48w, https://miro.medium.com/fit/c/140/140/1*9p8FLpoYHEOc_8bdG0J08A.png 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="rr rs rt ds ru rv rw du rx ry rz sa sb sc sd se sf sg sh si sj">
+                          <div class="sk sl s">
+                            <div class="aj eo">
+                              <div class="n gw">
+                                <div class="s bp sm sn so">
+                                  <div class="sp s">
+                                    <h2 class="ce jz sq sr kc ss st kf su sv kj sw sx kn sy sz kr gd"><a
+                                        href="https://levelup.gitconnected.com/understanding-micro-frontends-webpack5-configurations-step-by-step-4dd2f7d81dcb?source=post_internal_links---------7----------------------------"
+                                        rel="noopener nofollow">Understanding Micro-Frontends Webpack 5 Configurations
+                                        Step by Step</a></h2>
+                                  </div>
+                                  <div class="o n">
+                                    <div></div>
+                                    <div class="aj s">
+                                      <div class="n">
+                                        <div style="flex:1"><span class="ce b fc cg gd">
+                                            <div class="cq n o hf"><span class="ce b cf cg gd"><a
+                                                  href="https://ranyel.medium.com/?source=post_internal_links---------7----------------------------"
+                                                  class="ck cl au av aw ax ay az ba bb hm be co cp" rel="noopener">Rany
+                                                  ElHousieny</a><span>
+                                                  <!-- -->in
+                                                  <!-- --> <a
+                                                    href="https://levelup.gitconnected.com/?source=post_internal_links---------7----------------------------"
+                                                    class="ck cl au av aw ax ay az ba bb hm be co cp"
+                                                    rel="noopener nofollow">Level Up Coding</a>
+                                                </span></span></div>
+                                          </span></div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                                <div class="hd in s ta tb"><a
+                                    href="https://levelup.gitconnected.com/understanding-micro-frontends-webpack5-configurations-step-by-step-4dd2f7d81dcb?source=post_internal_links---------7----------------------------"
+                                    class="ck cl au av aw ax ay az ba bb cm cn be co cp s" rel="noopener nofollow">
+                                    <div class="er s ej es">
+                                      <div class="tc eu s">
+                                        <div class="em en t u v eo aj bk ep eq"><img class="t u v eo aj ev ew ex"
+                                            src="https://miro.medium.com/freeze/max/60/1*6js53mDPNElWcqe_NTDOIQ.gif?q=20"
+                                            width="70" height="70" role="presentation" /></div><img
+                                          class="em en td te tf tg th ti tj tk tl tm c" width="70" height="70"
+                                          role="presentation" /><noscript><img class="td te tf tg th ti tj tk tl tm"
+                                            src="https://miro.medium.com/fit/c/140/140/1*6js53mDPNElWcqe_NTDOIQ.gif"
+                                            width="70" height="70"
+                                            srcSet="https://miro.medium.com/fit/c/96/140/1*6js53mDPNElWcqe_NTDOIQ.gif 48w, https://miro.medium.com/fit/c/140/140/1*6js53mDPNElWcqe_NTDOIQ.gif 70w"
+                                            sizes="70px" role="presentation" /></noscript>
+                                      </div>
+                                    </div>
+                                  </a></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="tn s to tp">
+          <div class="n p">
+            <div class="ab ac ae af ag ah ai aj">
+              <div class="tq tr pu n gw g">
+                <div class="ts n gw">
+                  <div class="tt s tu">
+                    <div class="sp s"><a
+                        href="https://medium.com/about?autoplay=1&amp;source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb tv tw be tx ty" rel="noopener">
+                        <h2 class="ce jz tz ql ff ua">Learn more.</h2>
+                      </a></div>
+                    <p class="ce b fc cg ub">Medium
+                      <!-- --> is an open platform where 170 million readers come to find insightful and dynamic
+                      thinking. Here, expert and undiscovered voices alike dive into the heart of any topic and bring
+                      new ideas to the surface.
+                      <!-- --> <a
+                        href="https://medium.com/about?autoplay=1&amp;source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb be tx ty ky" rel="noopener">Learn more</a>
+                    </p>
+                  </div>
+                  <div class="tt s tu">
+                    <div class="sp s"><a
+                        href="https://medium.com/topics?source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb tv tw be tx ty" rel="noopener">
+                        <h2 class="ce jz tz ql ff ua">Make
+                          <!-- -->Medium
+                          <!-- --> yours.
+                        </h2>
+                      </a></div>
+                    <p class="ce b fc cg ub">Follow the writers, publications, and topics that matter to you, and you’ll
+                      see them on your homepage and in your inbox.
+                      <!-- --> <a
+                        href="https://medium.com/topics?source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb be tx ty ky" rel="noopener">Explore</a>
+                    </p>
+                  </div>
+                  <div class="tt s tu">
+                    <div class="sp s"><a
+                        href="https://about.medium.com/creators/?source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb tv tw be tx ty" rel="noopener">
+                        <h2 class="ce jz tz ql ff ua">Share your thinking.</h2>
+                      </a></div>
+                    <p class="ce b fc cg ub">If you have a story to tell, knowledge to share, or a perspective to offer
+                      — welcome home. It’s easy and free to post your thinking on any topic.
+                      <!-- --> <a
+                        href="https://about.medium.com/creators/?source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb be tx ty ky" rel="noopener">Write on
+                        <!-- -->Medium
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div class="n mp">
+                <div class="n o gw"><a class="ck cl au av aw ax ay az ba bb tv tw be tx ty" rel="noopener"
+                    href="/?source=post_page-----15fd2dd8f07b--------------------------------"><svg
+                      viewBox="0 0 3940 610" class="hq uc">
+                      <path
+                        d="M594.79 308.2c0 163.76-131.85 296.52-294.5 296.52S5.8 472 5.8 308.2 137.65 11.69 300.29 11.69s294.5 132.75 294.5 296.51M917.86 308.2c0 154.16-65.93 279.12-147.25 279.12s-147.25-125-147.25-279.12S689.29 29.08 770.61 29.08s147.25 125 147.25 279.12M1050 308.2c0 138.12-23.19 250.08-51.79 250.08s-51.79-112-51.79-250.08 23.19-250.08 51.8-250.08S1050 170.09 1050 308.2M1862.77 37.4l.82-.18v-6.35h-167.48l-155.51 365.5-155.51-365.5h-180.48v6.35l.81.18c30.57 6.9 46.09 17.19 46.09 54.3v434.45c0 37.11-15.58 47.4-46.15 54.3l-.81.18V587H1327v-6.35l-.81-.18c-30.57-6.9-46.09-17.19-46.09-54.3V116.9L1479.87 587h11.33l205.59-483.21V536.9c-2.62 29.31-18 38.36-45.68 44.61l-.82.19v6.3h213.3v-6.3l-.82-.19c-27.71-6.25-43.46-15.3-46.08-44.61l-.14-445.2h.14c0-37.11 15.52-47.4 46.08-54.3m97.43 287.8c3.49-78.06 31.52-134.4 78.56-135.37 14.51.24 26.68 5 36.14 14.16 20.1 19.51 29.55 60.28 28.09 121.21zm-2.11 22h250v-1.05c-.71-59.69-18-106.12-51.34-138-28.82-27.55-71.49-42.71-116.31-42.71h-1c-23.26 0-51.79 5.64-72.09 15.86-23.11 10.7-43.49 26.7-60.45 47.7-27.3 33.83-43.84 79.55-47.86 130.93-.13 1.54-.24 3.08-.35 4.62s-.18 2.92-.25 4.39a332.64 332.64 0 0 0-.36 21.69C1860.79 507 1923.65 600 2035.3 600c98 0 155.07-71.64 169.3-167.8l-7.19-2.53c-25 51.68-69.9 83-121 79.18-69.76-5.22-123.2-75.95-118.35-161.63m532.69 157.68c-8.2 19.45-25.31 30.15-48.24 30.15s-43.89-15.74-58.78-44.34c-16-30.7-24.42-74.1-24.42-125.51 0-107 33.28-176.21 84.79-176.21 21.57 0 38.55 10.7 46.65 29.37zm165.84 76.28c-30.57-7.23-46.09-18-46.09-57V5.28L2424.77 60v6.7l1.14-.09c25.62-2.07 43 1.47 53.09 10.79 7.9 7.3 11.75 18.5 11.75 34.26v71.14c-18.31-11.69-40.09-17.38-66.52-17.38-53.6 0-102.59 22.57-137.92 63.56-36.83 42.72-56.3 101.1-56.3 168.81C2230 518.72 2289.53 600 2378.13 600c51.83 0 93.53-28.4 112.62-76.3V588h166.65v-6.66zm159.29-505.33c0-37.76-28.47-66.24-66.24-66.24-37.59 0-67 29.1-67 66.24s29.44 66.24 67 66.24c37.77 0 66.24-28.48 66.24-66.24m43.84 505.33c-30.57-7.23-46.09-18-46.09-57h-.13V166.65l-166.66 47.85v6.5l1 .09c36.06 3.21 45.93 15.63 45.93 57.77V588h166.8v-6.66zm427.05 0c-30.57-7.23-46.09-18-46.09-57V166.65L3082 212.92v6.52l.94.1c29.48 3.1 38 16.23 38 58.56v226c-9.83 19.45-28.27 31-50.61 31.78-36.23 0-56.18-24.47-56.18-68.9V166.66l-166.66 47.85V221l1 .09c36.06 3.2 45.94 15.62 45.94 57.77v191.27a214.48 214.48 0 0 0 3.47 39.82l3 13.05c14.11 50.56 51.08 77 109 77 49.06 0 92.06-30.37 111-77.89v66h166.66v-6.66zM3934.2 588v-6.67l-.81-.19c-33.17-7.65-46.09-22.07-46.09-51.43v-243.2c0-75.83-42.59-121.09-113.93-121.09-52 0-95.85 30.05-112.73 76.86-13.41-49.6-52-76.86-109.06-76.86-50.12 0-89.4 26.45-106.25 71.13v-69.87l-166.66 45.89v6.54l1 .09c35.63 3.16 45.93 15.94 45.93 57V588h155.5v-6.66l-.82-.2c-26.46-6.22-35-17.56-35-46.66V255.72c7-16.35 21.11-35.72 49-35.72 34.64 0 52.2 24 52.2 71.28V588h155.54v-6.66l-.82-.2c-26.46-6.22-35-17.56-35-46.66v-248a160.45 160.45 0 0 0-2.2-27.68c7.42-17.77 22.34-38.8 51.37-38.8 35.13 0 52.2 23.31 52.2 71.28V588z">
+                      </path>
+                    </svg></a>
+                  <div class="qv ud n gw ue am">
+                    <p class="ce b lq ql ua"><a
+                        href="https://medium.com/about?autoplay=1&amp;source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb hm be tx ty" rel="noopener">About</a></p>
+                    <p class="ce b lq ql ua"><a
+                        href="https://help.medium.com/hc/en-us?source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb hm be tx ty" rel="noopener">Help</a></p>
+                    <p class="ce b lq ql ua"><a
+                        href="https://policy.medium.com/medium-terms-of-service-9db0094a1e0f?source=post_page-----15fd2dd8f07b--------------------------------"
+                        class="ck cl au av aw ax ay az ba bb hm be tx ty" rel="noopener">Legal</a></p>
+                  </div>
+                </div>
+                <div class="qm uf ug am">
+                  <p class="ce b lq ql ub">Get the Medium app</p>
+                </div>
+                <div class="qm uf uh am ui">
+                  <div class="uj s"><a
+                      href="https://itunes.apple.com/app/medium-everyones-stories/id828256236?pt=698524&amp;mt=8&amp;ct=post_page&amp;source=post_page-----15fd2dd8f07b--------------------------------"
+                      class="ck cl au av aw ax ay az ba bb tv tw be tx ty" rel="noopener nofollow"><img
+                        alt="A button that says &#x27;Download on the App Store&#x27;, and if clicked it will lead you to the iOS App store"
+                        class="" src="https://miro.medium.com/max/270/1*Crl55Tm6yDNMoucPo1tvDg.png" width="135"
+                        height="41" /></a></div>
+                  <div class="s"><a
+                      href="https://play.google.com/store/apps/details?id=com.medium.reader&amp;source=post_page-----15fd2dd8f07b--------------------------------"
+                      class="ck cl au av aw ax ay az ba bb tv tw be tx ty" rel="noopener nofollow"><img
+                        alt="A button that says &#x27;Get it on, Google Play&#x27;, and if clicked it will lead you to the Google Play store"
+                        class="" src="https://miro.medium.com/max/270/1*W_RAPQ62h0em559zluJLdQ.png" width="135"
+                        height="41" /></a></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script>window.__BUILD_ID__ = "main-20210305-183757-c310e81f10"</script>
+  <script>window.__GRAPHQL_URI__ = "https://medium.com/_/graphql"</script>
+  <script>window.__PRELOADED_STATE__ = { "auroraPage": { "isAuroraPageEnabled": false }, "bookReader": { "assets": {}, "reader": { "currentAsset": null, "settingsPanelIsOpen": false, "settings": { "fontFamily": "FELL", "fontScale": "M", "publisherStyling": true, "textAlignment": "START", "theme": "White", "lineSpacing": 0, "wordSpacing": 0, "letterSpacing": 0 }, "internalNavCounter": 0 } }, "cache": { "experimentGroupSet": true, "group": "control", "tags": [], "serverVariantState": "" }, "client": { "isUs": false, "isNativeMedium": false, "isSafariMobile": false, "isSafari": false, "routingEntity": { "type": "DEFAULT", "explicit": false }, "supportsWebp": false }, "config": { "nodeEnv": "production", "version": "main-20210305-183757-c310e81f10", "isTaggedVersion": false, "target": "production", "productName": "Medium", "publicUrl": "https:\u002F\u002Fcdn-client.medium.com\u002Flite", "authDomain": "medium.com", "authGoogleClientId": "216296035834-k1k6qe060s2tp2a2jam4ljdcms00sttg.apps.googleusercontent.com", "favicon": "production", "glyphUrl": "https:\u002F\u002Fglyph.medium.com", "branchKey": "key_live_ofxXr2qTrrU9NqURK8ZwEhknBxiI6KBm", "lightStep": { "name": "lite-web", "host": "lightstep.medium.systems", "token": "ce5be895bef60919541332990ac9fef2", "appVersion": "main-20210305-183757-c310e81f10" }, "algolia": { "appId": "MQ57UUUQZ2", "apiKeySearch": "394474ced050e3911ae2249ecc774921", "indexPrefix": "medium_", "host": "-dsn.algolia.net" }, "recaptchaKey": "6Lfc37IUAAAAAKGGtC6rLS13R1Hrw_BqADfS1LRk", "recaptcha3Key": "6Lf8R9wUAAAAABMI_85Wb8melS7Zj6ziuf99Yot5", "datadog": { "clientToken": "pub853ea8d17ad6821d9f8f11861d23dfed", "context": { "deployment": { "target": "production", "tag": "main-20210305-183757-c310e81f10", "commit": "c310e81f1083a2494066966a3d5a2eb55e2d87ae" } }, "datacenter": "us" }, "isAmp": false, "googleAnalyticsCode": "UA-24232453-2", "signInWallCustomDomainCollectionIds": ["3a8144eabfe3", "336d898217ee", "61061eb0c96b", "138adf9c44c", "819cc2aaeee0"], "mediumOwnedAndOperatedCollectionIds": ["544c7006046e", "bcc38c8f6edf", "444d13b52878", "8d6b8a439e32", "92d2092dc598", "1285ba81cada", "cb8577c9149e", "8ccfed20cbb2", "ae2a65f35510", "3f6ecf56618", "7b6769f2748b", "fc8964313712", "ef8e90590e66", "191186aaafa0", "d944778ce714", "bdc4052bbdba", "88d9857e584e", "9dc80918cc93", "8a9336e5bb4", "cef6983b292", "54c98c43354d", "193b68bd4fba", "b7e45b22fec3", "55760f21cdc5"], "tierOneDomains": ["medium.com", "thebolditalic.com", "arcdigital.media", "towardsdatascience.com", "uxdesign.cc", "codeburst.io", "psiloveyou.xyz", "writingcooperative.com", "entrepreneurshandbook.co", "prototypr.io", "betterhumans.coach.me", "theascent.pub"], "topicsToFollow": ["d61cf867d93f", "8a146bc21b28", "1eca0103fff3", "4d562ee63426", "aef1078a3ef5", "e15e46793f8d", "6158eb913466", "55f1c20aba7a", "3d18b94f6858", "4861fee224fd", "63c6f1f93ee", "1d98b3a9a871", "decb52b64abf", "ae5d4995e225", "830cded25262"], "defaultImages": { "avatar": { "imageId": "1*dmbNkD5D-u45r44go_cf0g.png", "height": 150, "width": 150 }, "orgLogo": { "imageId": "1*OMF3fSqH8t4xBJ9-6oZDZw.png", "height": 106, "width": 545 }, "postLogo": { "imageId": "1*kFrc4tBFM_tCis-2Ic87WA.png", "height": 810, "width": 1440 }, "postPreviewImage": { "imageId": "1*hn4v1tCaJy7cWMyb0bpNpQ.png", "height": 386, "width": 579 } }, "performanceTags": [], "collectionStructuredData": { "8d6b8a439e32": { "name": "Elemental", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fcdn-images-1.medium.com\u002Fmax\u002F980\u002F1*9ygdqoKprhwuTVKUM0DLPA@2x.png", "width": 980, "height": 159 } } }, "3f6ecf56618": { "name": "Forge", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fcdn-images-1.medium.com\u002Fmax\u002F596\u002F1*uULpIlImcO5TDuBZ6lm7Lg@2x.png", "width": 596, "height": 183 } } }, "ae2a65f35510": { "name": "GEN", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fmiro.medium.com\u002Fmax\u002F264\u002F1*RdVZMdvfV3YiZTw6mX7yWA.png", "width": 264, "height": 140 } } }, "88d9857e584e": { "name": "LEVEL", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fmiro.medium.com\u002Fmax\u002F540\u002F1*JqYMhNX6KNNb2UlqGqO2WQ.png", "width": 540, "height": 108 } } }, "7b6769f2748b": { "name": "Marker", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fcdn-images-1.medium.com\u002Fmax\u002F383\u002F1*haCUs0wF6TgOOvfoY-jEoQ@2x.png", "width": 383, "height": 92 } } }, "444d13b52878": { "name": "OneZero", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fmiro.medium.com\u002Fmax\u002F540\u002F1*cw32fIqCbRWzwJaoQw6BUg.png", "width": 540, "height": 123 } } }, "8ccfed20cbb2": { "name": "Zora", "data": { "@type": "NewsMediaOrganization", "ethicsPolicy": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Farticles\u002F360043290473", "logo": { "@type": "ImageObject", "url": "https:\u002F\u002Fmiro.medium.com\u002Fmax\u002F540\u002F1*tZUQqRcCCZDXjjiZ4bDvgQ.png", "width": 540, "height": 106 } } } }, "embeddedPostIds": { "coronavirus": "cd3010f9d81f" }, "sharedCdcMessaging": { "COVID_APPLICABLE_TAG_SLUGS": [], "COVID_APPLICABLE_TOPIC_NAMES": [], "COVID_APPLICABLE_TOPIC_NAMES_FOR_TOPIC_PAGE": [], "COVID_MESSAGES": { "tierA": { "text": "For more information on the novel coronavirus and Covid-19, visit cdc.gov.", "markups": [{ "start": 66, "end": 73, "href": "https:\u002F\u002Fwww.cdc.gov\u002Fcoronavirus\u002F2019-nCoV" }] }, "tierB": { "text": "Anyone can publish on Medium per our Policies, but we don’t fact-check every story. For more info about the coronavirus, see cdc.gov.", "markups": [{ "start": 37, "end": 45, "href": "https:\u002F\u002Fhelp.medium.com\u002Fhc\u002Fen-us\u002Fcategories\u002F201931128-Policies-Safety" }, { "start": 125, "end": 132, "href": "https:\u002F\u002Fwww.cdc.gov\u002Fcoronavirus\u002F2019-nCoV" }] }, "paywall": { "text": "This article has been made free for everyone, thanks to Medium Members. For more information on the novel coronavirus and Covid-19, visit cdc.gov.", "markups": [{ "start": 56, "end": 70, "href": "https:\u002F\u002Fmedium.com\u002Fmembership" }, { "start": 138, "end": 145, "href": "https:\u002F\u002Fwww.cdc.gov\u002Fcoronavirus\u002F2019-nCoV" }] }, "unbound": { "text": "This article is free for everyone, thanks to Medium Members. For more information on the novel coronavirus and Covid-19, visit cdc.gov.", "markups": [{ "start": 45, "end": 59, "href": "https:\u002F\u002Fmedium.com\u002Fmembership" }, { "start": 127, "end": 134, "href": "https:\u002F\u002Fwww.cdc.gov\u002Fcoronavirus\u002F2019-nCoV" }] } }, "COVID_BANNER_POST_ID_OVERRIDE_WHITELIST": ["3b31a67bff4a"] }, "sharedVoteMessaging": { "TAGS": ["politics", "election-2020", "government", "us-politics", "election", "2020-presidential-race", "trump", "donald-trump", "democrats", "republicans", "congress", "republican-party", "democratic-party", "biden", "joe-biden", "maga"], "TOPICS": ["politics", "election"], "MESSAGE": { "text": "Find out more about the U.S. election results here.", "markups": [{ "start": 46, "end": 50, "href": "https:\u002F\u002Fcookpolitical.com\u002F2020-national-popular-vote-tracker" }] }, "EXCLUDE_POSTS": ["397ef29e3ca5"] }, "embedPostRules": [], "recircOptions": { "v1": { "limit": 3 }, "v2": { "limit": 8 } }, "braintreeClientKey": "production_zjkj96jm_m56f8fqpf7ngnrd4", "paypalClientId": "AXj1G4fotC2GE8KzWX9mSxCH1wmPE3nJglf4Z2ig_amnhvlMVX87otaq58niAg9iuLktVNF_1WCMnN7v", "stripePublishableKey": "pk_live_7FReX44VnNIInZwrIIx6ghjl", "errorTracking": "none" }, "debug": { "requestId": "c8480dfc-20f5-4dba-896d-3e7d67c5bf42", "branchDeployConfig": null, "originalSpanCarrier": { "ot-tracer-spanid": "315a56c039ddc84c", "ot-tracer-traceid": "340f33c73b648faf", "ot-tracer-sampled": "true" } }, "multiVote": { "clapsPerPost": {} }, "navigation": { "branch": { "show": null, "hasRendered": null, "blockedByCTA": false }, "hideGoogleOneTap": false, "hasRenderedGoogleOneTap": null, "hasRenderedAlternateUserBanner": null, "currentLocation": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fwebpack-3-official-release-15fd2dd8f07b", "host": "medium.com", "hostname": "medium.com", "referrer": "", "susiModal": { "step": null, "operation": "register" }, "postRead": false, "responsesOpen": false }, "session": { "user": { "id": "lo_54464edd69c3" }, "xsrf": "", "isSpoofed": false }, "tracing": {} }</script>
+  <script>window.__APOLLO_STATE__ = { "ROOT_QUERY": { "__typename": "Query", "viewer": null, "variantFlags": [{ "__typename": "VariantFlag", "name": "allow_access", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "allow_signup", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "allow_test_auth", "valueType": { "__typename": "VariantFlagString", "value": "disallow" } }, { "__typename": "VariantFlag", "name": "android_enable_lock_responses", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "assign_default_topic_to_posts", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "available_annual_plan", "valueType": { "__typename": "VariantFlagString", "value": "2c754bcc2995" } }, { "__typename": "VariantFlag", "name": "available_monthly_plan", "valueType": { "__typename": "VariantFlagString", "value": "60e220181034" } }, { "__typename": "VariantFlag", "name": "bane_add_user", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "bane_verify_domain", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "branch_seo_metadata", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "browsable_stream_config_bucket", "valueType": { "__typename": "VariantFlagString", "value": "curated-topics" } }, { "__typename": "VariantFlag", "name": "coronavirus_topic_recirc", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "covid_19_cdc_banner", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "default_seo_post_titles", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "disable_android_subscription_activity_carousel", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "disable_ios_resume_reading_toast", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "disable_ios_subscription_activity_carousel", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "disable_mobile_featured_chunk", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "disable_post_recommended_from_friends_provider", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_android_local_currency", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_annual_renewal_reminder_email", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_app_flirty_thirty", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_apple_parse_expires_at", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_apple_sign_in", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_apple_webhook", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_apple_webhook_renewal_failure", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_about_page_routing", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_general_admission", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_nav", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_profile_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_pub_follower_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_recirc", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_sticky_nav", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_aurora_tag_page_routing", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_author_autotier", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_author_cards", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_author_cards_byline", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_automated_mission_control_triggers", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_braintree_apple_pay", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_braintree_client", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_braintree_integration", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_braintree_paypal", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_braintree_trial_membership", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_braintree_webhook", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_branch_io", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_branch_text_me_the_app", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_branding", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_branding_fonts", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_cleansweep_double_writes", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_client_error_tracking", "valueType": { "__typename": "VariantFlagString", "value": "none" } }, { "__typename": "VariantFlag", "name": "enable_confirm_sign_in", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_cta_meter", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_curation_priority_queue_experiment", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_custom_domain_v2_settings", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_dedicated_series_tab_api_ios", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_digest_feature_logging", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_digest_tagline", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_earn_redirect", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_edit_alt_text", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_email_sign_in_captcha", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_embedding_based_diversification", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_end_of_post_cleanup", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_evhead_com_to_ev_medium_com_redirect", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_expanded_feature_chunk_pool", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_filter_by_resend_rules", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_filter_expire_processor", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_footer_app_buttons", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_fyf_authors_and_collections", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_fyf_rex_sourcing", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_global_susi_modal", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_google_one_tap", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_google_webhook", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_google_webhook_subscription_cancelled", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_highlander_member_digest", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_hightower_user_minimum_guarantee", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_homepage_who_to_follow_module", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_homepage_write_button", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_ios_post_stats", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_json_logs_trained_ranker", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_kbfd_rex", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_kbfd_rex_app_highlights", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_homepage", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_homepage_feed", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_notifications", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_pay_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_post", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_post_cd", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_pub_homepage_for_selected_domains", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_publish_to_profile", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_server_upstream_deadlines", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_stories", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_threaded_responses", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_topics", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lite_unread_notification_count_mutation", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_lock_responses", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_login_code_flow", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_marketing_emails", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_media_resource_try_catch", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_medium2_kbfd", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_membership_remove_section_a", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_miro_on_kubernetes", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_mission_control", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_ml_rank_modules", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_ml_rank_rex_anno", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_mute", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_new_checkout_flow", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_new_collaborative_filtering_data", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_new_login_flow", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_new_three_dot_menu", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_parsely", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_patronus_on_kubernetes", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_popularity_feature", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_post_import", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_post_page_nav_stickiness_removal", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_post_settings_screen", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_primary_topic_for_mobile", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_profile_design_reminder", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_profile_page_seo_titles", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_publish_to_email_for_publication_posts", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_receipt_notes", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_responses_2", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_responses_all", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_responses_edit_and_delete", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_responses_moderation", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_rex_follow_feed_cache", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_rito_upstream_deadlines", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_rtr_channel", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_s3_sites", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_save_to_medium", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_signup_friction", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_starspace", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_starspace_ranker_starspace", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_stripegate", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_tick_landing_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_tipalti_onboarding", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_trending_posts_diversification", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_tribute_landing_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_triton_predictions", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_trumpland_landing_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_twitter_auth_suggestions", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_unfiltered_cf", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "enable_untruncated_author_post_as_email", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "glyph_font_set", "valueType": { "__typename": "VariantFlagString", "value": "m2-unbound" } }, { "__typename": "VariantFlag", "name": "google_sign_in_android", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "ios_enable_generic_home_modules", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "ios_enable_home_post_menu", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "ios_enable_iceland_paywall", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "ios_enable_lock_responses", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "ios_iceland_nux", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "ios_pub_follow_email_opt_in", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "is_not_medium_subscriber", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "kill_fastrak", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "kill_stripe_express", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "limit_post_referrers", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "limit_user_follows", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "make_nav_sticky", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "new_transition_page", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "provider_for_credit_card_form", "valueType": { "__typename": "VariantFlagString", "value": "BRAINTREE" } }, { "__typename": "VariantFlag", "name": "pub_sidebar", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "redefine_average_post_reading_time", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "remove_post_post_similarity", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "retrained_ranker", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "sign_up_with_email_button", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "signin_services", "valueType": { "__typename": "VariantFlagString", "value": "twitter,facebook,google,email,google-fastidv,google-one-tap,apple" } }, { "__typename": "VariantFlag", "name": "signup_services", "valueType": { "__typename": "VariantFlagString", "value": "twitter,facebook,google,email,google-fastidv,google-one-tap,apple" } }, { "__typename": "VariantFlag", "name": "skip_sign_in_recaptcha", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "suppress_apple_missing_expires_date_alert", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }, { "__typename": "VariantFlag", "name": "use_new_admin_topic_backend", "valueType": { "__typename": "VariantFlagBoolean", "value": true } }], "meterPost({\"postId\":\"15fd2dd8f07b\",\"postMeteringOptions\":{\"referrer\":\"\"}})": { "__ref": "MeteringInfo:{}" }, "postResult({\"id\":\"15fd2dd8f07b\"})": { "__ref": "Post:15fd2dd8f07b" } }, "MeteringInfo:{}": { "__typename": "MeteringInfo", "postIds": [], "maxUnlockCount": 3, "unlocksRemaining": 3 }, "ImageMetadata:": { "id": "", "__typename": "ImageMetadata" }, "ImageMetadata:1*gdoQ1_5OID90wf1eLTFvWw.png": { "id": "1*gdoQ1_5OID90wf1eLTFvWw.png", "__typename": "ImageMetadata", "originalWidth": 3916, "originalHeight": 1524 }, "User:cccc522e775a": { "id": "cccc522e775a", "__typename": "User" }, "ImageMetadata:1*Wx82vEGrMfW4AdSLodZXgQ.png": { "id": "1*Wx82vEGrMfW4AdSLodZXgQ.png", "__typename": "ImageMetadata" }, "Collection:b2f039622545": { "id": "b2f039622545", "__typename": "Collection", "domain": null, "googleAnalyticsId": null, "slug": "webpack", "colorBehavior": "ACCENT_COLOR", "isAuroraVisible": false, "favicon": { "__ref": "ImageMetadata:" }, "name": "webpack", "colorPalette": { "__typename": "ColorPalette", "highlightSpectrum": { "__typename": "ColorSpectrum", "backgroundColor": "#FFFFFFFF", "colorPoints": [{ "__typename": "ColorPoint", "color": "#FFF4F2F2", "point": 0 }, { "__typename": "ColorPoint", "color": "#FFF2F0F0", "point": 0.1 }, { "__typename": "ColorPoint", "color": "#FFF0EEEE", "point": 0.2 }, { "__typename": "ColorPoint", "color": "#FFEEECEC", "point": 0.3 }, { "__typename": "ColorPoint", "color": "#FFECEBEA", "point": 0.4 }, { "__typename": "ColorPoint", "color": "#FFEAE9E8", "point": 0.5 }, { "__typename": "ColorPoint", "color": "#FFE8E7E7", "point": 0.6 }, { "__typename": "ColorPoint", "color": "#FFE6E5E5", "point": 0.7 }, { "__typename": "ColorPoint", "color": "#FFE4E3E3", "point": 0.8 }, { "__typename": "ColorPoint", "color": "#FFE2E1E1", "point": 0.9 }, { "__typename": "ColorPoint", "color": "#FFE0DFDF", "point": 1 }] }, "defaultBackgroundSpectrum": { "__typename": "ColorSpectrum", "backgroundColor": "#FFFFFFFF", "colorPoints": [{ "__typename": "ColorPoint", "color": "#FF848585", "point": 0 }, { "__typename": "ColorPoint", "color": "#FF7B7B7B", "point": 0.1 }, { "__typename": "ColorPoint", "color": "#FF717272", "point": 0.2 }, { "__typename": "ColorPoint", "color": "#FF686868", "point": 0.3 }, { "__typename": "ColorPoint", "color": "#FF5E5E5E", "point": 0.4 }, { "__typename": "ColorPoint", "color": "#FF545454", "point": 0.5 }, { "__typename": "ColorPoint", "color": "#FF494A4A", "point": 0.6 }, { "__typename": "ColorPoint", "color": "#FF3F3F3F", "point": 0.7 }, { "__typename": "ColorPoint", "color": "#FF333333", "point": 0.8 }, { "__typename": "ColorPoint", "color": "#FF272727", "point": 0.9 }, { "__typename": "ColorPoint", "color": "#FF1A1A1A", "point": 1 }] }, "tintBackgroundSpectrum": { "__typename": "ColorSpectrum", "backgroundColor": "#FFFFFFFF", "colorPoints": [{ "__typename": "ColorPoint", "color": "#FFFFFFFF", "point": 0 }, { "__typename": "ColorPoint", "color": "#FFECECEC", "point": 0.1 }, { "__typename": "ColorPoint", "color": "#FFD9D9D9", "point": 0.2 }, { "__typename": "ColorPoint", "color": "#FFC5C6C6", "point": 0.3 }, { "__typename": "ColorPoint", "color": "#FFB1B1B1", "point": 0.4 }, { "__typename": "ColorPoint", "color": "#FF9C9D9D", "point": 0.5 }, { "__typename": "ColorPoint", "color": "#FF868787", "point": 0.6 }, { "__typename": "ColorPoint", "color": "#FF6F7071", "point": 0.7 }, { "__typename": "ColorPoint", "color": "#FF575959", "point": 0.8 }, { "__typename": "ColorPoint", "color": "#FF3D3F3F", "point": 0.9 }, { "__typename": "ColorPoint", "color": "#FF202122", "point": 1 }] } }, "customStyleSheet": null, "tagline": "The official Medium publication for the webpack open source…", "isAuroraEligible": false, "viewerIsEditor": false, "logo": { "__ref": "ImageMetadata:1*gdoQ1_5OID90wf1eLTFvWw.png" }, "navItems": [{ "__typename": "NavItem", "title": "Announcements", "url": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fannouncements\u002Fhome", "type": "TOPIC_PAGE" }, { "__typename": "NavItem", "title": "Google Summer of Code", "url": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fgsoc\u002Fhome", "type": "TOPIC_PAGE" }, { "__typename": "NavItem", "title": "Contributors Guide", "url": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fcontributors-guide\u002Fhome", "type": "TOPIC_PAGE" }, { "__typename": "NavItem", "title": "Tips and Tricks", "url": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Ftips-and-tricks\u002Fhome", "type": "TOPIC_PAGE" }, { "__typename": "NavItem", "title": "About Us", "url": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fabout", "type": "ABOUT_PAGE_NAV_ITEM" }, { "__typename": "NavItem", "title": "Official Documentation", "url": "http:\u002F\u002Fwebpack.js.org", "type": "EXTERNAL_LINK_NAV_ITEM" }], "creator": { "__ref": "User:cccc522e775a" }, "subscriberCount": 16306, "avatar": { "__ref": "ImageMetadata:1*Wx82vEGrMfW4AdSLodZXgQ.png" }, "isEnrolledInHightower": false, "newsletterV3": null, "viewerIsFollowing": false, "viewerIsSubscribedToLetters": false, "canToggleEmail": false, "isUserSubscribedToCollectionEmails": false, "viewerIsMuting": false, "viewerCanEditOwnPosts": false, "viewerCanEditPosts": false, "description": "The official Medium publication for the webpack open source project!", "ampEnabled": false, "twitterUsername": "webpack", "facebookPageId": null }, "User:393110b0b9e4": { "id": "393110b0b9e4", "__typename": "User", "isFollowing": null, "viewerIsUser": false, "isSuspended": false, "name": "Sean T. Larkin", "hasCompletedProfile": false, "bio": "@Webpack Core team & AngularCLI team. Program Manager @Microsoft @EdgeDevTools. Web Performance, JavaScripter, Woodworker, 🐓 Farmer, and Gardener!", "imageId": "1*AtcF5LLmMnXgwTpBMeos-w.jpeg", "username": "TheLarkInn", "customStyleSheet": null, "customDomainState": null, "isAuroraVisible": true, "createdAt": 0, "mediumMemberAt": 0, "lastPostCreatedAt": 0, "socialStats": { "__typename": "SocialStats", "followerCount": 8583 }, "hasSubdomain": false, "isBlocking": null, "isMuting": null, "allowNotes": true, "newsletterV3": null, "twitterScreenName": "TheLarkInn", "isPartnerProgramEnrolled": false }, "Paragraph:aca3888b20f_0": { "id": "aca3888b20f_0", "__typename": "Paragraph", "name": "821e", "text": "It’s finally here. And it’s beautiful.", "type": "IMG", "href": null, "layout": "OUTSET_CENTER", "metadata": { "__ref": "ImageMetadata:1*Ac4K68j43uSbvHnKZKfXPw.jpeg" }, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_1": { "id": "aca3888b20f_1", "__typename": "Paragraph", "name": "ea51", "text": "🍾🚀 webpack 3: Official Release!! 🚀🍾", "type": "H3", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_2": { "id": "aca3888b20f_2", "__typename": "Paragraph", "name": "8fe8", "text": "Scope Hoisting, “magic comments”, and more!", "type": "H4", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_3": { "id": "aca3888b20f_3", "__typename": "Paragraph", "name": "927b", "text": "After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Moreover, we promised to deliver them in a faster, more stable release cycle.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 175, "end": 181, "type": "STRONG", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 183, "end": 194, "type": "STRONG", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 175, "end": 181, "type": "EM", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 183, "end": 194, "type": "EM", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_4": { "id": "aca3888b20f_4", "__typename": "Paragraph", "name": "efac", "text": "No more year-long betas, no breaking changes between release candidates. We promised to do you right by you, the community that makes webpack thrive.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 104, "end": 108, "type": "STRONG", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 103, "end": 149, "type": "EM", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_5": { "id": "aca3888b20f_5", "__typename": "Paragraph", "name": "ca2d", "text": "The webpack team is proud to announce that today we have released webpack 3.0.0!!! You can download or upgrade to it today!!", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_6": { "id": "aca3888b20f_6", "__typename": "Paragraph", "name": "549b", "text": "npm install webpack@3.0.0 --save-dev", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 0, "end": 36, "type": "CODE", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_7": { "id": "aca3888b20f_7", "__typename": "Paragraph", "name": "69df", "text": "or with", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_8": { "id": "aca3888b20f_8", "__typename": "Paragraph", "name": "4ef7", "text": "yarn add webpack@3.0.0 --dev", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 0, "end": 28, "type": "CODE", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_9": { "id": "aca3888b20f_9", "__typename": "Paragraph", "name": "17f8", "text": "Migrating from webpack 2 to 3, should involve no effort beyond running the upgrade commands in your terminal. We marked this as a Major change because of internal breaking changes that could affect some plugins.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 46, "end": 109, "type": "STRONG", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 46, "end": 109, "type": "EM", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_10": { "id": "aca3888b20f_10", "__typename": "Paragraph", "name": "2878", "text": "So far we’ve seen 98% of users upgrade with no breaking functionality at all!!!", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 0, "end": 79, "type": "STRONG", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 0, "end": 79, "type": "EM", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_11": { "id": "aca3888b20f_11", "__typename": "Paragraph", "name": "3750", "text": "What’s new?", "type": "H3", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_12": { "id": "aca3888b20f_12", "__typename": "Paragraph", "name": "3c03", "text": "As we mentioned, we aimed to deliver the features that you voted for! Because of the overwhelming GitHub contributions, support from our backers and sponsors, we have been able to hit each one. 😍", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 59, "end": 68, "type": "A", "href": "https:\u002F\u002Fwebpack.js.org\u002Fvote", "anchorType": "LINK", "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 120, "end": 157, "type": "A", "href": "http:\u002F\u002Fopencollective.com\u002Fwebpack", "anchorType": "LINK", "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_13": { "id": "aca3888b20f_13", "__typename": "Paragraph", "name": "c11e", "text": "🔬 Scope Hoisting 🔬", "type": "H4", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_14": { "id": "aca3888b20f_14", "__typename": "Paragraph", "name": "0014", "text": "Scope Hoisting is the flagship feature of webpack 3. One of webpack’s trade-offs when bundling was that each module in your bundle would be wrapped in individual function closures. These wrapper functions made it slower for your JavaScript to execute in the browser. In comparison, tools like Closure Compiler and RollupJS ‘hoist’ or concatenate the scope of all your modules into one closure and allow for your code to have a faster execution time in the browser.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_15": { "id": "aca3888b20f_15", "__typename": "Paragraph", "name": "d5a2", "text": "", "type": "IFRAME", "href": null, "layout": "INSET_CENTER", "metadata": null, "hasDropCap": null, "iframe": { "__typename": "Iframe", "mediaResource": { "__ref": "MediaResource:4533845503a873853b93e6aaf0833c57" } }, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_16": { "id": "aca3888b20f_16", "__typename": "Paragraph", "name": "4965", "text": "As of today, with webpack 3, you can now add the following plugin to your configuration to enable scope hoisting:", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 37, "end": 113, "type": "STRONG", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_17": { "id": "aca3888b20f_17", "__typename": "Paragraph", "name": "7078", "text": "module.exports = {  \n  plugins: [\n    new webpack.optimize.ModuleConcatenationPlugin()\n  ]\n};", "type": "PRE", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_18": { "id": "aca3888b20f_18", "__typename": "Paragraph", "name": "95b8", "text": "Scope Hoisting is specifically a feature made possible by ECMAScript Module syntax. Because of this webpack may fallback to normal bundling based on what kind of modules you are using, and other conditions.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 189, "end": 205, "type": "A", "href": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fwebpack-freelancing-log-book-week-5-7-4764be3266f5", "anchorType": "LINK", "userId": "", "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_19": { "id": "aca3888b20f_19", "__typename": "Paragraph", "name": "40b6", "text": "To stay informed on what triggers these fallbacks, we’ve added a --display-optimization-bailout cli flag that will tell you what caused the fallback.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 65, "end": 95, "type": "CODE", "href": "", "anchorType": "LINK", "userId": "", "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_20": { "id": "aca3888b20f_20", "__typename": "Paragraph", "name": "6a0e", "text": "", "type": "IFRAME", "href": null, "layout": "INSET_CENTER", "metadata": null, "hasDropCap": null, "iframe": { "__typename": "Iframe", "mediaResource": { "__ref": "MediaResource:6663aed6525e9200886db81c9415337c" } }, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_21": { "id": "aca3888b20f_21", "__typename": "Paragraph", "name": "f203", "text": "Because scope hoisting will remove function wrappers around your modules, you may see some small size improvements. However, the significant improvement will be how fast the JavaScript loads in the browser. If you have awesome before and after comparisons, feel free to respond with some data as we’d be honored to share it!", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_22": { "id": "aca3888b20f_22", "__typename": "Paragraph", "name": "ea65", "text": "🔮 ”Magic Comments” 🔮", "type": "H4", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_23": { "id": "aca3888b20f_23", "__typename": "Paragraph", "name": "b50c", "text": "When we introduced in webpack 2 the ability to use the dynamic import syntax ( import() ), users expressed their concerns that they could not create named chunks like they were able to with require.ensure.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 79, "end": 87, "type": "CODE", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 190, "end": 204, "type": "CODE", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_24": { "id": "aca3888b20f_24", "__typename": "Paragraph", "name": "b465", "text": "We have now introduced what the community has coined “magic comments”, the ability to pass chunk name, and more as an inline comment to your import() statements.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 141, "end": 149, "type": "CODE", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }, { "__typename": "Markup", "start": 103, "end": 111, "type": "A", "href": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fhow-to-use-webpacks-new-magic-comment-feature-with-react-universal-component-ssr-a38fd3e296a", "anchorType": "LINK", "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_25": { "id": "aca3888b20f_25", "__typename": "Paragraph", "name": "1049", "text": "By using comments, we are able to stay true to the load specification, and still give you the great chunk naming features you love.", "type": "IFRAME", "href": null, "layout": "INSET_CENTER", "metadata": null, "hasDropCap": null, "iframe": { "__typename": "Iframe", "mediaResource": { "__ref": "MediaResource:1de84d98f7926e813eccd95ddac64e1b" } }, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_26": { "id": "aca3888b20f_26", "__typename": "Paragraph", "name": "f813", "text": "Although these are technically features we released in v2.4 and v2.6, we worked to stabilize and fix bugs for these features that have landed in v3. This now allows the dynamic import syntax to have the same flexibility as require.ensure.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 223, "end": 237, "type": "CODE", "href": null, "anchorType": null, "userId": null, "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_27": { "id": "aca3888b20f_27", "__typename": "Paragraph", "name": "e1b1", "text": "", "type": "IFRAME", "href": null, "layout": "INSET_CENTER", "metadata": null, "hasDropCap": null, "iframe": { "__typename": "Iframe", "mediaResource": { "__ref": "MediaResource:fd3c12141eb0e7363d3e33feb528480c" } }, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_28": { "id": "aca3888b20f_28", "__typename": "Paragraph", "name": "a2af", "text": "To learn more information, see our newest documentation guide on code-splitting that highlights these features!!!", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 35, "end": 79, "type": "A", "href": "https:\u002F\u002Fwebpack.js.org\u002Fguides\u002Fcode-splitting-async", "anchorType": "LINK", "userId": "", "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_29": { "id": "aca3888b20f_29", "__typename": "Paragraph", "name": "5371", "text": "😍 What’s next? 😍", "type": "H3", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_30": { "id": "aca3888b20f_30", "__typename": "Paragraph", "name": "4f06", "text": "We have quite a few features and enhancements that we are hoping to bring you!!! But to take control of the ones we should be working one, stop by our vote page, and upvote the features you would like to see!", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 150, "end": 208, "type": "A", "href": "http:\u002F\u002Fwebpack.js.org\u002Fvote", "anchorType": "LINK", "userId": "", "linkMetadata": null }, { "__typename": "Markup", "start": 150, "end": 208, "type": "EM", "href": "", "anchorType": "LINK", "userId": "", "linkMetadata": null }], "dropCapImage": null }, "Paragraph:aca3888b20f_31": { "id": "aca3888b20f_31", "__typename": "Paragraph", "name": "92e2", "text": "Here are some of those things we are hoping to bring you still:", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_32": { "id": "aca3888b20f_32", "__typename": "Paragraph", "name": "b1a0", "text": "Better Build Caching", "type": "ULI", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_33": { "id": "aca3888b20f_33", "__typename": "Paragraph", "name": "e784", "text": "Faster initial and incremental builds", "type": "ULI", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_34": { "id": "aca3888b20f_34", "__typename": "Paragraph", "name": "9ec9", "text": "Better TypeScript experience", "type": "ULI", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_35": { "id": "aca3888b20f_35", "__typename": "Paragraph", "name": "98e6", "text": "Revamped Long term caching", "type": "ULI", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_36": { "id": "aca3888b20f_36", "__typename": "Paragraph", "name": "8e9d", "text": "WASM Module Support", "type": "ULI", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_37": { "id": "aca3888b20f_37", "__typename": "Paragraph", "name": "8948", "text": "Improve User Experience", "type": "ULI", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_38": { "id": "aca3888b20f_38", "__typename": "Paragraph", "name": "f87b", "text": "🙇Thank you 🙇", "type": "H3", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_39": { "id": "aca3888b20f_39", "__typename": "Paragraph", "name": "48ea", "text": "All of our users, contributors, documentation writers, bloggers, sponsors, backers, and maintainers are all shareholders in helping us ensure webpack is successful for years to come.", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_40": { "id": "aca3888b20f_40", "__typename": "Paragraph", "name": "9f50", "text": "For this, we thank you all. It is not possible without you and we can’t wait to share what is in store for the future!!", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [], "dropCapImage": null }, "Paragraph:aca3888b20f_41": { "id": "aca3888b20f_41", "__typename": "Paragraph", "name": "d2ed", "text": "No time to help contribute? Want to give back in other ways? Become a Backer or Sponsor to webpack by donating to our open collective. Open Collective not only helps support the Core Team, but also supports contributors who have spent significant time improving our organization on their free time! ❤", "type": "P", "href": null, "layout": null, "metadata": null, "hasDropCap": null, "iframe": null, "mixtapeMetadata": null, "markups": [{ "__typename": "Markup", "start": 118, "end": 133, "type": "A", "href": "http:\u002F\u002Fopencollective.com\u002Fwebpack", "anchorType": "LINK", "userId": "", "linkMetadata": null }, { "__typename": "Markup", "start": 61, "end": 134, "type": "STRONG", "href": "", "anchorType": "LINK", "userId": "", "linkMetadata": null }, { "__typename": "Markup", "start": 0, "end": 300, "type": "EM", "href": "", "anchorType": "LINK", "userId": "", "linkMetadata": null }], "dropCapImage": null }, "ImageMetadata:1*Ac4K68j43uSbvHnKZKfXPw.jpeg": { "id": "1*Ac4K68j43uSbvHnKZKfXPw.jpeg", "__typename": "ImageMetadata", "originalHeight": 3264, "originalWidth": 4896, "focusPercentX": null, "focusPercentY": null, "alt": null }, "MediaResource:4533845503a873853b93e6aaf0833c57": { "id": "4533845503a873853b93e6aaf0833c57", "__typename": "MediaResource", "iframeSrc": "https:\u002F\u002Fcdn.embedly.com\u002Fwidgets\u002Fmedia.html?type=text%2Fhtml&key=d04bfffea46d4aeda930ec88cc64b87c&schema=twitter&url=https%3A\u002F\u002Ftwitter.com\u002Ftizmagik\u002Fstatus\u002F876128847682523138&image=https%3A\u002F\u002Fi.embed.ly\u002F1\u002Fimage%3Furl%3Dhttps%253A%252F%252Fpbs.twimg.com%252Fmedia%252FDCih0NiWAAAAtZl.jpg%253Alarge%26key%3D4fce0568f2ce49e8b54624ef71a8a5bd", "iframeHeight": 185, "iframeWidth": 500, "title": "Jeremy Gayed 🤓 on Twitter" }, "MediaResource:6663aed6525e9200886db81c9415337c": { "id": "6663aed6525e9200886db81c9415337c", "__typename": "MediaResource", "iframeSrc": "https:\u002F\u002Fcdn.embedly.com\u002Fwidgets\u002Fmedia.html?type=text%2Fhtml&key=a19fcc184b9711e1b4764040d3dc5c07&schema=twitter&url=https%3A\u002F\u002Ftwitter.com\u002Fjeremenichelli\u002Fstatus\u002F876527176606265344&image=https%3A\u002F\u002Fi.embed.ly\u002F1\u002Fimage%3Furl%3Dhttps%253A%252F%252Fpbs.twimg.com%252Fprofile_images%252F838369206907387904%252FPNdDKe77_400x400.jpg%26key%3Da19fcc184b9711e1b4764040d3dc5c07", "iframeHeight": 185, "iframeWidth": 500, "title": "Jeremias Menichelli on Twitter" }, "MediaResource:1de84d98f7926e813eccd95ddac64e1b": { "id": "1de84d98f7926e813eccd95ddac64e1b", "__typename": "MediaResource", "iframeSrc": "", "iframeHeight": 0, "iframeWidth": 0, "title": "Chunk Name" }, "MediaResource:fd3c12141eb0e7363d3e33feb528480c": { "id": "fd3c12141eb0e7363d3e33feb528480c", "__typename": "MediaResource", "iframeSrc": "https:\u002F\u002Fcdn.embedly.com\u002Fwidgets\u002Fmedia.html?type=text%2Fhtml&key=a19fcc184b9711e1b4764040d3dc5c07&schema=twitter&url=https%3A\u002F\u002Ftwitter.com\u002Fadamrackis\u002Fstatus\u002F872602076056088576&image=https%3A\u002F\u002Fi.embed.ly\u002F1\u002Fimage%3Furl%3Dhttps%253A%252F%252Fpbs.twimg.com%252Fmedia%252FDBwao-MVwAAnydG.jpg%253Alarge%26key%3Da19fcc184b9711e1b4764040d3dc5c07", "iframeHeight": 185, "iframeWidth": 500, "title": "Adam Rackis on Twitter" }, "Tag:javascript": { "id": "javascript", "__typename": "Tag", "displayTitle": "JavaScript" }, "Tag:webpack": { "id": "webpack", "__typename": "Tag", "displayTitle": "Webpack" }, "Tag:tech": { "id": "tech", "__typename": "Tag", "displayTitle": "Tech" }, "Tag:technology": { "id": "technology", "__typename": "Tag", "displayTitle": "Technology" }, "Tag:web-development": { "id": "web-development", "__typename": "Tag", "displayTitle": "Web Development" }, "ImageMetadata:1*LF_LYj06_VWwk-q6WEH0-w.png": { "id": "1*LF_LYj06_VWwk-q6WEH0-w.png", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "User:a5aabd9ad00a": { "id": "a5aabd9ad00a", "__typename": "User", "name": "Vincent Chan", "username": "okcdz", "bio": "C++\u002FRust\u002FTypeScript, Engineer", "isFollowing": null, "imageId": "1*RYAoNSK9gttwIZqtsuPuCw.png", "mediumMemberAt": 0, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "okcdz.medium.com" } }, "hasSubdomain": true }, "Post:a0b788c0ce77": { "id": "a0b788c0ce77", "__typename": "Post", "title": "Better tree shaking with deep scope analysis", "mediumUrl": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fbetter-tree-shaking-with-deep-scope-analysis-a0b788c0ce77", "previewImage": { "__ref": "ImageMetadata:1*LF_LYj06_VWwk-q6WEH0-w.png" }, "isPublished": true, "firstPublishedAt": 1534213613492, "readingTime": 5.058490566037736, "statusForCollection": "APPROVED", "isLocked": false, "isShortform": false, "visibility": "PUBLIC", "collection": { "__ref": "Collection:b2f039622545" }, "creator": { "__ref": "User:a5aabd9ad00a" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:1*wNaUljI2sG7HeDKQMJwqHQ.png": { "id": "1*wNaUljI2sG7HeDKQMJwqHQ.png", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "Collection:f5af2b715248": { "id": "f5af2b715248", "__typename": "Collection", "name": "The Startup", "slug": "swlh", "domain": null }, "User:6ee1d21716ab": { "id": "6ee1d21716ab", "__typename": "User", "name": "Tharaka Romesh", "username": "TRomesh", "bio": "Senior Software Engineer @99XTechnology", "isFollowing": null, "imageId": "1*-cOqqabGfysUpQ9aH93wmw.jpeg", "mediumMemberAt": 0, "customDomainState": null, "hasSubdomain": false }, "Post:d689a77c5f04": { "id": "d689a77c5f04", "__typename": "Post", "title": "Intro to Recoil", "mediumUrl": "https:\u002F\u002Fmedium.com\u002Fswlh\u002Fintro-to-recoil-d689a77c5f04", "previewImage": { "__ref": "ImageMetadata:1*wNaUljI2sG7HeDKQMJwqHQ.png" }, "isPublished": true, "firstPublishedAt": 1589920781581, "readingTime": 3.3320754716981136, "statusForCollection": "APPROVED", "isLocked": true, "isShortform": false, "visibility": "LOCKED", "collection": { "__ref": "Collection:f5af2b715248" }, "creator": { "__ref": "User:6ee1d21716ab" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:0*fvLeveZAwD-r-UXc": { "id": "0*fvLeveZAwD-r-UXc", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "User:74d56154f1f9": { "id": "74d56154f1f9", "__typename": "User", "name": "Omar Zahran", "username": "omarzahran", "bio": "Tech enthusiast, writer, and lover of food", "isFollowing": null, "imageId": "1*GGxQ2sFS3ITdV2cyBmWJNA.jpeg", "mediumMemberAt": 1578146987997, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "omarzahran.medium.com" } }, "hasSubdomain": true }, "Post:212d813b2798": { "id": "212d813b2798", "__typename": "Post", "title": "What If Chrome OS Was a Phone Operating System?", "mediumUrl": "https:\u002F\u002Fmedium.com\u002Fswlh\u002Fwhat-if-chrome-os-was-a-phone-operating-system-212d813b2798", "previewImage": { "__ref": "ImageMetadata:0*fvLeveZAwD-r-UXc" }, "isPublished": true, "firstPublishedAt": 1590248494744, "readingTime": 6.6169811320754715, "statusForCollection": "APPROVED", "isLocked": true, "isShortform": false, "visibility": "LOCKED", "collection": { "__ref": "Collection:f5af2b715248" }, "creator": { "__ref": "User:74d56154f1f9" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:1*cW9IvHMO5fBRNbjw2NW44Q.png": { "id": "1*cW9IvHMO5fBRNbjw2NW44Q.png", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "Collection:4737331fbdc0": { "id": "4737331fbdc0", "__typename": "Collection", "name": "The Guild", "slug": "the-guild", "domain": null }, "User:5a6962cd709e": { "id": "5a6962cd709e", "__typename": "User", "name": "Eytan Manor", "username": "eytanmanor", "bio": "Eytan is a JavaScript artist who comes from the land of the Promise(). His hobbies are eating, sleeping; and open-source… He loves open-source.", "isFollowing": null, "imageId": "1*xzrkykaDv7Ohk6OXzkOKFw.png", "mediumMemberAt": 0, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "eytanmanor.medium.com" } }, "hasSubdomain": true }, "Post:b0a13dcd0352": { "id": "b0a13dcd0352", "__typename": "Post", "title": "This is how I build Babel plug-ins", "mediumUrl": "https:\u002F\u002Fmedium.com\u002Fthe-guild\u002Fthis-is-how-i-build-babel-plug-ins-b0a13dcd0352", "previewImage": { "__ref": "ImageMetadata:1*cW9IvHMO5fBRNbjw2NW44Q.png" }, "isPublished": true, "firstPublishedAt": 1538994729668, "readingTime": 6.0698113207547175, "statusForCollection": "APPROVED", "isLocked": false, "isShortform": false, "visibility": "PUBLIC", "collection": { "__ref": "Collection:4737331fbdc0" }, "creator": { "__ref": "User:5a6962cd709e" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:0*nBNPobrQPLNmVp_a": { "id": "0*nBNPobrQPLNmVp_a", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "User:6895d5e78577": { "id": "6895d5e78577", "__typename": "User", "name": "Shailesh Jha", "username": "premeena", "bio": "Consultant | Full Stack Developer", "isFollowing": null, "imageId": "1*TFFMDq1asFHASUA9Pic-9Q.jpeg", "mediumMemberAt": 0, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "premeena.medium.com" } }, "hasSubdomain": true }, "Post:da8f75024ba4": { "id": "da8f75024ba4", "__typename": "Post", "title": "Webpack + React Optimised from scratch", "mediumUrl": "https:\u002F\u002Fpremeena.medium.com\u002Fwebpack-react-optimised-from-scratch-da8f75024ba4", "previewImage": { "__ref": "ImageMetadata:0*nBNPobrQPLNmVp_a" }, "isPublished": true, "firstPublishedAt": 1615095720033, "readingTime": 8.477358490566038, "statusForCollection": null, "isLocked": false, "isShortform": false, "visibility": "PUBLIC", "collection": null, "creator": { "__ref": "User:6895d5e78577" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:0*R7W2uXa4tMUvJrqS": { "id": "0*R7W2uXa4tMUvJrqS", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "Collection:be0b0399bbce": { "id": "be0b0399bbce", "__typename": "Collection", "name": "dooboolab", "slug": "dooboolab", "domain": null }, "User:3c26c3f84101": { "id": "3c26c3f84101", "__typename": "User", "name": "Donghyeon Kim", "username": "0916dhkim", "bio": "", "isFollowing": null, "imageId": "", "mediumMemberAt": 0, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "0916dhkim.medium.com" } }, "hasSubdomain": true }, "Post:d04ee074eb98": { "id": "d04ee074eb98", "__typename": "Post", "title": "How to Update Relay Cache", "mediumUrl": "https:\u002F\u002Fmedium.com\u002Fdooboolab\u002Fhow-to-update-relay-cache-d04ee074eb98", "previewImage": { "__ref": "ImageMetadata:0*R7W2uXa4tMUvJrqS" }, "isPublished": true, "firstPublishedAt": 1612132378295, "readingTime": 2.9871069182389935, "statusForCollection": "APPROVED", "isLocked": false, "isShortform": false, "visibility": "PUBLIC", "collection": { "__ref": "Collection:be0b0399bbce" }, "creator": { "__ref": "User:3c26c3f84101" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:1*9p8FLpoYHEOc_8bdG0J08A.png": { "id": "1*9p8FLpoYHEOc_8bdG0J08A.png", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "User:792f462bb0e7": { "id": "792f462bb0e7", "__typename": "User", "name": "TOAST UI", "username": "toastui", "bio": "JavaScript UI Library Open Source by http:\u002F\u002Fui.toast.com", "isFollowing": null, "imageId": "1*L3JIVv_0_gEInsRriDrt5Q.png", "mediumMemberAt": 0, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "toastui.medium.com" } }, "hasSubdomain": true }, "Post:26ffc025864d": { "id": "26ffc025864d", "__typename": "Post", "title": "Improving the Reactivity System (feat. TOAST UI Grid)", "mediumUrl": "https:\u002F\u002Ftoastui.medium.com\u002Fimproving-the-reactivity-system-feat-toast-ui-grid-26ffc025864d", "previewImage": { "__ref": "ImageMetadata:1*9p8FLpoYHEOc_8bdG0J08A.png" }, "isPublished": true, "firstPublishedAt": 1578972835689, "readingTime": 12.666352201257862, "statusForCollection": null, "isLocked": true, "isShortform": false, "visibility": "LOCKED", "collection": null, "creator": { "__ref": "User:792f462bb0e7" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "ImageMetadata:1*6js53mDPNElWcqe_NTDOIQ.gif": { "id": "1*6js53mDPNElWcqe_NTDOIQ.gif", "__typename": "ImageMetadata", "focusPercentX": null, "focusPercentY": null }, "Collection:5517fd7b58a6": { "id": "5517fd7b58a6", "__typename": "Collection", "name": "Level Up Coding", "slug": "gitconnected", "domain": "levelup.gitconnected.com" }, "User:2fe57836127": { "id": "2fe57836127", "__typename": "User", "name": "Rany ElHousieny", "username": "ranyel", "bio": "https:\u002F\u002Frany.tk Commercial software development manager offering 25+ years’ of technical experience. Certified Solutions Architect", "isFollowing": null, "imageId": "2*-MWSVEjycNfqU98EZSVVZg.jpeg", "mediumMemberAt": 1603377049000, "customDomainState": { "__typename": "CustomDomainState", "live": { "__typename": "CustomDomain", "domain": "ranyel.medium.com" } }, "hasSubdomain": true }, "Post:4dd2f7d81dcb": { "id": "4dd2f7d81dcb", "__typename": "Post", "title": "Understanding Micro-Frontends Webpack 5 Configurations Step by Step", "mediumUrl": "https:\u002F\u002Flevelup.gitconnected.com\u002Funderstanding-micro-frontends-webpack5-configurations-step-by-step-4dd2f7d81dcb", "previewImage": { "__ref": "ImageMetadata:1*6js53mDPNElWcqe_NTDOIQ.gif" }, "isPublished": true, "firstPublishedAt": 1614879438472, "readingTime": 7.944339622641509, "statusForCollection": "APPROVED", "isLocked": false, "isShortform": false, "visibility": "PUBLIC", "collection": { "__ref": "Collection:5517fd7b58a6" }, "creator": { "__ref": "User:2fe57836127" }, "previewContent": { "__typename": "PreviewContent", "isFullContent": false } }, "Post:15fd2dd8f07b": { "id": "15fd2dd8f07b", "__typename": "Post", "canonicalUrl": "", "collection": { "__ref": "Collection:b2f039622545" }, "content({})": { "__typename": "PostContent", "isLockedPreviewOnly": false, "validatedShareKey": "", "isCacheableContent": false, "bodyModel": { "__typename": "RichText", "paragraphs": [{ "__ref": "Paragraph:aca3888b20f_0" }, { "__ref": "Paragraph:aca3888b20f_1" }, { "__ref": "Paragraph:aca3888b20f_2" }, { "__ref": "Paragraph:aca3888b20f_3" }, { "__ref": "Paragraph:aca3888b20f_4" }, { "__ref": "Paragraph:aca3888b20f_5" }, { "__ref": "Paragraph:aca3888b20f_6" }, { "__ref": "Paragraph:aca3888b20f_7" }, { "__ref": "Paragraph:aca3888b20f_8" }, { "__ref": "Paragraph:aca3888b20f_9" }, { "__ref": "Paragraph:aca3888b20f_10" }, { "__ref": "Paragraph:aca3888b20f_11" }, { "__ref": "Paragraph:aca3888b20f_12" }, { "__ref": "Paragraph:aca3888b20f_13" }, { "__ref": "Paragraph:aca3888b20f_14" }, { "__ref": "Paragraph:aca3888b20f_15" }, { "__ref": "Paragraph:aca3888b20f_16" }, { "__ref": "Paragraph:aca3888b20f_17" }, { "__ref": "Paragraph:aca3888b20f_18" }, { "__ref": "Paragraph:aca3888b20f_19" }, { "__ref": "Paragraph:aca3888b20f_20" }, { "__ref": "Paragraph:aca3888b20f_21" }, { "__ref": "Paragraph:aca3888b20f_22" }, { "__ref": "Paragraph:aca3888b20f_23" }, { "__ref": "Paragraph:aca3888b20f_24" }, { "__ref": "Paragraph:aca3888b20f_25" }, { "__ref": "Paragraph:aca3888b20f_26" }, { "__ref": "Paragraph:aca3888b20f_27" }, { "__ref": "Paragraph:aca3888b20f_28" }, { "__ref": "Paragraph:aca3888b20f_29" }, { "__ref": "Paragraph:aca3888b20f_30" }, { "__ref": "Paragraph:aca3888b20f_31" }, { "__ref": "Paragraph:aca3888b20f_32" }, { "__ref": "Paragraph:aca3888b20f_33" }, { "__ref": "Paragraph:aca3888b20f_34" }, { "__ref": "Paragraph:aca3888b20f_35" }, { "__ref": "Paragraph:aca3888b20f_36" }, { "__ref": "Paragraph:aca3888b20f_37" }, { "__ref": "Paragraph:aca3888b20f_38" }, { "__ref": "Paragraph:aca3888b20f_39" }, { "__ref": "Paragraph:aca3888b20f_40" }, { "__ref": "Paragraph:aca3888b20f_41" }], "sections": [{ "__typename": "Section", "name": "33b6", "startIndex": 0, "textLayout": "FLOW", "imageLayout": "NONE", "backgroundImage": null, "videoLayout": "NO_VIDEO", "backgroundVideo": null }, { "__typename": "Section", "name": "33f3", "startIndex": 9, "textLayout": null, "imageLayout": null, "backgroundImage": null, "videoLayout": null, "backgroundVideo": null }, { "__typename": "Section", "name": "f349", "startIndex": 41, "textLayout": null, "imageLayout": null, "backgroundImage": null, "videoLayout": null, "backgroundVideo": null }] } }, "creator": { "__ref": "User:393110b0b9e4" }, "customStyleSheet": null, "firstPublishedAt": 1497893008613, "isLocked": false, "isPublished": true, "isShortform": false, "layerCake": 0, "primaryTopic": null, "title": "🍾🚀 webpack 3: Official Release!! 🚀🍾", "readCreatorPostsCount": 0, "mediumUrl": "https:\u002F\u002Fmedium.com\u002Fwebpack\u002Fwebpack-3-official-release-15fd2dd8f07b", "isLimitedState": false, "visibility": "PUBLIC", "license": "ALL_RIGHTS_RESERVED", "allowResponses": true, "newsletterId": "", "sequence": null, "tags": [{ "__ref": "Tag:javascript" }, { "__ref": "Tag:webpack" }, { "__ref": "Tag:tech" }, { "__ref": "Tag:technology" }, { "__ref": "Tag:web-development" }], "topics": [], "viewerClapCount": 0, "showSubscribeToProfilePromo": false, "showSubscribeToCollectionNewsletterV3Promo": false, "inResponseToPostResult": null, "isNewsletter": false, "socialTitle": "", "socialDek": "", "metaDescription": "After we released webpack v2, we made some promises to the community. We promised that we would deliver the features you voted for. Today, we’ve fulfilled these promises.", "latestPublishedAt": 1498064228802, "readingTime": 2.909433962264151, "previewContent": { "__typename": "PreviewContent", "subtitle": "Now with Scope Hoisting, “magic comments”, and more!" }, "previewImage": { "__ref": "ImageMetadata:1*Ac4K68j43uSbvHnKZKfXPw.jpeg" }, "creatorPartnerProgramEnrollmentStatus": "PERMISSION_DENIED", "clapCount": 4034, "lockedSource": "LOCKED_POST_SOURCE_NONE", "isSuspended": false, "pendingCollection": null, "statusForCollection": "APPROVED", "pinnedAt": 0, "pinnedByCreatorAt": 0, "curationEligibleAt": 0, "responseDistribution": "NOT_DISTRIBUTED", "shareKey": null, "internalLinks({\"paging\":{\"limit\":8}})": { "__typename": "InternalLinksConnection", "items": [{ "__ref": "Post:a0b788c0ce77" }, { "__ref": "Post:d689a77c5f04" }, { "__ref": "Post:212d813b2798" }, { "__ref": "Post:b0a13dcd0352" }, { "__ref": "Post:da8f75024ba4" }, { "__ref": "Post:d04ee074eb98" }, { "__ref": "Post:26ffc025864d" }, { "__ref": "Post:4dd2f7d81dcb" }] }, "collaborators": [], "translationSourcePost": null, "inResponseToMediaResource": null, "isDistributionAlertDismissed": false, "audioVersionUrl": "", "seoTitle": "", "updatedAt": 1528169345031, "shortformType": "SHORTFORM_TYPE_LINK", "structuredData": "", "seoDescription": "", "postResponses": { "__typename": "PostResponses", "count": 51 }, "latestPublishedVersion": "aca3888b20f", "isPublishToEmail": false, "readingList": "READING_LIST_NONE", "voterCount": 1841, "recommenders": [] } }</script>
+  <script src="https://cdn-client.medium.com/lite/static/js/manifest.1fd15351.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/5566.011c6c68.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/main.4f933583.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/5573.159bf40f.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/instrumentation.2774f137.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/reporting.0e714607.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/1752.a348f767.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/1491.c08ce3ca.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/4964.fb36722e.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/8342.6aa0b45e.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/9692.3fc1c18a.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/4586.7c07e0df.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/5064.ee9cac75.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/9355.c6c38ae6.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/2846.bbadae04.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/7012.f1ee6871.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/6230.b596e4e9.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/9972.a4eec407.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/5127.810d9eac.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/8580.84adae83.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/8751.8bd4ce88.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/2955.e3a25a19.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/7131.4059cf64.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/8127.58f0a64c.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/6371.4672dd1f.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/304.7fb69e54.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/2874.661d5cbc.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/2514.2c8bf092.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/3874.19af3a09.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/2558.1ac5c4fd.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/8286.962b84f6.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/5025.250e5ada.chunk.js"></script>
+  <script src="https://cdn-client.medium.com/lite/static/js/Post.4a47de6d.chunk.js"></script>
+  <script>window.main();</script>
+</body>
+
+</html>

--- a/packages/metascraper/test/integration/washington-post/input.html
+++ b/packages/metascraper/test/integration/washington-post/input.html
@@ -1,4614 +1,7065 @@
 <!DOCTYPE html>
-<html lang="en" class="story layout_article pb_actual_layout_article rendering-context-www outputtype_default-article">
-  <head>
-    <script>
-      window.pbDeferredScripts = window.pbDeferredScripts || new Array;
-    </script>
-    <script id="_$cookiemonster">
-      (function(document, undefined) {
-        var wl = {};
-        wl.reg = [];
-        wl.map = [];
-        function CM(wlmap, wlreg) {
-          this.wl = {
-            map: wl.map.concat(wlmap || []),
-            reg: wl.reg.concat(wlreg || [])
-          }
-        }
-        CM.prototype.ommNom = function() {
-          return this.nom(true, undefined)
-        };
-        CM.prototype.allows = function(cookieKey) {
-          var yum = this.nom(false, [cookieKey]).indexOf(cookieKey) > -1;
-          return !yum
-        };
-        CM.prototype.nom = function(deleteCookies, cookiesList) {
-          var unset = [];
-          var domainkey = document.location.hostname.split("").reverse().join("").slice(0, 18),
-            dcookies = cookiesList || document.cookie.split(";"),
-            dcookie, save, reg;
-          for (var i = 0; i < dcookies.length, dcookie = dcookies[i]; i++) {
-            save = dcookie.trim().split("\x3d")[0].toLowerCase();
-            if (this.wl.map.indexOf(save) > -1);
-            else unset.push(save)
-          }
-          for (var o = 0; o < this.wl.reg.length, reg = this.wl.reg[o]; o++) {
-            reg.lastIndex = 0;
-            for (var i = 0; i < dcookies.length, dcookie = dcookies[i]; i++) {
-              save = dcookie.trim().split("\x3d")[0].toLowerCase();
-              if (reg.test(save)) {
-                if (unset.indexOf(save) > -1) unset.splice(unset.indexOf(save), 1)
-              } else if (unset.indexOf(save) < 0 && this.wl.map.indexOf(save) < 0) unset.push(save)
-            }
-          }
-          if (deleteCookies)
-            if (domainkey ==
-              "moc.tsopnotgnihsaw" && (this.wl.reg.length || this.wl.map.length)) setTimeout(function(ctx) {
-              return function() {
-                for (var i = 0; i < unset.length; i++) {
-                  document.cookie = unset[i] + "\x3d; expires\x3dThu, 01 Jan 1970 00:00:01 GMT; path\x3d/; domain\x3dwww.washingtonpost.com";
-                  document.cookie = unset[i] + "\x3d; expires\x3dThu, 01 Jan 1970 00:00:01 GMT; path\x3d/; domain\x3d.washingtonpost.com";
-                  document.cookie = unset[i] + "\x3d; expires\x3dThu, 01 Jan 1970 00:00:01 GMT; path\x3d/; domain\x3d"
-                }
-              }
-            }(this), 0);
-            else console.error("[cookie-monster] Cowardly refusing to delete cookies on " +
-              document.location.hostname, unset);
-          return unset
-        };
-        document.__CookieMonster__ = CM;
-        return CM
-      })(document);
-    </script>
-    <script>
-      (function(document, cwlobj, map, reg, value) {
-        cwlobj = {
-          "cookies": ["wpatc", "beagle", "s_vi", "de", "rplsb", "rplm2", "rplmct", "rpld0", "rpld1", "wapo_login_id", "wapo_secure_login_id", "sec_wapo_login_id", "sec_wapo_secure_login_id", "wapo_groups", "wapo_display", "wppref", "devicetype", "s_sess", "s_pers", "backplane-channel", "_chartbeat2", "_chartbeat5", "client_region", "fbuid", "fbuname", "wapo_fb_token", "adsflag", "comicsint", "galleryplays", "homessoldcookie", "wapo_provider", "washingtonpost_avatar", "weather-preroll", "wpnisecure",
-            "x-wp-split", "x-split-override", "region_cookie", "rplpwmode", "rplrol", "wapo_actmgmt", "wapo_az_id", "sailthru_hid", "sailthru_bid", "__gads", "osfam", "wp_vi", "pwamtk", "drawbridge_o", "drawbridge_test", "debug_pwapi_ipdomainon", "comscore", "rplampr", "googleampredirectdebugoverride", "iabc", "comments_sortorder", "drdebugoverride", "_ga", "ddosdebugoverride", "washpost_poe", "pwadebugversiononoff", "pwahpprocdebug", "rplabrfg", "rplabtestdebug", "wapo_ab_test", "rplabscmtr", "rplabsectionmeterdebug", "rplabuniquevisitdebug",
-            "ptvenv", "rplpwabt2", "rplpwtrk", "pwabtestdebug", "rplpwabt3", "rplpwabt4", "amp_exp", "^fbm_.*", "^fbsr_.*", "^wordpress_.*", "sub$", "element-impression-debug", "^powaBucket_.*", "^wp.*"
-          ]
-        };
-        map = map || [];
-        reg = reg || [];
-        for (var i = 0; i < cwlobj.cookies.length, value = cwlobj.cookies[i]; i++)
-          if ("^" == value[0]) reg.push(new RegExp(value));
-          else map.push(value);
-        document.__twpCookieMonster__ = new document.__CookieMonster__(map, reg)
-      })(document);
-    </script>
-    <script>
-      var TWP_Debug = window.TWP_Debug || {};
-      TWP_Debug.initialTime = new Date;
-    </script>
-    <meta name="object-hash" content="1556472614">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta charset="utf-8">
-    <meta id="viewport" name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, minimum-scale=0.5, maximum-scale=2.0">
-    <meta name="referrer" content="unsafe-url">
-    <meta name="keywords" content="twitter, .@ twitter, twitter replies, twitter character limit">
-    <meta name="news_keywords" content="twitter, .@ twitter, twitter replies, twitter character limit">
-    <meta name="twitter:site" value="@WashingtonPost">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="og:type" content="article">
-    <meta property="og:site_name" content="Washington Post">
-    <meta itemprop="mainEntityOfPage" content="True">
-    <meta name="magnet" content>
-    <meta property="article:publisher" content="https://www.facebook.com/washingtonpost">
-    <meta property="fb:app_id" content="41245586762">
-    <meta property="fb:admins" content="4403963">
-    <meta property="fb:admins" content="500835072">
-    <meta property="article:content_tier" content="metered">
-    <script type="application/ld+json">
-      {
-        "@context": "http://schema.org",
-        "@type": "ReportageNewsArticle",
-        "mainEntityOfPage": {
-          "@type": "WebPage",
-          "@id": "https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/"
-        },
-        "headline": "Twitter says goodbye to all ‘.@’",
-        "description": "Twitter announced a series of changes that will make the site easier to use.",
-        "image": ["https://www.washingtonpost.com/resizer/koHP6G-N-IEesDnQ2qlC-c3G7H4=/1484x0/arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YU7K4QHOU45NXLUUOZBD64ZCM4.jpg"],
-        "datePublished": "2016-05-24T18:20:48Z",
-        "dateModified": "2016-05-24T18:20:48Z",
-        "isAccessibleForFree": false,
-        "hasPart": {
-          "@type": "WebPageElement",
-          "isAccessibleForFree": false,
-          "cssSelector": ".paywall"
-        },
-        "isPartOf": {
-          "@type": ["CreativeWork", "Product"],
-          "name": "The Washington Post",
-          "productID": "washingtonpost.com:basic"
-        },
-        "publisher": {
-          "@type": "NewsMediaOrganization",
-          "name": "The Washington Post",
-          "ethicsPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "masthead": "https://www.washingtonpost.com/policies-and-standards/masthead/",
-          "missionCoveragePrioritiesPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "diversityPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "correctionsPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "verificationFactCheckingPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "unnamedSourcesPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "actionableFeedbackPolicy": "https://www.washingtonpost.com/policies-and-standards/",
-          "foundingDate": "1877-12-06",
-          "ownershipFundingGrants": "https://www.washingtonpost.com/policies-and-standards/",
-          "diversityStaffingReport": "http://asne.org/newsroom_diversitysurvey",
-          "refLocalNationalRequirements": null,
-          "logo": {
-            "@type": "ImageObject",
-            "url": "https://www.washingtonpost.com/pb/resources/img/thewashingtonpost-black-400x60.png"
-          }
-        }
+<html lang="en">
+<div id="51a574dd-0bb6-494b-b4e5-2470cedc353d" style="display: none;">
+  {"method":"get","path":"self.navigator.globalPrivacyControl","level":"info","category":"navigator","jsContextId":"ab05af6d-79b5-45ff-aa6e-164ce8cca161","url":"https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/","stack":[{"functionName":"e.value","fileName":"https://www.washingtonpost.com/zeus/main.js","lineNumber":"2","columnNumber":"265175"},{"functionName":"e.value","fileName":"https://www.washingtonpost.com/zeus/main.js","lineNumber":"2","columnNumber":"266007"},{"functionName":"e.value","fileName":"https://www.washingtonpost.com/zeus/main.js","lineNumber":"2","columnNumber":"252836"},{"functionName":"new
+  e","fileName":"https://www.washingtonpost.com/zeus/main.js","lineNumber":"2","columnNumber":"252548"},{"functionName":"Object.t.init","fileName":"https://www.washingtonpost.com/zeus/main.js","lineNumber":"2","columnNumber":"254458"},{"fileName":"https://www.washingtonpost.com/zeus/main.js","lineNumber":"2","columnNumber":"163291"}]}
+</div>
+
+<head>
+  <title>Twitter says goodbye to all ‘.@’ - The Washington Post</title>
+  <meta name="description" content="Twitter announced a series of changes that will make the site easier to use. ">
+  <meta property="og:site_name" content="Washington Post">
+  <meta property="og:type" content="article">
+  <meta property="og:url"
+    content="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
+  <meta property="og:image"
+    content="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YU7K4QHOU45NXLUUOZBD64ZCM4.jpg&amp;w=1440">
+  <meta property="og:title" content="Twitter says goodbye to all ‘.@’">
+  <meta property="og:description"
+    content="Twitter announced a series of changes that will make the site easier to use. ">
+  <meta property="twitter:site" content="@WashingtonPost">
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:title" content="Twitter says goodbye to all ‘.@’">
+  <meta property="twitter:description"
+    content="Twitter announced a series of changes that will make the site easier to use. ">
+  <meta name="last_updated_date" content="2019-04-28T17:30:14.537Z">
+  <meta property="article:published_time" content="2016-05-24T18:20:48Z">
+  <meta property="article:modified_time" content="2019-04-28T17:30:14.537Z">
+  <meta property="article:section" content="Internet Culture">
+  <meta property="article:content_tier" content="metered">
+  <meta property="article:opinion" content="false">
+  <meta name="robots" content="max-image-preview:large">
+  <script src="https://browser.sentry-cdn.com/5.30.0/bundle.min.js"></script>
+  <script async="" src="https://www.googleoptimize.com/optimize.js?id=GTM-TB6VDCH"></script>
+  <script async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-WHNNX8B"></script>
+  <script type="application/ld+json"
+    data-qa="schema">{"@context":"http://schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/"},"headline":"Twitter says goodbye to all ‘.@’","datePublished":"2016-05-24T18:20:48Z","dateModified":"2016-05-24T18:20:48Z","description":"Twitter announced a series of changes that will make the site easier to use. ","author":{"@type":"Person","name":"Abby Ohlheiser"},"isPartOf":{"@type":["CreativeWork","Product"],"name":"The Washington Post","productID":"washingtonpost.com:basic","description":"Breaking news and analysis on politics, business, world, national news, entertainment and more. In-depth DC, Virginia, Maryland news coverage including traffic, weather, crime, education, restaurant reviews and more.","sku":"https://subscribe.washingtonpost.com","image":"https://www.washingtonpost.com/resizer/2CjPNwqvXHPS_2RpuRTKY-p3eVo=/1484x0/www.washingtonpost.com/pb/resources/img/twp-social-share.png","brand":{"@type":"brand","name":"The Washington Post"},"offers":{"@type":"offer","url":"https://subscribe.washingtonpost.com/acquisition?promo=o26"}},"publisher":{"@id":"washingtonpost.com","@type":"NewsMediaOrganization","name":"The Washington Post","logo":{"@type":"ImageObject","url":"https://www.washingtonpost.com/wp-stat/img/wplogo_344x60_blk.png","width":344,"height":60}},"isAccessibleForFree":false,"image":{"@type":"ImageObject","url":"https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YU7K4QHOU45NXLUUOZBD64ZCM4.jpg&w=1200"}}</script>
+  <link rel="amphtml"
+    href="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/?outputType=amp">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="canonical"
+    href="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
+  <link hreflang="en" href="https://www.washingtonpost.com">
+  <link rel="preload" as="image"
+    href="https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg"
+    imagesrcset="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=440 400w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=540 540w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=691 691w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=767 767w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=916 916w"
+    imagesizes="(max-width: 440px) 440px,(max-width: 600px) 691px,(max-width: 768px) 691px,(min-width: 769px) and (max-width: 1023px) 960px,(min-width: 1024px) and (max-width: 1299px) 530px,(min-width: 1300px) and (max-width: 1439px) 691px,(min-width: 1440px) 916px,440px">
+  <link rel="preload" as="font" crossorigin="crossorigin"
+    href="https://www.washingtonpost.com/wp-stat/assets/fonts/PostoniWide-Bold.woff2">
+  <link rel="preload" as="font" crossorigin="crossorigin"
+    href="https://www.washingtonpost.com/wp-stat/assets/fonts/ITC_Franklin-Bold.woff2">
+  <link rel="preload" as="font" crossorigin="crossorigin"
+    href="https://www.washingtonpost.com/wp-stat/assets/fonts/ITC_Franklin-Light.woff2">
+  <style>
+    :root {
+      --color-brand-blue-normal: #1955a5;
+      --color-brand-blue-dark: #172a52;
+      --color-brand-blue-bright: #3d73d5;
+      --color-brand-blue-pale: #dde6f2;
+      --color-ui-white: #fff;
+      --color-ui-offwhite: #f7f7f7;
+      --color-ui-black: #000;
+      --color-ui-offblack: #111;
+      --color-ui-gray-lightest: #f0f0f0;
+      --color-ui-gray-lighter: #e9e9e9;
+      --color-ui-gray-light: #d5d5d5;
+      --color-ui-gray-base: #aaa;
+      --color-ui-gray-dark: #666;
+      --color-ui-gray-darker: #333;
+      --color-ui-gray-darkest: #2a2a2a;
+      --color-ui-red-normal: #ea0017;
+      --color-ui-red-dark: #d10000;
+      --color-ui-red-bright: #f27b81;
+      --color-ui-red-pale: #f2dede;
+      --color-ui-orange-normal: #f29f18;
+      --color-ui-orange-dark: #b16e00;
+      --color-ui-orange-bright: #ffb743;
+      --color-ui-orange-pale: #fbedd5;
+      --color-ui-green-normal: #61a125;
+      --color-ui-green-dark: #498a0c;
+      --color-ui-green-bright: #aede7d;
+      --color-ui-green-pale: #dfecd3;
+      --color-corporate-amazon-normal: #f90;
+      --color-corporate-amazon-hover: #f90;
+      --color-corporate-facebook-normal: #3b5998;
+      --color-corporate-facebook-hover: #5a78b4;
+      --color-corporate-twitter-normal: #55acee;
+      --color-corporate-twitter-hover: #5fc0ff;
+      --color-corporate-pinterest: #bd081c;
+      --color-corporate-linkedin: #0077b5;
+      --color-opinion-gold-normal: #9e6105;
+      --color-opinion-gold-bright: #d39e4c;
+      --color-opinion-gold-dark: #7b4e0b;
+      --color-subscription-blue-normal: #166dfc;
+      --color-subscription-blue-dark: #039;
+      --color-subscription-blue-bright: #5193ff;
+      --color-subscription-blue-pale: #eff5ff;
+      --color-subscription-pink-normal: #b0578c;
+      --color-subscription-pink-dark: #853b67;
+      --color-subscription-pink-bright: #e3a7cb;
+      --color-subscription-pink-pale: #fef4fa;
+      --color-subscription-green-normal: #1c7c4e;
+      --color-subscription-green-dark: #0b5733;
+      --color-subscription-green-bright: #439e73;
+      --color-subscription-green-pale: #eff5f2;
+      --color-subscription-navy-normal: #0c198a;
+      --color-subscription-navy-dark: #0e1555;
+      --color-subscription-navy-bright: #3846c1;
+      --size-spacing-xxs: 4px;
+      --size-spacing-xs: 8px;
+      --size-spacing-sm: 16px;
+      --size-spacing-md: 24px;
+      --size-spacing-lg: 32px;
+      --size-spacing-lg-mod: 40px;
+      --size-spacing-xl: 48px;
+      --size-spacing-xxl: 64px;
+      --size-spacing-xxl-mod: 80px;
+      --shadow-card: 0px 2px 0px 0px #d5d5d5;
+      --shadow-xs: 0px 1px 2px 0px hsla(0, 0%, 40%, 0.25);
+      --shadow-sm: 0px 2px 4px 0px hsla(0, 0%, 40%, 0.25);
+      --shadow-md: 0px 4px 8px 0px hsla(0, 0%, 40%, 0.25);
+      --shadow-lg: 0px 8px 16px 0px hsla(0, 0%, 40%, 0.25);
+      --shadow-xl: 0px 16px 32px 0px hsla(0, 0%, 40%, 0.25);
+      --white: #fff;
+      --white-alpha-50: hsla(0, 0%, 100%, 0.5);
+      --offwhite: #f7f7f7;
+      --black: #000;
+      --offblack: #111;
+      --gray-light: #d5d5d5;
+      --gray-lighter: #e9e9e9;
+      --gray-lightest: #f0f0f0;
+      --gray: #aaa;
+      --gray-dark: #666;
+      --gray-darker: #333;
+      --gray-darkest: #2a2a2a;
+      --gray-darkest-alpha-50: rgba(42, 42, 42, 0.5);
+      --gray-darkest-alpha-25: rgba(42, 42, 42, 0.25);
+      --blue: #1955a5;
+      --blue-hover: #3d73d5;
+      --blue-dark: #182d57;
+      --success-green: #61a125;
+      --success-green-tint: #dfecd3;
+      --red: #ea0017;
+      --red-dark: #d10000;
+      --red-bright: #f27b81;
+      --red-pale: #f2dede;
+      --subs-blue: #166dfc;
+      --subs-blue-dark: #039;
+      --subs-blue-bright: #5193ff;
+      --subs-blue-pale: #eff5ff;
+      --subs-pink: #b0578c;
+      --subs-pink-dark: #853b67;
+      --subs-pink-bright: #e3a7cb;
+      --subs-pink-pale: #fef4fa;
+      --subs-green: #1c7c4e;
+      --subs-green-dark: #0b5733;
+      --subs-green-bright: #439e73;
+      --subs-green-pale: #eff5f2;
+      --subs-navy: #0c198a;
+      --subs-navy-dark: #0e1555;
+      --subs-navy-bright: #3846c1;
+      --xxs: 4px;
+      --xs: 8px;
+      --sm: 16px;
+      --md: 24px;
+      --lg: 32px;
+      --lg-mod: 40px;
+      --xl: 48px;
+      --xxl: 64px;
+      --xxl-mod: 80px;
+      --font-weight-heavy: 800;
+      --font-weight-medium: 700;
+      --font-weight-light: 300;
+      --line-height-medium: 1.25;
+      --line-height-xl: 2;
+      --line-height-xxl: 2.4;
+      --font-size-xxxs: 0.875rem;
+      --font-size-xxs: 1rem;
+      --font-size-small: 1.25rem;
+      --font-size-medium: 1.5rem;
+      --font-size-medium-variant-three: 2rem
+    }
+
+    body,
+    figure,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+      margin: 0
+    }
+
+    h1 {
+      font-size: 2rem
+    }
+
+    h2 {
+      font-size: 1rem
+    }
+
+    a {
+      color: var(--blue)
+    }
+
+    :root {
+      --primary-border-color: var(--color-ui-gray-lighter);
+      --secondary-border-color: var(--color-ui-black);
+      --primary-border-width: 1px
+    }
+
+    .b,
+    .b-hover:hover {
+      border: var(--primary-border-width) solid var(--primary-border-color)
+    }
+
+    .bc-secondary {
+      border-color: var(--secondary-border-color)
+    }
+
+    .bc-inherit {
+      border-color: inherit
+    }
+
+    .bc-transparent {
+      border-color: transparent
+    }
+
+    .bc-white-20 {
+      border-color: hsla(0, 0%, 100%, .2)
+    }
+
+    .bw-0 {
+      border-width: 0
+    }
+
+    .bw {
+      border-width: 1px
+    }
+
+    .bw-thin {
+      border-width: 2px
+    }
+
+    .bw-thick {
+      border-width: 4px
+    }
+
+    .bt,
+    .bt-hover:hover,
+    .last\:bt:last-child {
+      border-bottom: 0
+    }
+
+    .bb,
+    .bb-hover:hover,
+    .bt {
+      border-left: 0;
+      border-right: 0
+    }
+
+    .bb,
+    .bb-hover:hover {
+      border-top: 0
+    }
+
+    .bl {
+      border-right: 0
+    }
+
+    .bl,
+    .br {
+      border-bottom: 0;
+      border-top: 0
+    }
+
+    .bh,
+    .br {
+      border-left: 0
+    }
+
+    .bh {
+      border-right: 0
+    }
+
+    .b-none {
+      border: 0
+    }
+
+    .b-dotted {
+      border-style: dotted
+    }
+
+    .b-solid {
+      border-style: solid
+    }
+
+    .brad-2 {
+      border-radius: 2px
+    }
+
+    .brad-3 {
+      border-radius: 3px
+    }
+
+    .brad-4 {
+      border-radius: 4px
+    }
+
+    .brad-8 {
+      border-radius: 8px
+    }
+
+    .brad-50 {
+      border-radius: 50%
+    }
+
+    .brad-11 {
+      border-radius: 11px
+    }
+
+    .brad-md {
+      border-radius: 16px
+    }
+
+    .brad-lg {
+      border-radius: 20px
+    }
+
+    .brad-xl {
+      border-radius: 28px
+    }
+
+    .brad-tl-0 {
+      border-top-left-radius: 0
+    }
+
+    .brad-tr-0 {
+      border-top-right-radius: 0
+    }
+
+    .brad-bl-0 {
+      border-bottom-left-radius: 0
+    }
+
+    .brad-br-0 {
+      border-bottom-right-radius: 0
+    }
+
+    .bc-white-alpha-50 {
+      border-color: var(--white-alpha-50)
+    }
+
+    .focus-bc-gray-darkest-alpha-25 {
+      border-color: var(--gray-darkest-alpha-25)
+    }
+
+    .focus-bc-gray-darkest-alpha-50 {
+      border-color: var(--gray-darkest-alpha-50)
+    }
+
+    .bw-sibling+.bw-l-sibling {
+      border-left-width: 0
+    }
+
+    .bg-blue {
+      background-color: var(--color-brand-blue-normal)
+    }
+
+    .blue {
+      color: var(--color-brand-blue-normal)
+    }
+
+    .bc-blue {
+      border-color: var(--color-brand-blue-normal)
+    }
+
+    .fill-blue,
+    .hover-fill-blue:hover {
+      fill: var(--color-brand-blue-normal)
+    }
+
+    .hover-blue:hover {
+      color: var(--color-brand-blue-normal)
+    }
+
+    .focus-bg-blue:focus,
+    .hover-bg-blue:hover {
+      background-color: var(--color-brand-blue-normal)
+    }
+
+    .focus-bc-blue:focus {
+      border-color: var(--color-brand-blue-normal)
+    }
+
+    .bg-blue-dark {
+      background-color: var(--color-brand-blue-dark)
+    }
+
+    .blue-dark {
+      color: var(--color-brand-blue-dark)
+    }
+
+    .bc-blue-dark {
+      border-color: var(--color-brand-blue-dark)
+    }
+
+    .fill-blue-dark,
+    .hover-fill-blue-dark:hover {
+      fill: var(--color-brand-blue-dark)
+    }
+
+    .hover-blue-dark:hover {
+      color: var(--color-brand-blue-dark)
+    }
+
+    .focus-bg-blue-dark:focus,
+    .hover-bg-blue-dark:hover {
+      background-color: var(--color-brand-blue-dark)
+    }
+
+    .focus-bc-blue-dark:focus {
+      border-color: var(--color-brand-blue-dark)
+    }
+
+    .bg-blue-bright {
+      background-color: var(--color-brand-blue-bright)
+    }
+
+    .blue-bright {
+      color: var(--color-brand-blue-bright)
+    }
+
+    .bc-blue-bright {
+      border-color: var(--color-brand-blue-bright)
+    }
+
+    .fill-blue-bright,
+    .hover-fill-blue-bright:hover {
+      fill: var(--color-brand-blue-bright)
+    }
+
+    .hover-blue-bright:hover {
+      color: var(--color-brand-blue-bright)
+    }
+
+    .focus-bg-blue-bright:focus,
+    .hover-bg-blue-bright:hover {
+      background-color: var(--color-brand-blue-bright)
+    }
+
+    .focus-bc-blue-bright:focus {
+      border-color: var(--color-brand-blue-bright)
+    }
+
+    .bg-blue-pale {
+      background-color: var(--color-brand-blue-pale)
+    }
+
+    .blue-pale {
+      color: var(--color-brand-blue-pale)
+    }
+
+    .bc-blue-pale {
+      border-color: var(--color-brand-blue-pale)
+    }
+
+    .fill-blue-pale,
+    .hover-fill-blue-pale:hover {
+      fill: var(--color-brand-blue-pale)
+    }
+
+    .hover-blue-pale:hover {
+      color: var(--color-brand-blue-pale)
+    }
+
+    .focus-bg-blue-pale:focus,
+    .hover-bg-blue-pale:hover {
+      background-color: var(--color-brand-blue-pale)
+    }
+
+    .focus-bc-blue-pale:focus {
+      border-color: var(--color-brand-blue-pale)
+    }
+
+    .bg-white {
+      background-color: var(--color-ui-white)
+    }
+
+    .white {
+      color: var(--color-ui-white)
+    }
+
+    .bc-white {
+      border-color: var(--color-ui-white)
+    }
+
+    .fill-white,
+    .hover-fill-white:hover {
+      fill: var(--color-ui-white)
+    }
+
+    .hover-white:hover {
+      color: var(--color-ui-white)
+    }
+
+    .focus-bg-white:focus,
+    .hover-bg-white:hover {
+      background-color: var(--color-ui-white)
+    }
+
+    .focus-bc-white:focus {
+      border-color: var(--color-ui-white)
+    }
+
+    .bg-offwhite {
+      background-color: var(--color-ui-offwhite)
+    }
+
+    .offwhite {
+      color: var(--color-ui-offwhite)
+    }
+
+    .bc-offwhite {
+      border-color: var(--color-ui-offwhite)
+    }
+
+    .fill-offwhite,
+    .hover-fill-offwhite:hover {
+      fill: var(--color-ui-offwhite)
+    }
+
+    .hover-offwhite:hover {
+      color: var(--color-ui-offwhite)
+    }
+
+    .focus-bg-offwhite:focus,
+    .hover-bg-offwhite:hover {
+      background-color: var(--color-ui-offwhite)
+    }
+
+    .focus-bc-offwhite:focus {
+      border-color: var(--color-ui-offwhite)
+    }
+
+    .bg-black {
+      background-color: var(--color-ui-black)
+    }
+
+    .black {
+      color: var(--color-ui-black)
+    }
+
+    .bc-black {
+      border-color: var(--color-ui-black)
+    }
+
+    .fill-black,
+    .hover-fill-black:hover {
+      fill: var(--color-ui-black)
+    }
+
+    .hover-black:hover {
+      color: var(--color-ui-black)
+    }
+
+    .focus-bg-black:focus,
+    .hover-bg-black:hover {
+      background-color: var(--color-ui-black)
+    }
+
+    .focus-bc-black:focus {
+      border-color: var(--color-ui-black)
+    }
+
+    .bg-offblack {
+      background-color: var(--color-ui-offblack)
+    }
+
+    .offblack {
+      color: var(--color-ui-offblack)
+    }
+
+    .bc-offblack {
+      border-color: var(--color-ui-offblack)
+    }
+
+    .fill-offblack,
+    .hover-fill-offblack:hover {
+      fill: var(--color-ui-offblack)
+    }
+
+    .hover-offblack:hover {
+      color: var(--color-ui-offblack)
+    }
+
+    .focus-bg-offblack:focus,
+    .hover-bg-offblack:hover {
+      background-color: var(--color-ui-offblack)
+    }
+
+    .focus-bc-offblack:focus {
+      border-color: var(--color-ui-offblack)
+    }
+
+    .bg-gray-lightest {
+      background-color: var(--color-ui-gray-lightest)
+    }
+
+    .gray-lightest {
+      color: var(--color-ui-gray-lightest)
+    }
+
+    .bc-gray-lightest {
+      border-color: var(--color-ui-gray-lightest)
+    }
+
+    .fill-gray-lightest,
+    .hover-fill-gray-lightest:hover {
+      fill: var(--color-ui-gray-lightest)
+    }
+
+    .hover-gray-lightest:hover {
+      color: var(--color-ui-gray-lightest)
+    }
+
+    .focus-bg-gray-lightest:focus,
+    .hover-bg-gray-lightest:hover {
+      background-color: var(--color-ui-gray-lightest)
+    }
+
+    .focus-bc-gray-lightest:focus {
+      border-color: var(--color-ui-gray-lightest)
+    }
+
+    .bg-gray-lighter {
+      background-color: var(--color-ui-gray-lighter)
+    }
+
+    .gray-lighter {
+      color: var(--color-ui-gray-lighter)
+    }
+
+    .bc-gray-lighter {
+      border-color: var(--color-ui-gray-lighter)
+    }
+
+    .fill-gray-lighter,
+    .hover-fill-gray-lighter:hover {
+      fill: var(--color-ui-gray-lighter)
+    }
+
+    .hover-gray-lighter:hover {
+      color: var(--color-ui-gray-lighter)
+    }
+
+    .focus-bg-gray-lighter:focus,
+    .hover-bg-gray-lighter:hover {
+      background-color: var(--color-ui-gray-lighter)
+    }
+
+    .focus-bc-gray-lighter:focus {
+      border-color: var(--color-ui-gray-lighter)
+    }
+
+    .bg-gray-light {
+      background-color: var(--color-ui-gray-light)
+    }
+
+    .gray-light {
+      color: var(--color-ui-gray-light)
+    }
+
+    .bc-gray-light {
+      border-color: var(--color-ui-gray-light)
+    }
+
+    .fill-gray-light,
+    .hover-fill-gray-light:hover {
+      fill: var(--color-ui-gray-light)
+    }
+
+    .hover-gray-light:hover {
+      color: var(--color-ui-gray-light)
+    }
+
+    .focus-bg-gray-light:focus,
+    .hover-bg-gray-light:hover {
+      background-color: var(--color-ui-gray-light)
+    }
+
+    .focus-bc-gray-light:focus {
+      border-color: var(--color-ui-gray-light)
+    }
+
+    .bg-gray {
+      background-color: var(--color-ui-gray-base)
+    }
+
+    .gray {
+      color: var(--color-ui-gray-base)
+    }
+
+    .bc-gray {
+      border-color: var(--color-ui-gray-base)
+    }
+
+    .fill-gray,
+    .hover-fill-gray:hover {
+      fill: var(--color-ui-gray-base)
+    }
+
+    .hover-gray:hover {
+      color: var(--color-ui-gray-base)
+    }
+
+    .focus-bg-gray:focus,
+    .hover-bg-gray:hover {
+      background-color: var(--color-ui-gray-base)
+    }
+
+    .focus-bc-gray:focus {
+      border-color: var(--color-ui-gray-base)
+    }
+
+    .bg-gray-dark {
+      background-color: var(--color-ui-gray-dark)
+    }
+
+    .gray-dark {
+      color: var(--color-ui-gray-dark)
+    }
+
+    .bc-gray-dark {
+      border-color: var(--color-ui-gray-dark)
+    }
+
+    .fill-gray-dark,
+    .hover-fill-gray-dark:hover {
+      fill: var(--color-ui-gray-dark)
+    }
+
+    .hover-gray-dark:hover {
+      color: var(--color-ui-gray-dark)
+    }
+
+    .focus-bg-gray-dark:focus,
+    .hover-bg-gray-dark:hover {
+      background-color: var(--color-ui-gray-dark)
+    }
+
+    .focus-bc-gray-dark:focus {
+      border-color: var(--color-ui-gray-dark)
+    }
+
+    .bg-gray-darker {
+      background-color: var(--color-ui-gray-darker)
+    }
+
+    .gray-darker {
+      color: var(--color-ui-gray-darker)
+    }
+
+    .bc-gray-darker {
+      border-color: var(--color-ui-gray-darker)
+    }
+
+    .fill-gray-darker,
+    .hover-fill-gray-darker:hover {
+      fill: var(--color-ui-gray-darker)
+    }
+
+    .hover-gray-darker:hover {
+      color: var(--color-ui-gray-darker)
+    }
+
+    .focus-bg-gray-darker:focus,
+    .hover-bg-gray-darker:hover {
+      background-color: var(--color-ui-gray-darker)
+    }
+
+    .focus-bc-gray-darker:focus {
+      border-color: var(--color-ui-gray-darker)
+    }
+
+    .bg-gray-darkest {
+      background-color: var(--color-ui-gray-darkest)
+    }
+
+    .gray-darkest {
+      color: var(--color-ui-gray-darkest)
+    }
+
+    .bc-gray-darkest {
+      border-color: var(--color-ui-gray-darkest)
+    }
+
+    .fill-gray-darkest,
+    .hover-fill-gray-darkest:hover {
+      fill: var(--color-ui-gray-darkest)
+    }
+
+    .hover-gray-darkest:hover {
+      color: var(--color-ui-gray-darkest)
+    }
+
+    .focus-bg-gray-darkest:focus,
+    .hover-bg-gray-darkest:hover {
+      background-color: var(--color-ui-gray-darkest)
+    }
+
+    .focus-bc-gray-darkest:focus {
+      border-color: var(--color-ui-gray-darkest)
+    }
+
+    .bg-red {
+      background-color: var(--color-ui-red-normal)
+    }
+
+    .red {
+      color: var(--color-ui-red-normal)
+    }
+
+    .bc-red {
+      border-color: var(--color-ui-red-normal)
+    }
+
+    .fill-red,
+    .hover-fill-red:hover {
+      fill: var(--color-ui-red-normal)
+    }
+
+    .hover-red:hover {
+      color: var(--color-ui-red-normal)
+    }
+
+    .focus-bg-red:focus,
+    .hover-bg-red:hover {
+      background-color: var(--color-ui-red-normal)
+    }
+
+    .focus-bc-red:focus {
+      border-color: var(--color-ui-red-normal)
+    }
+
+    .bg-red-dark {
+      background-color: var(--color-ui-red-dark)
+    }
+
+    .red-dark {
+      color: var(--color-ui-red-dark)
+    }
+
+    .bc-red-dark {
+      border-color: var(--color-ui-red-dark)
+    }
+
+    .fill-red-dark,
+    .hover-fill-red-dark:hover {
+      fill: var(--color-ui-red-dark)
+    }
+
+    .hover-red-dark:hover {
+      color: var(--color-ui-red-dark)
+    }
+
+    .focus-bg-red-dark:focus,
+    .hover-bg-red-dark:hover {
+      background-color: var(--color-ui-red-dark)
+    }
+
+    .focus-bc-red-dark:focus {
+      border-color: var(--color-ui-red-dark)
+    }
+
+    .bg-red-bright {
+      background-color: var(--color-ui-red-bright)
+    }
+
+    .red-bright {
+      color: var(--color-ui-red-bright)
+    }
+
+    .bc-red-bright {
+      border-color: var(--color-ui-red-bright)
+    }
+
+    .fill-red-bright,
+    .hover-fill-red-bright:hover {
+      fill: var(--color-ui-red-bright)
+    }
+
+    .hover-red-bright:hover {
+      color: var(--color-ui-red-bright)
+    }
+
+    .focus-bg-red-bright:focus,
+    .hover-bg-red-bright:hover {
+      background-color: var(--color-ui-red-bright)
+    }
+
+    .focus-bc-red-bright:focus {
+      border-color: var(--color-ui-red-bright)
+    }
+
+    .bg-red-pale {
+      background-color: var(--color-ui-red-pale)
+    }
+
+    .red-pale {
+      color: var(--color-ui-red-pale)
+    }
+
+    .bc-red-pale {
+      border-color: var(--color-ui-red-pale)
+    }
+
+    .fill-red-pale,
+    .hover-fill-red-pale:hover {
+      fill: var(--color-ui-red-pale)
+    }
+
+    .hover-red-pale:hover {
+      color: var(--color-ui-red-pale)
+    }
+
+    .focus-bg-red-pale:focus,
+    .hover-bg-red-pale:hover {
+      background-color: var(--color-ui-red-pale)
+    }
+
+    .focus-bc-red-pale:focus {
+      border-color: var(--color-ui-red-pale)
+    }
+
+    .bg-orange {
+      background-color: var(--color-ui-orange-normal)
+    }
+
+    .orange {
+      color: var(--color-ui-orange-normal)
+    }
+
+    .bc-orange {
+      border-color: var(--color-ui-orange-normal)
+    }
+
+    .fill-orange,
+    .hover-fill-orange:hover {
+      fill: var(--color-ui-orange-normal)
+    }
+
+    .hover-orange:hover {
+      color: var(--color-ui-orange-normal)
+    }
+
+    .focus-bg-orange:focus,
+    .hover-bg-orange:hover {
+      background-color: var(--color-ui-orange-normal)
+    }
+
+    .focus-bc-orange:focus {
+      border-color: var(--color-ui-orange-normal)
+    }
+
+    .bg-orange-dark {
+      background-color: var(--color-ui-orange-dark)
+    }
+
+    .orange-dark {
+      color: var(--color-ui-orange-dark)
+    }
+
+    .bc-orange-dark {
+      border-color: var(--color-ui-orange-dark)
+    }
+
+    .fill-orange-dark,
+    .hover-fill-orange-dark:hover {
+      fill: var(--color-ui-orange-dark)
+    }
+
+    .hover-orange-dark:hover {
+      color: var(--color-ui-orange-dark)
+    }
+
+    .focus-bg-orange-dark:focus,
+    .hover-bg-orange-dark:hover {
+      background-color: var(--color-ui-orange-dark)
+    }
+
+    .focus-bc-orange-dark:focus {
+      border-color: var(--color-ui-orange-dark)
+    }
+
+    .bg-orange-bright {
+      background-color: var(--color-ui-orange-bright)
+    }
+
+    .orange-bright {
+      color: var(--color-ui-orange-bright)
+    }
+
+    .bc-orange-bright {
+      border-color: var(--color-ui-orange-bright)
+    }
+
+    .fill-orange-bright,
+    .hover-fill-orange-bright:hover {
+      fill: var(--color-ui-orange-bright)
+    }
+
+    .hover-orange-bright:hover {
+      color: var(--color-ui-orange-bright)
+    }
+
+    .focus-bg-orange-bright:focus,
+    .hover-bg-orange-bright:hover {
+      background-color: var(--color-ui-orange-bright)
+    }
+
+    .focus-bc-orange-bright:focus {
+      border-color: var(--color-ui-orange-bright)
+    }
+
+    .bg-orange-pale {
+      background-color: var(--color-ui-orange-pale)
+    }
+
+    .orange-pale {
+      color: var(--color-ui-orange-pale)
+    }
+
+    .bc-orange-pale {
+      border-color: var(--color-ui-orange-pale)
+    }
+
+    .fill-orange-pale,
+    .hover-fill-orange-pale:hover {
+      fill: var(--color-ui-orange-pale)
+    }
+
+    .hover-orange-pale:hover {
+      color: var(--color-ui-orange-pale)
+    }
+
+    .focus-bg-orange-pale:focus,
+    .hover-bg-orange-pale:hover {
+      background-color: var(--color-ui-orange-pale)
+    }
+
+    .focus-bc-orange-pale:focus {
+      border-color: var(--color-ui-orange-pale)
+    }
+
+    .bg-green {
+      background-color: var(--color-ui-green-normal)
+    }
+
+    .green {
+      color: var(--color-ui-green-normal)
+    }
+
+    .bc-green {
+      border-color: var(--color-ui-green-normal)
+    }
+
+    .fill-green,
+    .hover-fill-green:hover {
+      fill: var(--color-ui-green-normal)
+    }
+
+    .hover-green:hover {
+      color: var(--color-ui-green-normal)
+    }
+
+    .focus-bg-green:focus,
+    .hover-bg-green:hover {
+      background-color: var(--color-ui-green-normal)
+    }
+
+    .focus-bc-green:focus {
+      border-color: var(--color-ui-green-normal)
+    }
+
+    .bg-green-dark {
+      background-color: var(--color-ui-green-dark)
+    }
+
+    .green-dark {
+      color: var(--color-ui-green-dark)
+    }
+
+    .bc-green-dark {
+      border-color: var(--color-ui-green-dark)
+    }
+
+    .fill-green-dark,
+    .hover-fill-green-dark:hover {
+      fill: var(--color-ui-green-dark)
+    }
+
+    .hover-green-dark:hover {
+      color: var(--color-ui-green-dark)
+    }
+
+    .focus-bg-green-dark:focus,
+    .hover-bg-green-dark:hover {
+      background-color: var(--color-ui-green-dark)
+    }
+
+    .focus-bc-green-dark:focus {
+      border-color: var(--color-ui-green-dark)
+    }
+
+    .bg-green-bright {
+      background-color: var(--color-ui-green-bright)
+    }
+
+    .green-bright {
+      color: var(--color-ui-green-bright)
+    }
+
+    .bc-green-bright {
+      border-color: var(--color-ui-green-bright)
+    }
+
+    .fill-green-bright,
+    .hover-fill-green-bright:hover {
+      fill: var(--color-ui-green-bright)
+    }
+
+    .hover-green-bright:hover {
+      color: var(--color-ui-green-bright)
+    }
+
+    .focus-bg-green-bright:focus,
+    .hover-bg-green-bright:hover {
+      background-color: var(--color-ui-green-bright)
+    }
+
+    .focus-bc-green-bright:focus {
+      border-color: var(--color-ui-green-bright)
+    }
+
+    .bg-green-pale {
+      background-color: var(--color-ui-green-pale)
+    }
+
+    .green-pale {
+      color: var(--color-ui-green-pale)
+    }
+
+    .bc-green-pale {
+      border-color: var(--color-ui-green-pale)
+    }
+
+    .fill-green-pale,
+    .hover-fill-green-pale:hover {
+      fill: var(--color-ui-green-pale)
+    }
+
+    .hover-green-pale:hover {
+      color: var(--color-ui-green-pale)
+    }
+
+    .focus-bg-green-pale:focus,
+    .hover-bg-green-pale:hover {
+      background-color: var(--color-ui-green-pale)
+    }
+
+    .focus-bc-green-pale:focus {
+      border-color: var(--color-ui-green-pale)
+    }
+
+    .bg-gold {
+      background-color: var(--color-opinion-gold-normal)
+    }
+
+    .gold {
+      color: var(--color-opinion-gold-normal)
+    }
+
+    .bc-gold {
+      border-color: var(--color-opinion-gold-normal)
+    }
+
+    .fill-gold,
+    .hover-fill-gold:hover {
+      fill: var(--color-opinion-gold-normal)
+    }
+
+    .hover-gold:hover {
+      color: var(--color-opinion-gold-normal)
+    }
+
+    .focus-bg-gold:focus,
+    .hover-bg-gold:hover {
+      background-color: var(--color-opinion-gold-normal)
+    }
+
+    .focus-bc-gold:focus {
+      border-color: var(--color-opinion-gold-normal)
+    }
+
+    .bg-gold-bright {
+      background-color: var(--color-opinion-gold-bright)
+    }
+
+    .gold-bright {
+      color: var(--color-opinion-gold-bright)
+    }
+
+    .bc-gold-bright {
+      border-color: var(--color-opinion-gold-bright)
+    }
+
+    .fill-gold-bright,
+    .hover-fill-gold-bright:hover {
+      fill: var(--color-opinion-gold-bright)
+    }
+
+    .hover-gold-bright:hover {
+      color: var(--color-opinion-gold-bright)
+    }
+
+    .focus-bg-gold-bright:focus,
+    .hover-bg-gold-bright:hover {
+      background-color: var(--color-opinion-gold-bright)
+    }
+
+    .focus-bc-gold-bright:focus {
+      border-color: var(--color-opinion-gold-bright)
+    }
+
+    .bg-gold-dark {
+      background-color: var(--color-opinion-gold-dark)
+    }
+
+    .gold-dark {
+      color: var(--color-opinion-gold-dark)
+    }
+
+    .bc-gold-dark {
+      border-color: var(--color-opinion-gold-dark)
+    }
+
+    .fill-gold-dark,
+    .hover-fill-gold-dark:hover {
+      fill: var(--color-opinion-gold-dark)
+    }
+
+    .hover-gold-dark:hover {
+      color: var(--color-opinion-gold-dark)
+    }
+
+    .focus-bg-gold-dark:focus,
+    .hover-bg-gold-dark:hover {
+      background-color: var(--color-opinion-gold-dark)
+    }
+
+    .focus-bc-gold-dark:focus {
+      border-color: var(--color-opinion-gold-dark)
+    }
+
+    .subs-theme.bg-blue {
+      background-color: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.blue {
+      color: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.bc-blue {
+      border-color: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.fill-blue,
+    .subs-theme.hover-fill-blue:hover {
+      fill: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.hover-blue:hover {
+      color: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.focus-bg-blue:focus,
+    .subs-theme.hover-bg-blue:hover {
+      background-color: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.focus-bc-blue:focus {
+      border-color: var(--color-subscription-blue-normal)
+    }
+
+    .subs-theme.bg-blue-dark {
+      background-color: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.blue-dark {
+      color: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.bc-blue-dark {
+      border-color: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.fill-blue-dark,
+    .subs-theme.hover-fill-blue-dark:hover {
+      fill: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.hover-blue-dark:hover {
+      color: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.focus-bg-blue-dark:focus,
+    .subs-theme.hover-bg-blue-dark:hover {
+      background-color: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.focus-bc-blue-dark:focus {
+      border-color: var(--color-subscription-blue-dark)
+    }
+
+    .subs-theme.bg-blue-bright {
+      background-color: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.blue-bright {
+      color: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.bc-blue-bright {
+      border-color: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.fill-blue-bright,
+    .subs-theme.hover-fill-blue-bright:hover {
+      fill: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.hover-blue-bright:hover {
+      color: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.focus-bg-blue-bright:focus,
+    .subs-theme.hover-bg-blue-bright:hover {
+      background-color: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.focus-bc-blue-bright:focus {
+      border-color: var(--color-subscription-blue-bright)
+    }
+
+    .subs-theme.bg-blue-pale {
+      background-color: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.blue-pale {
+      color: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.bc-blue-pale {
+      border-color: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.fill-blue-pale,
+    .subs-theme.hover-fill-blue-pale:hover {
+      fill: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.hover-blue-pale:hover {
+      color: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.focus-bg-blue-pale:focus,
+    .subs-theme.hover-bg-blue-pale:hover {
+      background-color: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.focus-bc-blue-pale:focus {
+      border-color: var(--color-subscription-blue-pale)
+    }
+
+    .subs-theme.bg-pink {
+      background-color: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.pink {
+      color: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.bc-pink {
+      border-color: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.fill-pink,
+    .subs-theme.hover-fill-pink:hover {
+      fill: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.hover-pink:hover {
+      color: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.focus-bg-pink:focus,
+    .subs-theme.hover-bg-pink:hover {
+      background-color: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.focus-bc-pink:focus {
+      border-color: var(--color-subscription-pink-normal)
+    }
+
+    .subs-theme.bg-pink-dark {
+      background-color: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.pink-dark {
+      color: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.bc-pink-dark {
+      border-color: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.fill-pink-dark,
+    .subs-theme.hover-fill-pink-dark:hover {
+      fill: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.hover-pink-dark:hover {
+      color: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.focus-bg-pink-dark:focus,
+    .subs-theme.hover-bg-pink-dark:hover {
+      background-color: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.focus-bc-pink-dark:focus {
+      border-color: var(--color-subscription-pink-dark)
+    }
+
+    .subs-theme.bg-pink-bright {
+      background-color: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.pink-bright {
+      color: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.bc-pink-bright {
+      border-color: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.fill-pink-bright,
+    .subs-theme.hover-fill-pink-bright:hover {
+      fill: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.hover-pink-bright:hover {
+      color: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.focus-bg-pink-bright:focus,
+    .subs-theme.hover-bg-pink-bright:hover {
+      background-color: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.focus-bc-pink-bright:focus {
+      border-color: var(--color-subscription-pink-bright)
+    }
+
+    .subs-theme.bg-pink-pale {
+      background-color: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.pink-pale {
+      color: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.bc-pink-pale {
+      border-color: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.fill-pink-pale,
+    .subs-theme.hover-fill-pink-pale:hover {
+      fill: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.hover-pink-pale:hover {
+      color: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.focus-bg-pink-pale:focus,
+    .subs-theme.hover-bg-pink-pale:hover {
+      background-color: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.focus-bc-pink-pale:focus {
+      border-color: var(--color-subscription-pink-pale)
+    }
+
+    .subs-theme.bg-green {
+      background-color: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.green {
+      color: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.bc-green {
+      border-color: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.fill-green,
+    .subs-theme.hover-fill-green:hover {
+      fill: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.hover-green:hover {
+      color: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.focus-bg-green:focus,
+    .subs-theme.hover-bg-green:hover {
+      background-color: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.focus-bc-green:focus {
+      border-color: var(--color-subscription-green-normal)
+    }
+
+    .subs-theme.bg-green-dark {
+      background-color: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.green-dark {
+      color: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.bc-green-dark {
+      border-color: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.fill-green-dark,
+    .subs-theme.hover-fill-green-dark:hover {
+      fill: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.hover-green-dark:hover {
+      color: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.focus-bg-green-dark:focus,
+    .subs-theme.hover-bg-green-dark:hover {
+      background-color: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.focus-bc-green-dark:focus {
+      border-color: var(--color-subscription-green-dark)
+    }
+
+    .subs-theme.bg-green-bright {
+      background-color: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.green-bright {
+      color: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.bc-green-bright {
+      border-color: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.fill-green-bright,
+    .subs-theme.hover-fill-green-bright:hover {
+      fill: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.hover-green-bright:hover {
+      color: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.focus-bg-green-bright:focus,
+    .subs-theme.hover-bg-green-bright:hover {
+      background-color: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.focus-bc-green-bright:focus {
+      border-color: var(--color-subscription-green-bright)
+    }
+
+    .subs-theme.bg-green-pale {
+      background-color: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.green-pale {
+      color: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.bc-green-pale {
+      border-color: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.fill-green-pale,
+    .subs-theme.hover-fill-green-pale:hover {
+      fill: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.hover-green-pale:hover {
+      color: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.focus-bg-green-pale:focus,
+    .subs-theme.hover-bg-green-pale:hover {
+      background-color: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.focus-bc-green-pale:focus {
+      border-color: var(--color-subscription-green-pale)
+    }
+
+    .subs-theme.bg-navy {
+      background-color: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.navy {
+      color: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.bc-navy {
+      border-color: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.fill-navy,
+    .subs-theme.hover-fill-navy:hover {
+      fill: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.hover-navy:hover {
+      color: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.focus-bg-navy:focus,
+    .subs-theme.hover-bg-navy:hover {
+      background-color: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.focus-bc-navy:focus {
+      border-color: var(--color-subscription-navy-normal)
+    }
+
+    .subs-theme.bg-navy-dark {
+      background-color: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.navy-dark {
+      color: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.bc-navy-dark {
+      border-color: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.fill-navy-dark,
+    .subs-theme.hover-fill-navy-dark:hover {
+      fill: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.hover-navy-dark:hover {
+      color: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.focus-bg-navy-dark:focus,
+    .subs-theme.hover-bg-navy-dark:hover {
+      background-color: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.focus-bc-navy-dark:focus {
+      border-color: var(--color-subscription-navy-dark)
+    }
+
+    .subs-theme.bg-navy-bright {
+      background-color: var(--color-subscription-navy-bright)
+    }
+
+    .subs-theme.navy-bright {
+      color: var(--color-subscription-navy-bright)
+    }
+
+    .subs-theme.bc-navy-bright {
+      border-color: var(--color-subscription-navy-bright)
+    }
+
+    .subs-theme.fill-navy-bright,
+    .subs-theme.hover-fill-navy-bright:hover {
+      fill: var(--color-subscription-navy-bright)
+    }
+
+    .subs-theme.hover-navy-bright:hover {
+      color: var(--color-subscription-navy-bright)
+    }
+
+    .subs-theme.focus-bg-navy-bright:focus,
+    .subs-theme.hover-bg-navy-bright:hover {
+      background-color: var(--color-subscription-navy-bright)
+    }
+
+    .subs-theme.focus-bc-navy-bright:focus {
+      border-color: var(--color-subscription-navy-bright)
+    }
+
+    .bg-transparent {
+      background-color: initial
+    }
+
+    .bg-no-repeat {
+      background-repeat: no-repeat
+    }
+
+    .bg-right {
+      background-position: 100%
+    }
+
+    .bg-success-green {
+      background-color: var(--success-green)
+    }
+
+    .bg-success-green-tint {
+      background-color: var(--success-green-tint)
+    }
+
+    .success-green {
+      color: var(--success-green)
+    }
+
+    .focus-bg-white-alpha-50:focus,
+    .hover-bg-white-alpha-50:hover {
+      background-color: var(--white-alpha-50)
+    }
+
+    .bg-clip-content {
+      background-clip: content-box
+    }
+
+    .ma-0 {
+      margin: 0
+    }
+
+    .ma-auto {
+      margin: auto
+    }
+
+    .ma-xxs {
+      margin: var(--xxs)
+    }
+
+    .ma-xs {
+      margin: var(--xs)
+    }
+
+    .ma-sm {
+      margin: var(--sm)
+    }
+
+    .-ma-sm {
+      margin: calc(-1*var(--sm))
+    }
+
+    .ma-md {
+      margin: var(--md)
+    }
+
+    .-ma-md {
+      margin: calc(-1*var(--md))
+    }
+
+    .ma-lg {
+      margin: var(--lg)
+    }
+
+    .-ma-lg {
+      margin: calc(-1*var(--lg))
+    }
+
+    .mt-xxs {
+      margin-top: var(--xxs)
+    }
+
+    .-mt-xxs {
+      margin-top: calc(-1*var(--xxs))
+    }
+
+    .-mt-xxxs {
+      margin-top: -2px
+    }
+
+    .mt-xs {
+      margin-top: var(--xs)
+    }
+
+    .-mt-xs {
+      margin-top: calc(-1*var(--xs))
+    }
+
+    .mt-sm {
+      margin-top: var(--sm)
+    }
+
+    .-mt-sm {
+      margin-top: calc(-1*var(--sm))
+    }
+
+    .mt-md {
+      margin-top: var(--md)
+    }
+
+    .-mt-md {
+      margin-top: calc(-1*var(--md))
+    }
+
+    .mt-lg {
+      margin-top: var(--lg)
+    }
+
+    .-mt-lg {
+      margin-top: calc(-1*var(--lg))
+    }
+
+    .mt-lg-mod {
+      margin-top: var(--lg-mod)
+    }
+
+    .-mt-lg-mod {
+      margin-top: calc(-1*var(--lg-mod))
+    }
+
+    .mt-xl {
+      margin-top: var(--xl)
+    }
+
+    .-mt-xl {
+      margin-top: calc(-1*var(--xl))
+    }
+
+    .mt-xxl {
+      margin-top: var(--xxl)
+    }
+
+    .-mt-xxl {
+      margin-top: calc(-1*var(--xxl))
+    }
+
+    .mt-0 {
+      margin-top: 0
+    }
+
+    .mr-auto {
+      margin-right: auto
+    }
+
+    .mr-neg-gutter {
+      margin-right: -5vw
+    }
+
+    .mr-gutter {
+      margin-right: 5vw
+    }
+
+    .mr-xxs {
+      margin-right: var(--xxs)
+    }
+
+    .-mr-xxs {
+      margin-right: calc(-1*var(--xxs))
+    }
+
+    .mr-xs {
+      margin-right: var(--xs)
+    }
+
+    .-mr-xs {
+      margin-right: calc(-1*var(--xs))
+    }
+
+    .mr-sm {
+      margin-right: var(--sm)
+    }
+
+    .-mr-sm {
+      margin-right: calc(-1*var(--sm))
+    }
+
+    .mr-md {
+      margin-right: var(--md)
+    }
+
+    .-mr-md {
+      margin-right: calc(-1*var(--md))
+    }
+
+    .mr-lg {
+      margin-right: var(--lg)
+    }
+
+    .-mr-lg {
+      margin-right: calc(-1*var(--lg))
+    }
+
+    .mr-xl {
+      margin-right: var(--xl)
+    }
+
+    .-mr-xl {
+      margin-right: calc(-1*var(--xl))
+    }
+
+    .mr-xxl {
+      margin-right: var(--xxl)
+    }
+
+    .-mr-xxl {
+      margin-right: calc(-1*var(--xxl))
+    }
+
+    .mb-xxs {
+      margin-bottom: var(--xxs)
+    }
+
+    .-mb-xxs {
+      margin-bottom: calc(-1*var(--xxs))
+    }
+
+    .mb-xs {
+      margin-bottom: var(--xs)
+    }
+
+    .-mb-xs {
+      margin-bottom: calc(-1*var(--xs))
+    }
+
+    .mb-sm {
+      margin-bottom: var(--sm)
+    }
+
+    .-mb-sm {
+      margin-bottom: calc(-1*var(--sm))
+    }
+
+    .mb-md {
+      margin-bottom: var(--md)
+    }
+
+    .-mb-md {
+      margin-bottom: calc(-1*var(--md))
+    }
+
+    .mb-lg {
+      margin-bottom: var(--lg)
+    }
+
+    .-mb-lg {
+      margin-bottom: calc(-1*var(--lg))
+    }
+
+    .mb-lg-mod {
+      margin-bottom: var(--lg-mod)
+    }
+
+    .-mb-lg-mod {
+      margin-bottom: calc(-1*var(--lg-mod))
+    }
+
+    .mb-xl {
+      margin-bottom: var(--xl)
+    }
+
+    .-mb-xl {
+      margin-bottom: calc(-1*var(--xl))
+    }
+
+    .mb-xxl {
+      margin-bottom: var(--xxl)
+    }
+
+    .-mb-xxl {
+      margin-bottom: calc(-1*var(--xxl))
+    }
+
+    .ml-auto {
+      margin-left: auto
+    }
+
+    .ml-neg-gutter {
+      margin-left: -5vw
+    }
+
+    .ml-gutter {
+      margin-left: 5vw
+    }
+
+    .ml-0 {
+      margin-left: 0
+    }
+
+    .ml-xxs {
+      margin-left: var(--xxs)
+    }
+
+    .-ml-xxs {
+      margin-left: calc(-1*var(--xxs))
+    }
+
+    .ml-xs {
+      margin-left: var(--xs)
+    }
+
+    .-ml-xs {
+      margin-left: calc(-1*var(--xs))
+    }
+
+    .ml-sm {
+      margin-left: var(--sm)
+    }
+
+    .-ml-sm {
+      margin-left: calc(-1*var(--sm))
+    }
+
+    .ml-md {
+      margin-left: var(--md)
+    }
+
+    .-ml-md {
+      margin-left: calc(-1*var(--md))
+    }
+
+    .ml-lg {
+      margin-left: var(--lg)
+    }
+
+    .-ml-lg {
+      margin-left: calc(-1*var(--lg))
+    }
+
+    .ml-xl {
+      margin-left: var(--xl)
+    }
+
+    .-ml-xl {
+      margin-left: calc(-1*var(--xl))
+    }
+
+    .ml-xxl {
+      margin-left: var(--xxl)
+    }
+
+    .-ml-xxl {
+      margin-left: calc(-1*var(--xxl))
+    }
+
+    .pa-0 {
+      padding: 0
+    }
+
+    .pa-xxs {
+      padding: var(--xxs)
+    }
+
+    .pa-xs {
+      padding: var(--xs)
+    }
+
+    .pa-sm {
+      padding: var(--sm)
+    }
+
+    .pa-md {
+      padding: var(--md)
+    }
+
+    .pa-lg {
+      padding: var(--lg)
+    }
+
+    .pa-lgmod {
+      padding: var(--lg-mod)
+    }
+
+    .pa-xl {
+      padding: var(--xl)
+    }
+
+    .pa-xxl {
+      padding: var(--xxl)
+    }
+
+    .pa-xxlmod {
+      padding: var(--xxl-mod)
+    }
+
+    .pt-0 {
+      padding-top: 0
+    }
+
+    .pt-xxs {
+      padding-top: var(--xxs)
+    }
+
+    .pt-xs {
+      padding-top: var(--xs)
+    }
+
+    .pt-sm {
+      padding-top: var(--sm)
+    }
+
+    .pt-md {
+      padding-top: var(--md)
+    }
+
+    .pt-lg {
+      padding-top: var(--lg)
+    }
+
+    .pt-lgmod {
+      padding-top: var(--lg-mod)
+    }
+
+    .pt-xl {
+      padding-top: var(--xl)
+    }
+
+    .pt-xxl {
+      padding-top: var(--xxl)
+    }
+
+    .pt-xxlmod {
+      padding-top: var(--xxl-mod)
+    }
+
+    .pr-0 {
+      padding-right: 0
+    }
+
+    .pr-xxs {
+      padding-right: var(--xxs)
+    }
+
+    .pr-xs {
+      padding-right: var(--xs)
+    }
+
+    .pr-sm {
+      padding-right: var(--sm)
+    }
+
+    .pr-md {
+      padding-right: var(--md)
+    }
+
+    .pr-lg {
+      padding-right: var(--lg)
+    }
+
+    .pr-lgmod {
+      padding-right: var(--lg-mod)
+    }
+
+    .pr-xl {
+      padding-right: var(--xl)
+    }
+
+    .pr-xxl {
+      padding-right: var(--xxl)
+    }
+
+    .pr-xxlmod {
+      padding-right: var(--xxl-mod)
+    }
+
+    .pb-0 {
+      padding-bottom: 0
+    }
+
+    .pb-xxs {
+      padding-bottom: var(--xxs)
+    }
+
+    .pb-xs {
+      padding-bottom: var(--xs)
+    }
+
+    .pb-sm {
+      padding-bottom: var(--sm)
+    }
+
+    .pb-md {
+      padding-bottom: var(--md)
+    }
+
+    .pb-lg {
+      padding-bottom: var(--lg)
+    }
+
+    .pb-lgmod {
+      padding-bottom: var(--lg-mod)
+    }
+
+    .pb-xl {
+      padding-bottom: var(--xl)
+    }
+
+    .pb-xxl {
+      padding-bottom: var(--xxl)
+    }
+
+    .pb-xxlmod {
+      padding-bottom: var(--xxl-mod)
+    }
+
+    .pl-0 {
+      padding-left: 0
+    }
+
+    .pl-xxs {
+      padding-left: var(--xxs)
+    }
+
+    .pl-xs {
+      padding-left: var(--xs)
+    }
+
+    .pl-sm {
+      padding-left: var(--sm)
+    }
+
+    .pl-md {
+      padding-left: var(--md)
+    }
+
+    .pl-lg {
+      padding-left: var(--lg)
+    }
+
+    .pl-lgmod {
+      padding-left: var(--lg-mod)
+    }
+
+    .pl-xl {
+      padding-left: var(--xl)
+    }
+
+    .pl-xxl {
+      padding-left: var(--xxl)
+    }
+
+    .pl-xxlmod {
+      padding-left: var(--xxl-mod)
+    }
+
+    .pl-vw-sm {
+      padding-left: 5vw
+    }
+
+    .pr-vw-sm {
+      padding-right: 5vw
+    }
+
+    .right-rail>.dn:last-of-type .bb,
+    .right-rail>.dn:last-of-type .bb-hover:hover {
+      border-bottom: 0
+    }
+
+    .header-nav {
+      height: 60px;
+      top: 0;
+      transition: top .3s ease-in;
+      -webkit-font-smoothing: antialiased
+    }
+
+    .header-nav.nav-hide {
+      top: -60px
+    }
+
+    .header-nav .btn.btn-transparent {
+      background-color: initial;
+      color: #000;
+      border: none
+    }
+
+    .header-nav .btn {
+      background-color: #000;
+      border-color: transparent
+    }
+
+    .header-nav .btn,
+    .header-nav .header-nav-button-font-size {
+      font-size: 15px;
+      height: 36px
+    }
+
+    @font-face {
+      font-family: Postoni;
+      font-weight: 700;
+      font-display: fallback;
+      src: url(https://www.washingtonpost.com/wp-stat/assets/fonts/PostoniWide-Bold.woff2);
+      unicode-range: u+a, u+20-29, u+2c-5b, u+5d, u+5f, u+61-7d, u+a0, u+a9, u+c9, u+e0-e3, u+e7, u+e9, u+ea, u+ed, u+f3-f5, u+fa, u+2009, u+2013, u+2014, u+2018, u+2019, u+201c, u+201d, u+2026
+    }
+
+    @font-face {
+      font-family: Postoni;
+      font-weight: 300;
+      font-display: fallback;
+      src: url(https://www.washingtonpost.com/wp-stat/assets/fonts/PostoniWide-Regular.woff2)
+    }
+
+    @font-face {
+      font-family: Postoni;
+      font-weight: 300;
+      font-display: fallback;
+      font-style: italic;
+      src: url(https://www.washingtonpost.com/wp-stat/assets/fonts/PostoniWide-Italic.woff2)
+    }
+
+    @font-face {
+      font-family: Postoni;
+      font-weight: 700;
+      font-display: fallback;
+      font-style: italic;
+      src: url(https://www.washingtonpost.com/wp-stat/assets/fonts/PostoniWide-BoldItalic.woff2)
+    }
+
+    @font-face {
+      font-family: Franklin;
+      font-weight: 700;
+      font-display: fallback;
+      unicode-range: u+a, u+20-29, u+2c-5b, u+5d, u+5f, u+61-7d, u+a0, u+a9, u+c9, u+e0-e3, u+e7, u+e9, u+ea, u+ed, u+f3-f5, u+fa, u+2009, u+2013, u+2014, u+2018, u+2019, u+201c, u+201d, u+2026;
+      src: url(https://www.washingtonpost.com/wp-stat/assets/fonts/ITC_Franklin-Bold.woff2)
+    }
+
+    @font-face {
+      font-family: Franklin;
+      font-weight: 300;
+      font-display: fallback;
+      src: url(https://www.washingtonpost.com/wp-stat/assets/fonts/ITC_Franklin-Light.woff2);
+      unicode-range: u+a, u+20-29, u+2c-5b, u+5d, u+5f, u+61-7d, u+a0, u+a9, u+c9, u+e0-e3, u+e7, u+e9, u+ea, u+ed, u+f1, u+f3-f5, u+fa, u+2009, u+2013, u+2014, u+2018, u+2019, u+201c, u+201d, u+2026
+    }
+
+    .font--headline {
+      font-family: Postoni, BodoniSvtyTwoITCTT-Book, georgia, serif;
+      line-height: 1.1
+    }
+
+    .font--magazine-headline {
+      font-family: PostoniDisplay, Postoni, BodoniSvtyTwoITCTT-Book, georgia, serif;
+      line-height: 1.1
+    }
+
+    .font--meta-text,
+    .font--subhead {
+      font-family: Franklin, arial, sans-serif;
+      line-height: 1.25
+    }
+
+    .font--body {
+      font-family: georgia, Times New Roman, serif;
+      line-height: 1.75
+    }
+
+    .font-sans-serif {
+      font-family: Franklin, arial, sans-serif
+    }
+
+    .font-copy {
+      font-size: 1.125rem
+    }
+
+    .font-xxxxs {
+      font-size: .75rem
+    }
+
+    .font-xxxs {
+      font-size: var(--font-size-xxxs)
+    }
+
+    .font-xxs {
+      font-size: var(--font-size-xxs)
+    }
+
+    .font-xs {
+      font-size: 1.125rem
+    }
+
+    .font-sm {
+      font-size: var(--font-size-small)
+    }
+
+    .font-md {
+      font-size: var(--font-size-medium)
+    }
+
+    .font-md2 {
+      font-size: 1.75rem
+    }
+
+    .font-md3 {
+      font-size: var(--font-size-medium-variant-three)
+    }
+
+    .font-lg {
+      font-size: 2.5rem
+    }
+
+    .font-xl {
+      font-size: 3.5rem
+    }
+
+    .font-xxl {
+      font-size: 4.5rem
+    }
+
+    .font-xxxl {
+      font-size: 5rem
+    }
+
+    .font-0 {
+      font-size: 0
+    }
+
+    .bold {
+      font-weight: var(--font-weight-heavy)
+    }
+
+    .font-bold {
+      font-weight: var(--font-weight-medium)
+    }
+
+    .font-light,
+    .light {
+      font-weight: var(--font-weight-light)
+    }
+
+    .uppercase {
+      text-transform: uppercase
+    }
+
+    .capitalize {
+      text-transform: capitalize
+    }
+
+    .center {
+      text-align: center
+    }
+
+    .left {
+      text-align: left
+    }
+
+    .right {
+      text-align: right
+    }
+
+    .hover-underline:hover,
+    .underline {
+      text-decoration: underline
+    }
+
+    .strike {
+      text-decoration: line-through
+    }
+
+    .italic {
+      font-style: italic
+    }
+
+    .lh3,
+    .lh-lg {
+      line-height: 1.5
+    }
+
+    .lh-md {
+      line-height: var(--line-height-medium)
+    }
+
+    .lh-xl {
+      line-height: var(--line-height-xl)
+    }
+
+    .lh-xxl {
+      line-height: var(--line-height-xxl)
+    }
+
+    .lh-sm {
+      line-height: 1.1
+    }
+
+    .lh-default {
+      line-height: 1.75
+    }
+
+    .lh-initial {
+      line-height: normal
+    }
+
+    .lh-1 {
+      line-height: 1
+    }
+
+    .lh-0-9 {
+      line-height: .9
+    }
+
+    .lh-1-9 {
+      line-height: 1.9
+    }
+
+    .letter-spacing {
+      letter-spacing: .04em
+    }
+
+    .list-none {
+      list-style-type: none
+    }
+
+    .antialiased {
+      -moz-osx-font-smoothing: grayscale
+    }
+
+    .antialiased,
+    .btn {
+      -webkit-font-smoothing: antialiased
+    }
+
+    .btn {
+      min-width: 36px;
+      padding: 9px 16px;
+      color: var(--white);
+      font-size: var(--font-size-xxs);
+      font-weight: var(--font-weight-medium);
+      line-height: var(--line-height-medium);
+      text-align: center;
+      width: auto;
+      cursor: pointer;
+      background-color: var(--gray-darkest);
+      border: 1px solid var(--gray-dark);
+      border-radius: 2px;
+      transition: .2s ease
+    }
+
+    .btn.btn-pa-0 {
+      padding: 0
+    }
+
+    .btn.btn-selected,
+    .btn:active,
+    .btn:focus,
+    .btn:hover {
+      border-color: var(--white)
+    }
+
+    .btn.btn-sm {
+      padding-top: 5px;
+      padding-bottom: 5px
+    }
+
+    .btn.btn-lg {
+      padding-top: 17px;
+      padding-bottom: 17px
+    }
+
+    .btn.btn-black {
+      background-color: var(--black)
+    }
+
+    .btn.btn-black:active,
+    .btn.btn-black:hover,
+    .btn.btn-selected.btn-black {
+      background-color: var(--gray-dark)
+    }
+
+    .btn.btn-blue {
+      border-color: var(--blue-hover);
+      background-color: var(--blue)
+    }
+
+    .btn.btn-blue.btn-selected,
+    .btn.btn-blue:active,
+    .btn.btn-blue:hover {
+      background-color: var(--blue-hover)
+    }
+
+    .btn.btn-white {
+      color: var(--gray-darkest);
+      background-color: var(--white);
+      border: 1px solid var(--gray-light);
+      -webkit-font-smoothing: auto;
+      padding: 10px 17px
+    }
+
+    .btn.btn-white.btn-lg {
+      padding-top: 18px;
+      padding-bottom: 18px
+    }
+
+    .btn.btn-white.btn-sm {
+      padding-top: 6px;
+      padding-bottom: 6px
+    }
+
+    .btn.btn-white:hover {
+      border: 1px solid var(--gray-light)
+    }
+
+    .btn.btn-selected.btn-white,
+    .btn.btn-white:active,
+    .btn.btn-white:hover {
+      background-color: var(--gray-lightest)
+    }
+
+    .btn.btn-alert {
+      background-color: var(--red);
+      border: none
+    }
+
+    .btn.btn-alert:active,
+    .btn.btn-alert:hover,
+    .btn.btn-selected.btn-alert {
+      background-color: var(--red-bright)
+    }
+
+    .btn.btn-disabled {
+      box-shadow: none;
+      color: var(--gray);
+      cursor: default;
+      -webkit-font-smoothing: auto
+    }
+
+    .btn.btn-disabled,
+    .btn.btn-disabled:hover {
+      background-color: var(--gray-light);
+      border: none
+    }
+
+    .btn.btn-disabled:active {
+      background-color: var(--gray-light);
+      border: 2px solid transparent
+    }
+
+    .btn.btn-ghost {
+      background-color: initial;
+      border: 1px solid hsla(0, 0%, 100%, .5);
+      padding: 10px 18px;
+      box-shadow: none
+    }
+
+    .btn.btn-ghost:hover {
+      background-color: hsla(0, 0%, 100%, .2);
+      border: 1px solid transparent
+    }
+
+    .btn.btn-ghost:active,
+    .btn.btn-selected.btn-ghost {
+      background-color: hsla(0, 0%, 100%, .2);
+      border: 2px solid hsla(0, 0%, 100%, .15);
+      padding: 9px 17px
+    }
+
+    .btn.btn-sm.btn-ghost {
+      padding-top: 6px;
+      padding-bottom: 6px
+    }
+
+    .btn.btn-lg.btn-ghost {
+      padding-top: 18px;
+      padding-bottom: 18px
+    }
+
+    .btn.btn-sm.btn-ghost.btn-selected,
+    .btn.btn-sm.btn-ghost:active {
+      padding-top: 5px;
+      padding-bottom: 5px
+    }
+
+    .btn.btn-lg.btn-ghost.btn-selected,
+    .btn.btn-lg.btn-ghost:active {
+      padding-top: 17px;
+      padding-bottom: 17px
+    }
+
+    .transition-opacity {
+      transition-property: opacity
+    }
+
+    .transition-colors {
+      transition-property: background-color, border-color, color, fill, stroke
+    }
+
+    .transition-height {
+      transition-property: height, max-height, min-height
+    }
+
+    .transition-width {
+      transition-property: width, max-width, min-width
+    }
+
+    .transition-font-size {
+      transition-property: font-size
+    }
+
+    .transition-transform {
+      transition-property: transform
+    }
+
+    .transition-all {
+      transition-property: all
+    }
+
+    .transition-flex {
+      transition-property: flex
+    }
+
+    .transition-visibility {
+      transition-property: visibility
+    }
+
+    .duration-1000 {
+      transition-duration: 1s
+    }
+
+    .duration-400 {
+      transition-duration: .4s
+    }
+
+    .duration-200 {
+      transition-duration: .2s
+    }
+
+    .ease-out {
+      transition-timing-function: ease-out
+    }
+
+    .ease-in {
+      transition-timing-function: ease-in
+    }
+
+    .ease-in-out {
+      transition-timing-function: ease-in-out
+    }
+
+    .shadow {
+      box-shadow: 0 2px 0 0 rgba(0, 0, 0, .2)
+    }
+
+    .shadow-light {
+      box-shadow: 0 1px 1px 0 hsla(0, 0%, 40%, .1)
+    }
+
+    .inset-shadow {
+      box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, .5)
+    }
+
+    .no-shadow {
+      box-shadow: none
+    }
+
+    .drop-shadow {
+      filter: drop-shadow(var(--gray-light) 0 2px 10px)
+    }
+
+    .shadow-1 {
+      box-shadow: var(--shadow-card)
+    }
+
+    .shadow-2 {
+      box-shadow: var(--shadow-xs)
+    }
+
+    .shadow-3 {
+      box-shadow: var(--shadow-sm)
+    }
+
+    .shadow-4 {
+      box-shadow: var(--shadow-md)
+    }
+
+    .shadow-5 {
+      box-shadow: var(--shadow-lg)
+    }
+
+    .shadow-6 {
+      box-shadow: var(--shadow-xl)
+    }
+
+    .w-0 {
+      width: 0
+    }
+
+    .w-33 {
+      width: 33%
+    }
+
+    .w-66 {
+      width: 66%
+    }
+
+    .w-100 {
+      width: 100%
+    }
+
+    .w-300 {
+      width: 300px
+    }
+
+    .mw-99 {
+      max-width: 99%
+    }
+
+    .mw-100 {
+      max-width: 100%
+    }
+
+    .mw-144 {
+      max-width: 144px
+    }
+
+    .mw-200 {
+      max-width: 200px
+    }
+
+    .mw-300 {
+      max-width: 300px
+    }
+
+    .mw-600 {
+      max-width: 600px
+    }
+
+    .minw-200 {
+      min-width: 200px
+    }
+
+    .mw-420 {
+      max-width: 420px
+    }
+
+    .min-w-btn {
+      min-width: 120px
+    }
+
+    .w-auto {
+      width: auto
+    }
+
+    .w-fit {
+      width: fit-content
+    }
+
+    .minw-max {
+      min-width: max-content
+    }
+
+    .h-0 {
+      height: 0
+    }
+
+    .h-100 {
+      height: 100%
+    }
+
+    .h-auto,
+    .h-initial {
+      height: auto
+    }
+
+    .h-xxxs {
+      height: 8px
+    }
+
+    .h-xxs {
+      height: 16px
+    }
+
+    .h-20 {
+      height: 20px
+    }
+
+    .h-24,
+    .h-xs {
+      height: 24px
+    }
+
+    .h-sm {
+      height: 32px
+    }
+
+    .h-md {
+      height: 40px
+    }
+
+    .h-lg {
+      height: 44px
+    }
+
+    .h-xl {
+      height: 48px
+    }
+
+    .h-xxl {
+      height: 56px
+    }
+
+    .fill-current {
+      fill: currentColor
+    }
+
+    .gap-x-0 {
+      grid-column-gap: 0;
+      column-gap: 0
+    }
+
+    .mw-grid {
+      max-width: calc(1440px + 16vw)
+    }
+
+    .grid-cols-12 {
+      grid-template-columns: repeat(12, minmax(0, 1fr))
+    }
+
+    .col-span-12 {
+      grid-column: span 12/span 12
+    }
+
+    .col-span-8 {
+      grid-column: span 8/span 8
+    }
+
+    .col-span-4 {
+      grid-column: span 4/span 4
+    }
+
+    [class*=aspect-] {
+      position: relative
+    }
+
+    [class*=aspect-]>* {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0
+    }
+
+    .aspect-3-2 {
+      padding-bottom: 66.66667%
+    }
+
+    .aspect-1-1 {
+      padding-bottom: 100%
+    }
+
+    .aspect-16-9 {
+      padding-bottom: 56.25%
+    }
+
+    .aspect-4-3 {
+      padding-bottom: 75%
+    }
+
+    :root {
+      --aspect-height: 1;
+      --aspect-width: 1
+    }
+
+    .aspect-custom {
+      padding-bottom: calc(var(--aspect-height)/var(--aspect-width)*100%)
+    }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0
+    }
+
+    .sr-only-focusable:active,
+    .sr-only-focusable:focus {
+      clip: auto;
+      height: auto;
+      margin: 0;
+      overflow: visible;
+      position: static;
+      width: auto
+    }
+
+    .skip-link:active,
+    .skip-link:focus {
+      display: block
+    }
+
+    .article-body a {
+      border-bottom: 1px solid var(--gray-lighter)
+    }
+
+    .pullquote {
+      font-size: var(--font-size-small)
+    }
+
+    .pullquote blockquote {
+      line-height: var(--line-height-medium)
+    }
+
+    .headline-flex-basis {
+      flex-basis: 90%
+    }
+
+    .placeholder-color-inherit::placeholder {
+      color: inherit
+    }
+
+    :root {
+      --nested-focus-within-color: var(--color-brand-blue-normal)
+    }
+
+    .focus-within:focus-within .nested-focus-within-color {
+      color: var(--nested-focus-within-color)
+    }
+
+    .focus-within:focus-within .focused-db {
+      display: block
+    }
+
+    .focus-within:focus-within .focused-pt-sm {
+      padding-top: var(--sm)
+    }
+
+    .scrollbar-width-none {
+      scrollbar-width: none;
+      -ms-overflow-style: none
+    }
+
+    .scrollbar-width-none::-webkit-scrollbar {
+      width: 0
+    }
+
+    .select-none {
+      user-select: none
+    }
+
+    .outline-none {
+      outline: none
+    }
+
+    .appearance-none {
+      appearance: none
+    }
+
+    .webkit-search-cancel-button-appearance-none::-webkit-search-cancel-button {
+      appearance: none
+    }
+
+    .default {
+      cursor: default
+    }
+
+    .pointer {
+      cursor: pointer
+    }
+
+    .not-allowed {
+      cursor: not-allowed
+    }
+
+    .pointer-events-none {
+      pointer-events: none
+    }
+
+    .dn,
+    .hover-dn:hover {
+      display: none
+    }
+
+    .db {
+      display: block
+    }
+
+    .dib,
+    .hover-dib:hover {
+      display: inline-block
+    }
+
+    .dit {
+      display: inline-table
+    }
+
+    .hover-parent:hover .hover-child-db {
+      display: block
+    }
+
+    .hover-parent:hover .hover-child-dib {
+      display: inline-block
+    }
+
+    .hover-parent:hover .hover-child-dn {
+      display: none
+    }
+
+    .fill-dodgerblue {
+      fill: #2c85fc
+    }
+
+    .fill-success-green {
+      fill: #61a125
+    }
+
+    .fill-inherit {
+      fill: inherit
+    }
+
+    .table {
+      display: table
+    }
+
+    .flex {
+      display: flex
+    }
+
+    .flex-column {
+      flex-direction: column
+    }
+
+    .flex-row {
+      flex-direction: row
+    }
+
+    .flex-1 {
+      flex: 1
+    }
+
+    .flex-0 {
+      flex: 0
+    }
+
+    .flex-none {
+      flex: none
+    }
+
+    .flex-grow-1 {
+      flex-grow: 1
+    }
+
+    .flex-shrink-0 {
+      flex-shrink: 0
+    }
+
+    .flex-wrap {
+      flex-wrap: wrap
+    }
+
+    .inline-flex {
+      display: inline-flex
+    }
+
+    .inline-flex-column {
+      flex-direction: column
+    }
+
+    .inline-flex-row {
+      flex-direction: row
+    }
+
+    .inline-flex-1 {
+      flex: 1
+    }
+
+    .items-start {
+      align-items: flex-start
+    }
+
+    .items-end {
+      align-items: flex-end
+    }
+
+    .items-baseline {
+      align-items: baseline
+    }
+
+    .items-center {
+      align-items: center
+    }
+
+    .self-center {
+      align-self: center
+    }
+
+    .justify-center {
+      justify-content: center
+    }
+
+    .justify-end {
+      justify-content: flex-end
+    }
+
+    .justify-between {
+      justify-content: space-between
+    }
+
+    .justify-flex-start,
+    .justify-start {
+      justify-content: flex-start
+    }
+
+    .fl {
+      float: left
+    }
+
+    .fr {
+      float: right
+    }
+
+    .fn {
+      float: none
+    }
+
+    .cb {
+      clear: both
+    }
+
+    .clearfix:after {
+      display: block;
+      content: "";
+      clear: both
+    }
+
+    .of-contain {
+      object-fit: contain
+    }
+
+    .of-cover {
+      object-fit: cover
+    }
+
+    .o-100 {
+      opacity: 1
+    }
+
+    .overflow-hidden {
+      overflow: hidden
+    }
+
+    .overflow-auto {
+      overflow: auto
+    }
+
+    .overflow-xscroll {
+      overflow-x: scroll;
+      scrollbar-width: none
+    }
+
+    .overflow-xscroll::-webkit-scrollbar {
+      display: none
+    }
+
+    .truncate {
+      text-overflow: ellipsis;
+      overflow: hidden
+    }
+
+    .nowrap,
+    .truncate {
+      white-space: nowrap
+    }
+
+    .relative {
+      position: relative
+    }
+
+    .absolute {
+      position: absolute
+    }
+
+    .fixed {
+      position: fixed
+    }
+
+    .sticky {
+      position: -webkit-sticky;
+      position: sticky
+    }
+
+    .right-0 {
+      right: 0
+    }
+
+    .left-0 {
+      left: 0
+    }
+
+    .top-0 {
+      top: 0
+    }
+
+    .bottom-0 {
+      bottom: 0
+    }
+
+    .va-t {
+      vertical-align: top
+    }
+
+    .va-m {
+      vertical-align: middle
+    }
+
+    .va-sub {
+      vertical-align: sub
+    }
+
+    .va-b {
+      vertical-align: bottom
+    }
+
+    .hidden {
+      visibility: hidden
+    }
+
+    .visible {
+      visibility: visible
+    }
+
+    .z-0 {
+      z-index: 0
+    }
+
+    .z-1 {
+      z-index: 1
+    }
+
+    .z-2 {
+      z-index: 2
+    }
+
+    .z-3 {
+      z-index: 3
+    }
+
+    .z-4 {
+      z-index: 4
+    }
+
+    .z-5 {
+      z-index: 5
+    }
+
+    .z-6 {
+      z-index: 6
+    }
+
+    .z-7 {
+      z-index: 7
+    }
+
+    .content-box {
+      box-sizing: initial
+    }
+
+    .touch-none {
+      touch-action: none
+    }
+
+    .cand-GOP-text {
+      color: #aa3b30
+    }
+
+    .cand-DEM-text {
+      color: #35639b
+    }
+
+    .cand-IND-text {
+      color: #626262
+    }
+
+    .CandidateIllustration-module_circle__-z6Td {
+      max-height: 50px;
+      width: 50px
+    }
+
+    .RaceCall-module_DEM__13jla {
+      color: #35639b
+    }
+
+    .RaceCall-module_GOP__1yGSR {
+      color: #aa3b30
+    }
+
+    .RaceCall-module_IND__2G6q1 {
+      color: #bb641d
+    }
+
+    .RaceCall-module_OTHER__1KKIf {
+      color: #626262
+    }
+
+    .RaceCall-module_image__1pEEN {
+      border-radius: 50%;
+      max-height: 50px;
+      width: 50px
+    }
+
+    .RaceCall-module_content-stretch__1rPEZ {
+      align-content: stretch
+    }
+
+    .RaceCall-module_flex-basis-100__3ObJq {
+      flex-basis: 100%
+    }
+
+    .RaceCall-module_mw-50__31eMU {
+      max-width: 50px
+    }
+
+    .grid {
+      display: -ms-grid;
+      display: grid;
+      -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+      grid-template-columns: repeat(12, 1fr [col-start]);
+      width: 100%;
+      max-width: calc(1440px + 16vw);
+      padding: 0 5vw;
+      grid-column-gap: 0
+    }
+
+    .grid,
+    .grid-item {
+      box-sizing: border-box
+    }
+
+    .grid-item {
+      max-width: 100%
+    }
+
+    .grid-item--cols-start-sm-1 {
+      -ms-grid-column: 1
+    }
+
+    .grid-item--cols-start-sm-2 {
+      -ms-grid-column: 2
+    }
+
+    .grid-item--cols-start-sm-3 {
+      -ms-grid-column: 3
+    }
+
+    .grid-item--cols-start-sm-4 {
+      -ms-grid-column: 4
+    }
+
+    .grid-item--cols-start-sm-5 {
+      -ms-grid-column: 5
+    }
+
+    .grid-item--cols-start-sm-6 {
+      -ms-grid-column: 6
+    }
+
+    .grid-item--cols-start-sm-7 {
+      -ms-grid-column: 7
+    }
+
+    .grid-item--cols-start-sm-8 {
+      -ms-grid-column: 8
+    }
+
+    .grid-item--cols-start-sm-9 {
+      -ms-grid-column: 9
+    }
+
+    .grid-item--cols-start-sm-10 {
+      -ms-grid-column: 10
+    }
+
+    .grid-item--cols-start-sm-11 {
+      -ms-grid-column: 11
+    }
+
+    .grid-item--cols-start-sm-12 {
+      -ms-grid-column: 12
+    }
+
+    .grid-item--cols-sm-1 {
+      -ms-grid-column-span: 1;
+      grid-column-end: span 1
+    }
+
+    .grid-item--cols-sm-2 {
+      -ms-grid-column-span: 2;
+      grid-column-end: span 2
+    }
+
+    .grid-item--cols-sm-3 {
+      -ms-grid-column-span: 3;
+      grid-column-end: span 3
+    }
+
+    .grid-item--cols-sm-4 {
+      -ms-grid-column-span: 4;
+      grid-column-end: span 4
+    }
+
+    .grid-item--cols-sm-5 {
+      -ms-grid-column-span: 5;
+      grid-column-end: span 5
+    }
+
+    .grid-item--cols-sm-6 {
+      -ms-grid-column-span: 6;
+      grid-column-end: span 6
+    }
+
+    .grid-item--cols-sm-7 {
+      -ms-grid-column-span: 7;
+      grid-column-end: span 7
+    }
+
+    .grid-item--cols-sm-8 {
+      -ms-grid-column-span: 8;
+      grid-column-end: span 8
+    }
+
+    .grid-item--cols-sm-9 {
+      -ms-grid-column-span: 9;
+      grid-column-end: span 9
+    }
+
+    .grid-item--cols-sm-10 {
+      -ms-grid-column-span: 10;
+      grid-column-end: span 10
+    }
+
+    .grid-item--cols-sm-11 {
+      -ms-grid-column-span: 11;
+      grid-column-end: span 11
+    }
+
+    .grid-item--cols-sm-12 {
+      -ms-grid-column-span: 12;
+      grid-column-end: span 12
+    }
+
+    .grid-item--rows-start-sm-1 {
+      -ms-grid-row: 1
+    }
+
+    .grid-item--rows-start-sm-2 {
+      -ms-grid-row: 2
+    }
+
+    .grid-item--rows-start-sm-3 {
+      -ms-grid-row: 3
+    }
+
+    .grid-item--rows-start-sm-4 {
+      -ms-grid-row: 4
+    }
+
+    .grid-item--rows-start-sm-5 {
+      -ms-grid-row: 5
+    }
+
+    .grid-item--rows-start-sm-6 {
+      -ms-grid-row: 6
+    }
+
+    .grid-item--rows-start-sm-7 {
+      -ms-grid-row: 7
+    }
+
+    .grid-item--rows-start-sm-8 {
+      -ms-grid-row: 8
+    }
+
+    .grid-item--rows-start-sm-9 {
+      -ms-grid-row: 9
+    }
+
+    .grid-item--rows-start-sm-10 {
+      -ms-grid-row: 10
+    }
+
+    .grid-item--rows-start-sm-11 {
+      -ms-grid-row: 11
+    }
+
+    .grid-item--rows-start-sm-12 {
+      -ms-grid-row: 12
+    }
+
+    .grid-item--rows-sm-1 {
+      -ms-grid-row-span: 1;
+      grid-row-end: span 1
+    }
+
+    .grid-item--rows-sm-2 {
+      -ms-grid-row-span: 2;
+      grid-row-end: span 2
+    }
+
+    .grid-item--rows-sm-3 {
+      -ms-grid-row-span: 3;
+      grid-row-end: span 3
+    }
+
+    .grid-item--rows-sm-4 {
+      -ms-grid-row-span: 4;
+      grid-row-end: span 4
+    }
+
+    .grid-item--rows-sm-5 {
+      -ms-grid-row-span: 5;
+      grid-row-end: span 5
+    }
+
+    .grid-item--rows-sm-6 {
+      -ms-grid-row-span: 6;
+      grid-row-end: span 6
+    }
+
+    .grid-item--rows-sm-7 {
+      -ms-grid-row-span: 7;
+      grid-row-end: span 7
+    }
+
+    .grid-item--rows-sm-8 {
+      -ms-grid-row-span: 8;
+      grid-row-end: span 8
+    }
+
+    .grid-item--rows-sm-9 {
+      -ms-grid-row-span: 9;
+      grid-row-end: span 9
+    }
+
+    .grid-item--rows-sm-10 {
+      -ms-grid-row-span: 10;
+      grid-row-end: span 10
+    }
+
+    .grid-item--rows-sm-11 {
+      -ms-grid-row-span: 11;
+      grid-row-end: span 11
+    }
+
+    .grid-item--rows-sm-12 {
+      -ms-grid-row-span: 12;
+      grid-row-end: span 12
+    }
+
+    .o-0 {
+      opacity: 0
+    }
+
+    .o-15 {
+      opacity: .15
+    }
+
+    .o-50 {
+      opacity: .5
+    }
+
+    .o-75 {
+      opacity: .75
+    }
+
+    .byline .author-tooltip {
+      width: 225px
+    }
+
+    @keyframes fadeout {
+      0% {
+        opacity: 1
       }
-    </script>
-    <link rel="manifest" href="/pb/resources/json/desktop-notifications-manifest.json">
-    <meta name="zeusAds" content="true">
-    <title>Twitter says goodbye to all ‘.@’ - The Washington Post</title>
-    <link itemprop="url" rel="canonical" href="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
-    <meta property="og:url" content="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
-    <meta property="og:image" content="https://www.washingtonpost.com/resizer/koHP6G-N-IEesDnQ2qlC-c3G7H4=/1484x0/arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YU7K4QHOU45NXLUUOZBD64ZCM4.jpg" itemprop="image">
-    <meta property="og:title" content="Twitter says goodbye to all ‘.@’">
-    <meta itemprop="description" name="description" content="Twitter announced a series of changes that will make the site easier to use.">
-    <meta property="og:description" content="Twitter announced a series of changes that will make the site easier to use.">
-    <meta name="robots" content="index,follow">
-    <meta name="theme" content="normal">
-    <meta name="audio_url" content>
-    <link rel="amphtml" href="https://beta.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/?outputType=amp">
-    <link rel="alternate" href="android-app://com.washingtonpost.rainbow/wp-android-rainbow/www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
-    <link rel="alternate" href="android-app://com.washingtonpost.android/wp-android/www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
-    <meta property="article:author" content="https://www.facebook.com/aohlheiser">
-    <meta property="author" content="https://www.facebook.com/aohlheiser">
-    <meta property="twitter:creator" content="@abbyohlheiser">
-    <script>
-      window.commercialNode = "technology";
-      (function() {
-        try {
-          wp_meta_data = window.wp_meta_data || {};
-          wp_meta_data.platform = "pagebuilder";
-          if (!("isPageInitiallyHydrated" in wp_meta_data)) wp_meta_data.isPageInitiallyHydrated = true;
-          wp_meta_data.showAds = true;
-          wp_meta_data.isPWA = false;
-          wp_meta_data.showPreRollAds = false;
-          wp_meta_data.isHomepage = false;
-          wp_meta_data.isErrorPage = false;
-          wp_meta_data.isMultimedia = false;
-          wp_meta_data.wt = "article_story";
-          delete wp_meta_data.facet;
-          wp_meta_data.contentName = ["internet-culture"];
-          delete wp_meta_data.contentLength;
-          wp_meta_data.page_id = ["internet-culture15491"];
-          wp_meta_data.meta_date = ["1464114048"];
-          wp_meta_data.author = ["Abby Ohlheiser"];
-          wp_meta_data.keywords = ["twitter", ".@ twitter", "twitter replies", "twitter character limit"];
-          delete wp_meta_data.destinations;
-          wp_meta_data.hot_topic = [false];
-          delete wp_meta_data.subjects;
-          wp_meta_data.tags = "online media".split(",");
-          wp_meta_data.tags_for_paywall = "online media".replace(/[^a-zA-Z0-9-_,]/g, "");
-          delete wp_meta_data.tags_for_paywall_subs;
-          delete wp_meta_data.category;
-          delete wp_meta_data.people_names;
-          delete wp_meta_data.people_positions;
-          delete wp_meta_data.organization_names;
-          delete wp_meta_data.coverage_industrys;
-          delete wp_meta_data.ideology;
-          delete wp_meta_data.addresses;
-          delete wp_meta_data.neighborhoods;
-          delete wp_meta_data.zip_codes;
-          delete wp_meta_data.counties;
-          delete wp_meta_data.venues;
-          delete wp_meta_data.cities;
-          delete wp_meta_data.states;
-          delete wp_meta_data.countries;
-          delete wp_meta_data.breaking_news;
-          wp_meta_data.contentType = ["BlogStory"];
-          delete wp_meta_data.isPremium;
-          try {
-            if (wp_meta_data) {
-              if (!wp_meta_data.clavis) wp_meta_data.clavis = {};
-              (function() {
-                var clavisAuxs = [];
-                var clavisAuxNames = [];
-                var clavisKeywords = [];
-                var clavisTopics = [];
-                var clavisTopicsDFP = [];
-                clavisAuxs.push("8z8");
-                clavisAuxNames.push("Sensitive1");
-                clavisAuxs.push("5k4");
-                clavisAuxNames.push("China_HongKong Exclusion 12-12-14");
-                clavisAuxs.push("wkq");
-                clavisAuxNames.push("Science, Health \x26 Technology");
-                clavisAuxs.push("7aq");
-                clavisAuxNames.push("Sensitive 2");
-                clavisAuxs.push("34n");
-                clavisAuxNames.push("Social Media");
-                clavisAuxs.push("ieb");
-                clavisAuxNames.push("Companies");
-                clavisAuxs.push("vat");
-                clavisAuxNames.push("TV and Movies");
-                clavisAuxs.push("ngs");
-                clavisAuxNames.push("Macys");
-                clavisAuxs.push("l7l");
-                clavisAuxNames.push("Ahld");
-                clavisAuxs.push("zhn");
-                clavisAuxNames.push("Emissions");
-                clavisAuxs.push("zwn");
-                clavisAuxNames.push("Murdoch neg");
-                clavisAuxs.push("xzm");
-                clavisAuxNames.push("IC - JPMC - Decisive Action");
-                clavisAuxs.push("4em");
-                clavisAuxNames.push("IC - JPMC - Houston");
-                clavisAuxs.push("i7i");
-                clavisAuxNames.push("IC - JPMC - Entrepreneures");
-                clavisAuxs.push("vfq");
-                clavisAuxNames.push("IC - JPMC - Detroits Comeback");
-                clavisAuxs.push("9xx");
-                clavisAuxNames.push("Exn neg");
-                clavisAuxs.push("xyt");
-                clavisAuxNames.push("food safety neg");
-                clavisAuxs.push("7rl");
-                clavisAuxNames.push("Icahn neg");
-                clavisAuxs.push("wxg");
-                clavisAuxNames.push("Apple Content");
-                clavisAuxs.push("oq2");
-                clavisAuxNames.push("IC-JPMC-Mothers to Mentors");
-                clavisAuxs.push("0hv");
-                clavisAuxNames.push("IC-JPMC-Tech Savvy");
-                clavisAuxs.push("mgr");
-                clavisAuxNames.push("IC-JPMC-Detroit");
-                clavisAuxs.push("7nc");
-                clavisAuxNames.push("emails - neg");
-                clavisAuxs.push("ft0");
-                clavisAuxNames.push("IC-JPMC-Detroit (2)");
-                clavisAuxs.push("r5x");
-                clavisAuxNames.push("Young Professional / International Businessman");
-                clavisAuxs.push("w5n");
-                clavisAuxNames.push("Qualcomm Smart Cities");
-                clavisAuxs.push("n0e");
-                clavisAuxNames.push("IC-Allstate-MM");
-                clavisAuxs.push("f79");
-                clavisAuxNames.push("Johnnie Walker");
-                clavisAuxs.push("n95");
-                clavisAuxNames.push("BofA Dashboard Auxiliary");
-                clavisAuxs.push("r6u");
-                clavisAuxNames.push("jb kws");
-                clavisAuxs.push("w4t");
-                clavisAuxNames.push("gldmn kws");
-                clavisAuxs.push("97K");
-                clavisAuxNames.push("Travel TG");
-                clavisAuxs.push("sqb");
-                clavisAuxNames.push("Entrepreneurship");
-                clavisAuxs.push("gno");
-                clavisAuxNames.push("Space");
-                clavisAuxs.push("WC9");
-                clavisAuxNames.push("Election 2016");
-                clavisAuxs.push("0KS");
-                clavisAuxNames.push("Sub: Neutral");
-                clavisAuxs.push("FTM");
-                clavisAuxNames.push("Corporate Responsibility");
-                clavisAuxs.push("F85");
-                clavisAuxNames.push("Boeing Targeting 6.8.17");
-                clavisAuxs.push("BUM");
-                clavisAuxNames.push("api kws");
-                clavisAuxs.push("PKT");
-                clavisAuxNames.push("bp kws");
-                clavisAuxs.push("q15");
-                clavisAuxNames.push("Siemens");
-                clavisAuxs.push("IAJ");
-                clavisAuxNames.push("New Auxiliary 460");
-                clavisAuxs.push("0GA");
-                clavisAuxNames.push("BofA Audience 101017");
-                clavisAuxs.push("GQP");
-                clavisAuxNames.push("intel kw");
-                clavisAuxs.push("IAM");
-                clavisAuxNames.push("aig kws");
-                clavisAuxs.push("4ld");
-                clavisAuxNames.push("IC-Rackspace-2017");
-                clavisAuxs.push("6yp");
-                clavisAuxNames.push("IC-Raytheon-12.2017");
-                clavisAuxs.push("dya");
-                clavisAuxNames.push("Discover: Aux 2: Keywords \x26 Topics");
-                clavisAuxs.push("zk5");
-                clavisAuxNames.push("Discover: Aux 3: Keywords \x26 Topics");
-                clavisAuxs.push("erz");
-                clavisAuxNames.push("Discovery: Aux 8: Keywords \x26 Topics");
-                clavisAuxs.push("hws");
-                clavisAuxNames.push("Business");
-                clavisAuxs.push("54y");
-                clavisAuxNames.push("Tech");
-                clavisAuxs.push("3uh");
-                clavisAuxNames.push("New Auxiliary 561");
-                clavisAuxs.push("1nw");
-                clavisAuxNames.push("apple kws");
-                clavisAuxs.push("muj");
-                clavisAuxNames.push("ggl kws");
-                clavisKeywords.push("twitter");
-                clavisKeywords.push("tweet");
-                clavisKeywords.push("Twitter");
-                clavisKeywords.push("reply");
-                clavisKeywords.push("user");
-                clavisKeywords.push("change");
-                clavisKeywords.push("users");
-                clavisKeywords.push("button");
-                clavisKeywords.push("tweets");
-                clavisKeywords.push("way");
-                clavisKeywords.push("person");
-                clavisKeywords.push("reach");
-                clavisKeywords.push("announcement");
-                clavisKeywords.push("link");
-                clavisKeywords.push("plan");
-                clavisKeywords.push("changes");
-                clavisKeywords.push("need");
-                clavisKeywords.push("character");
-                clavisKeywords.push("anything");
-                clavisKeywords.push("fact");
-                clavisKeywords.push("bit");
-                clavisKeywords.push("lot");
-                clavisKeywords.push("everyone");
-                clavisKeywords.push("retweet");
-                clavisKeywords.push("platform");
-                clavisTopics.push("Companies");
-                clavisTopicsDFP.push("jp");
-                clavisTopics.push("Social Media");
-                clavisTopicsDFP.push("us");
-                wp_meta_data.clavis.auxiliaries = clavisAuxs;
-                wp_meta_data.clavis.auxiliary_names = clavisAuxNames;
-                wp_meta_data.clavis.ct =
-                  clavisTopicsDFP;
-                wp_meta_data.clavis.topics = clavisTopics;
-                wp_meta_data.clavis.keywords = clavisKeywords.slice(0, 25)
-              })()
-            }
-          } catch (e) {}
-        } catch (e) {}
-      })();
-    </script>
-    <script>
-      (function() {
-        var temp = "il:3,8,13;v:6;i:0;l:18",
-          videoPosition = null;
-        try {
-          videoPosition = temp.match(/.*v:([0-9,])/) && temp.match(/.*v:([0-9,])/)[1];
-          videoPosition = videoPosition === null ? 0 : parseInt(videoPosition) + 1;
-          videoPosition = videoPosition > 99 ? 99 : videoPosition
-        } catch (err) {
-          videoPosition = 0
-        }
-        TWP = typeof TWP == "undefined" ? {} : TWP;
-        TWP.Data = typeof TWP.Data == "undefined" ? {} : TWP.Data;
-        TWP.Data["Tracking"] = {
-          init: function() {
-            this.props = {};
-            this.props.platform = "pagebuilder";
-            this.props.cms_system = "wordpress";
-            this.props.site = window.top !==
-              window.self ? "external_iframe" : "www.washingtonpost.com";
-            this.props.page_type = "";
-            this.props.page_name = "technology:blog:internet-culture - 15491 - 20160524 - twitter-says-goodbye-to-all";
-            this.props.section = "technology";
-            this.props.channel = "wp - technology";
-            this.props.subsection = "technology";
-            this.props.hierarchy = "technology|blog";
-            this.props.content_type = "blog";
-            this.props.story_type = "";
-            this.props.headline = "Twitter says goodbye to all \u2018.@\u2019";
-            this.props.author = "Abby Ohlheiser";
-            this.props.source =
-              "The Washington Post";
-            this.props.content_id = "internet-culture15491";
-            this.props.arc_id = "M4IAOPWKF5CS3PUTQH6IOFYVD4";
-            this.props.page_num = "";
-            this.props.columnname = "";
-            this.props.blogname = "internet-culture";
-            this.props.published = "";
-            this.props.news_or_commercial = "News";
-            this.props.commercial_node = "/technology";
-            this.props.content_category = "Technology";
-            this.props.sectionfront = "";
-            this.props.track_scrolling = true;
-            this.props.inline_elements = "il:3,8,13;v:6;i:0;l:18";
-            this.props.video_ids = "a7b621ae-685a-11e5-bdb6-6861f4521205";
-            this.props.video_position = videoPosition;
-            this.props.tests = "";
-            this.props.events = "";
-            this.props.seo_keywords = "twitter; .@ twitter; twitter replies; twitter character limit";
-            this.props.clavis_keywords = "twitter; tweet; Twitter; reply; user; change; users; button; tweets; way; person; reach; announcement; link; plan; changes; need; character; anything; fact; bit; lot; everyone; retweet; platform";
-            this.props.clavis_topics = "Social Media; Companies; iptc-media/arts_culture_entertainment_and_media/mass_media/online_media; iptc-media/economy_business_and_finance/economic_sector/computing_and_information_technology/software; iptc-media/economy_business_and_finance/economic_sector/media; iptc-media/science_and_technology/technology_and_engineering; iptc-media/economy_business_and_finance/economic_sector/computing_and_information_technology/computer_networking";
-            this.props.paywall_status = "default"
-          }
-        };
-        TWP.Data["Tracking"].init()
-      })();
-    </script>
-    <script async src="https://www.washingtonpost.com/wp-stat/pwapi/prod/wpPwapi2-min.js"></script>
-    <link rel="preload" href="https://www.washingtonpost.com/wp-stat/wapo-sass-assets/fonts/Franklin-ITC-Pro-Thin/latest/ITC_Franklin-Thin.woff2?_=20180322" as="font" type="font/woff2" crossorigin="anonymous">
-    <link rel="preload" href="https://www.washingtonpost.com/wp-stat/wapo-sass-assets/fonts/Postoni-Wide-Regular/latest/PostoniWide-Regular.woff2?_=20180322" as="font" type="font/woff2" crossorigin="anonymous">
-    <link href="/pb/gr/ro/default-article/r08eSKG9hDierr/css/1b37d037e9.css?_=73611" rel="stylesheet">
-    <link href="/pb/gr/p/default-article/r08eSKG9hDierr/style.css?_=addb1" rel="stylesheet">
-    <style data-id="pb-r-head"></style>
-    <script>
-      window.wpAd = {
-        "inventory": {
-          "interstitial": {
-            "size": [],
-            "keyvalues": {
-              "ad": "interstitial"
-            }
-          },
-          "leaderboard": {
-            "size": [
-              [2, 1],
-              [728, 90],
-              [970, 66],
-              [970, 250], "fluid"
-            ],
-            "keyvalues": {
-              "pos": "leaderboard"
-            },
-            "refresh": {
-              "status": "on",
-              "exception": ["washingtonpost.com"]
-            }
-          },
-          "leaderboard_*": {
-            "size": [
-              [2, 1],
-              [728, 90],
-              [970, 66],
-              [970, 250], "fluid"
-            ],
-            "keyvalues": {
-              "pos": "leaderboard"
-            },
-            "refresh": {
-              "status": "on",
-              "exception": ["washingtonpost.com"]
-            }
-          },
-          "hp_responsive": {
-            "size": [
-              [2, 1],
-              [1, 2]
-            ]
-          },
-          "inline_bb": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "sizeOnCondition": {
-              "windowWidth": 1250,
-              "size": [620, 250]
-            },
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "inline_bb_*": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "sizeOnCondition": {
-              "windowWidth": 1250,
-              "size": [620, 250]
-            },
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "flex_ss_bb_hp": {
-            "size": [
-              [2, 1],
-              [336, 850],
-              [336, 280],
-              [160, 600],
-              [300, 250],
-              [300, 600],
-              [300, 1050]
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "flex_ss_bb_hp_*": {
-            "size": [
-              [2, 1],
-              [336, 850],
-              [336, 280],
-              [160, 600],
-              [300, 250],
-              [300, 600],
-              [300, 1050]
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "flex_bb_hp": {
-            "size": [
-              [2,
-                1
-              ],
-              [336, 850],
-              [336, 280],
-              [300, 600],
-              [300, 1050],
-              [300, 250]
-            ]
-          },
-          "flex_bb_hp_sm": {
-            "size": [
-              [2, 1],
-              [160, 600],
-              [300, 600],
-              [300, 250]
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "tiffany_tile": {
-            "size": [
-              [2, 1],
-              [200, 60],
-              [184, 90]
-            ],
-            "keyvalues": {
-              "ad": ["tiffany_tile"]
-            }
-          },
-          "tiffany_tile_*": {
-            "size": [
-              [2, 1],
-              [200, 60],
-              [184, 90]
-            ]
-          },
-          "brandconnect_front": {
-            "size": [
-              [2, 1],
-              [1, 8], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "brandconnect_magnet": {
-            "size": [
-              [2, 1],
-              [1, 8]
-            ]
-          },
-          "bc_pb_homepage": {
-            "size": [
-              [2, 1],
-              [1, 8], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "bc_pb_regional": {
-            "size": [
-              [2, 1],
-              [1, 8], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "336x60": {
-            "size": [
-              [2, 1],
-              [336, 60]
-            ],
-            "keyvalues": {
-              "ad": ["336x60"]
-            }
-          },
-          "336x35_top": {
-            "size": [
-              [2, 1],
-              [336, 35]
-            ],
-            "keyvalues": {
-              "ad": ["336x35"]
-            }
-          },
-          "marketing_2": {
-            "size": [
-              [2, 1],
-              [1, 1]
-            ]
-          },
-          "marketwatch": {
-            "size": [
-              [2, 1],
-              [1, 1]
-            ]
-          },
-          "twittermodule": {
-            "size": [
-              [2, 1],
-              [1, 1]
-            ]
-          },
-          "88x31": {
-            "size": [
-              [2, 1],
-              [88, 31]
-            ]
-          },
-          "bigbox": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "bigbox_*": {
-            "size": [
-              [2, 1],
-              [300,
-                250
-              ], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "bigbox_stay": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "bigbox_eat": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "bigbox_do": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "bigbox_gallery": {
-            "size": [
-              [2, 1],
-              [300, 250]
-            ]
-          },
-          "bs_btw": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ]
-          },
-          "context_notes": {
-            "size": [
-              [2, 1],
-              [1, 1]
-            ]
-          },
-          "enterprise": {
-            "size": [
-              [2, 1],
-              [1, 1],
-              [620, 250],
-              [728, 90],
-              [970, 250], "fluid"
-            ]
-          },
-          "enterprise_*": {
-            "size": [
-              [2, 1],
-              [1, 1],
-              [620, 250],
-              [728, 90],
-              [970, 250], "fluid"
-            ]
-          },
-          "mob_enterprise": {
-            "size": [
-              [2, 1],
-              [1, 1],
-              [300, 250], "fluid"
-            ]
-          },
-          "mob_enterprise_*": {
-            "size": [
-              [2, 1],
-              [1, 1],
-              [300, 250], "fluid"
-            ]
-          },
-          "mob_bigbox": {
-            "size": [
-              [2, 1],
-              [300, 250],
-              [300, 600], "fluid"
-            ],
-            "refresh": {
-              "status": "off",
-              "exception": []
-            }
-          },
-          "mob_bigbox_*": {
-            "size": [
-              [2, 1],
-              [300, 250], "fluid"
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "fixedBottom": {
-            "size": [
-              [2, 1],
-              [320, 50],
-              [300, 50]
-            ],
-            "refresh": {
-              "status": "on",
-              "exception": []
-            }
-          },
-          "pushdown": {
-            "size": [
-              [2,
-                1
-              ],
-              [1, 1],
-              [970, 66],
-              [970, 90],
-              [728, 90],
-              [970, 250]
-            ]
-          },
-          "bc_bigbox": {
-            "size": [
-              [2, 1],
-              [300, 250]
-            ]
-          },
-          "polly_article": {
-            "size": [
-              [2, 1],
-              [1, 1]
-            ]
-          }
-        },
-        "sraBundles": {
-          "a": ["slug_leaderboard", "slug_flex_ss_bb_hp"],
-          "b": ["slug_interstitial", "slug_tiffany_tile", "slug_tiffany_tile_2"]
-        },
-        "exclusionsKeyWords": {
-          "natural_disaster": ["deepwater", "oil spill", "shell", "exxon", "citgo", "bp", "chevron", "hess", "sunoco", "disaster", "fire", "explosion", "oil", "coal", "death", "dead", "quake", "earthquake", "tsunami", "tornado", "hurricane", "flood", "bed bug",
-            "infestation", "gas", "tropical storm", "Irma", "Harvey"
-          ],
-          "human_disaster": ["blood", "accident", "Weinstein", "massacre", "oreilly", "Ailes", "o'reilly", "fox news", "abuse", "death", "trafficking", "dead", "gunshot", "murderer", "porn", "sex tape", "sexting", "sexual abuse", "molestation", "assault", "child abuse", "sex abuse", "ISIS", "ISIL", "Islamic State", "Al Qaeda", "Syria", "Syrian", "Assad", "shooter", "shooting", "migrants", "aylan kurdi", "refugee crisis", "drown", "shoot", "vatican", "spanair", "aground", "rescue", "attack", "disaster",
-            "explosion", "war", "hostage", "terror", "terrorist", "bomb", "blast", "mining", "miner", "violence", "riot", "crash", "9/11", "sept. 11", "september 11", "behead", "United 93", "pistorius", "ebola", "rape", "rapist", "amtrak", "derailment", "benghazi", "misconduct", "illegal downloads", "illegal drugs", "hate speech", "offensive language"
-          ],
-          "financial_crisis": ["corrupt", "lawsuit", "goldman", "aig", "foreclosure", "enron", "sec", "mortgage", "Insurance", "health", "bank", "wall street", "protest", "labor strike", "union strike", "labor issue",
-            "union issue", "teacher strike", "teachers strike", "election"
-          ],
-          "inappropriate": ["porn", "pussy", "cunt", "fuck", "deepwater", "gambling", "sex", "alcohol", "pornography"]
-        },
-        "posOnCommericalNode": {
-          "washingtonpost.com": {
-            "pos": {
-              "leaderboard": {
-                "start": "06/04/2019 00:00 EDT",
-                "end": "06/07/2019 23:59 EDT"
-              },
-              "flex_bb_hp": {
-                "start": "12/14/2018 00:00 EDT",
-                "end": "12/31/2019 23:59 EDT"
-              },
-              "tiffany_tile": {
-                "start": "01/10/2019 00:00 EDT",
-                "end": "12/31/2019 23:59 EDT"
-              },
-              "tiffany_tile_2": {
-                "start": "01/10/2019 00:00 EDT",
-                "end": "12/31/2019 23:59 EDT"
-              },
-              "hp_responsive": {
-                "start": "03/27/2019 19:00 EDT",
-                "end": "03/28/2019 18:59 EDT"
-              },
-              "pushdown": {
-                "start": "05/14/2019 00:00 EDT",
-                "end": "05/14/2019 23:59 EDT"
-              }
-            }
-          },
-          "bytheway": {
-            "pos": {
-              "fixedBottom": {
-                "start": "05/13/2019 00:00 EDT",
-                "end": "05/13/2019 23:59 EDT"
-              }
-            }
-          },
-          "bytheway/tips": {
-            "pos": {
-              "fixedBottom": {
-                "start": "05/13/2019 00:00 EDT",
-                "end": "05/13/2019 23:59 EDT"
-              }
-            }
-          },
-          "bytheway/tips/front": {
-            "pos": {
-              "fixedBottom": {
-                "start": "05/13/2019 00:00 EDT",
-                "end": "05/13/2019 23:59 EDT"
-              }
-            }
-          },
-          "bytheway/news": {
-            "pos": {
-              "fixedBottom": {
-                "start": "05/13/2019 00:00 EDT",
-                "end": "05/13/2019 23:59 EDT"
-              }
-            }
-          },
-          "bytheway/news/front": {
-            "pos": {
-              "fixedBottom": {
-                "start": "05/13/2019 00:00 EDT",
-                "end": "05/13/2019 23:59 EDT"
-              }
-            }
-          }
-        },
-        "inlineAdsConfig": {
-          "mobile": {
-            "defaultPos": "mob_bigbox",
-            "adSpacing": {
-              "a": {
-                "firstAdOnChar": 650,
-                "minCharCount": 650,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "b": {
-                "firstAdOnChar": 650,
-                "minCharCount": 650,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "c": {
-                "firstAdOnChar": 650,
-                "minCharCount": 650,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "d": {
-                "firstAdOnChar": 650,
-                "minCharCount": 650,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "default": {
-                "firstAdOnChar": 650,
-                "minCharCount": 650,
-                "minParaCount": 3,
-                "totalAdCount": 4
-              }
-            }
-          },
-          "desktop": {
-            "defaultPos": "inline_bb",
-            "adSpacing": {
-              "a": {
-                "firstAdOnChar": 800,
-                "minCharCount": 800,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "b": {
-                "firstAdOnChar": 800,
-                "minCharCount": 800,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "c": {
-                "firstAdOnChar": 800,
-                "minCharCount": 800,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "d": {
-                "firstAdOnChar": 800,
-                "minCharCount": 800,
-                "minParaCount": 3,
-                "totalAdCount": 8
-              },
-              "default": {
-                "firstAdOnChar": 800,
-                "minCharCount": 800,
-                "minParaCount": 3,
-                "totalAdCount": 4
-              }
-            }
-          },
-          "bufferSpace": 100,
-          "spacingTags": "DIV,IFRAME,TABLE,BLOCKQUOTE",
-          "skipClassList": ["interstitial-link", "pb-f-page-newsletter-inLine", "inline-content", "voraciously-recipe-ingredient", "voraciously-recipe-step", "voraciously-recipe-nutrition"]
-        },
-        "refreshAdsConfig": {
-          "a": {
-            "frequency": 30,
-            "enable": true
-          },
-          "b": {
-            "frequency": 30,
-            "enable": true
-          },
-          "c": {
-            "frequency": 30,
-            "enable": true
-          },
-          "d": {
-            "frequency": 30,
-            "enable": true
-          },
-          "default": {
-            "frequency": 30,
-            "enable": false
-          }
-        },
-        "hbConfig": {
-          "slug_leaderboard": {
-            "openx": 540038581,
-            "apnx": 12456623,
-            "criteo": [1275783, 1275784],
-            "trustx": 7201
-          },
-          "slug_mob_lb": {
-            "apnx": 14675087,
-            "criteo": [1275837, 1275838],
-            "trustx": 7232
-          },
-          "slug_inline_bb": {
-            "openx": 540038591,
-            "apnx": 12456622,
-            "criteo": 1275791,
-            "trustx": 7202
-          },
-          "slug_inline_bb_2": {
-            "openx": 540038592,
-            "apnx": 12456638,
-            "criteo": 1275792,
-            "trustx": 7203
-          },
-          "slug_inline_bb_3": {
-            "openx": 540038593,
-            "apnx": 12456645,
-            "criteo": 1275793,
-            "trustx": 7204
-          },
-          "slug_inline_bb_4": {
-            "openx": 540038594,
-            "apnx": 12456635,
-            "criteo": 1275794,
-            "trustx": 7205
-          },
-          "slug_inline_bb_5": {
-            "openx": 540205943,
-            "apnx": 14675069,
-            "criteo": 1284218,
-            "trustx": 7206
-          },
-          "slug_inline_bb_6": {
-            "openx": 540205990,
-            "apnx": 14675070,
-            "criteo": 1284219,
-            "trustx": 7207
-          },
-          "slug_inline_bb_7": {
-            "openx": 540205946,
-            "apnx": 14675072,
-            "criteo": 1284220,
-            "trustx": 7208
-          },
-          "slug_inline_bb_8": {
-            "openx": 540205945,
-            "apnx": 14675073,
-            "criteo": 1284221,
-            "trustx": 7209
-          },
-          "slug_bigbox": {
-            "openx": 540038595,
-            "apnx": 12456627,
-            "criteo": 1275821,
-            "trustx": 7214
-          },
-          "slug_bigbox_2": {
-            "openx": 540038596,
-            "apnx": 12456643,
-            "criteo": 1275822,
-            "trustx": 7215
-          },
-          "slug_bigbox_3": {
-            "openx": 540038597,
-            "criteo": 1275823,
-            "trustx": 7216
-          },
-          "slug_bigbox_4": {
-            "openx": 540038598,
-            "criteo": 1275824,
-            "trustx": 7217
-          },
-          "slug_bigbox_gallery": {
-            "openx": 540038599,
-            "apnx": 12456649,
-            "criteo": 1275825,
-            "trustx": 7218
-          },
-          "slug_enterprise": {
-            "openx": 540038600,
-            "apnx": 12456628,
-            "criteo": 1275826,
-            "trustx": 7219
-          },
-          "slug_enterprise_2": {
-            "openx": 540038601,
-            "apnx": 14675083,
-            "criteo": 1275827,
-            "trustx": 7220
-          },
-          "slug_enterprise_3": {
-            "openx": 540038602,
-            "apnx": 14675084,
-            "criteo": 1275828,
-            "trustx": 7221
-          },
-          "slug_enterprise_4": {
-            "openx": 540038603,
-            "apnx": 14675086,
-            "criteo": 1275829,
-            "trustx": 7222
-          },
-          "slug_mob_bigbox": {
-            "openx": 540038604,
-            "apnx": 12456636,
-            "criteo": [1275830, 1275831],
-            "trustx": 7223
-          },
-          "slug_mob_bigbox_2": {
-            "openx": 540038605,
-            "apnx": 12456646,
-            "criteo": 1275832,
-            "trustx": 7224
-          },
-          "slug_mob_bigbox_3": {
-            "openx": 540038606,
-            "apnx": 12456647,
-            "criteo": 1275833,
-            "trustx": 7225
-          },
-          "slug_mob_bigbox_4": {
-            "openx": 540038607,
-            "apnx": 12456631,
-            "criteo": 1275834,
-            "trustx": 7226
-          },
-          "slug_mob_bigbox_5": {
-            "openx": 540205994,
-            "apnx": 14700918,
-            "criteo": 1284222,
-            "trustx": 7227
-          },
-          "slug_mob_bigbox_6": {
-            "openx": 540205995,
-            "apnx": 14700919,
-            "criteo": 1284223,
-            "trustx": 7228
-          },
-          "slug_mob_bigbox_7": {
-            "openx": 540205996,
-            "apnx": 14700920,
-            "criteo": 1284224,
-            "trustx": 7229
-          },
-          "slug_mob_bigbox_8": {
-            "openx": 540205998,
-            "apnx": 14700922,
-            "criteo": 1284225,
-            "trustx": 7230
-          },
-          "slug_fixedBottom": {
-            "openx": 540038608,
-            "apnx": 12456634,
-            "criteo": [1275835, 1275836],
-            "trustx": 7231
-          },
-          "slug_bc_bigbox": {
-            "openx": 540038613,
-            "apnx": 12456641,
-            "criteo": 1275845,
-            "trustx": 7236
-          },
-          "slug_flex_ss_bb_hp": {
-            "openx": 540038616,
-            "apnx": 12456629,
-            "criteo": [1275795, 1275796, 1275797],
-            "trustx": 7210
-          },
-          "slug_flex_ss_bb_hp_2": {
-            "openx": 540038617,
-            "apnx": 12456630,
-            "criteo": [1275798, 1275799, 1275800],
-            "trustx": 7211
-          },
-          "slug_flex_ss_bb_hp_3": {
-            "openx": 540038618,
-            "apnx": 12456621,
-            "criteo": [1275801, 1275802, 1275803],
-            "trustx": 7212
-          },
-          "slug_flex_ss_bb_hp_4": {
-            "openx": 540038619,
-            "apnx": 14675074,
-            "criteo": [1275804, 1275805, 1275806],
-            "trustx": 7213
-          },
-          "slug_flex_bb_hp": {
-            "openx": 540038620,
-            "apnx": 12456644,
-            "criteo": [1275807, 1275808, 1275809]
-          }
-        }
-      };
-    </script>
-    <link rel="dns-prefetch" href="https://adserver-us.adtech.advertising.com">
-    <link rel="dns-prefetch" href="https://secure.adnxs.com">
-    <link rel="dns-prefetch" href="https://bidder.criteo.com">
-    <link rel="dns-prefetch" href="https://static.criteo.net">
-    <link rel="dns-prefetch" href="https://cdn.krxd.net">
-    <link rel="dns-prefetch" href="https://widgets.outbrain.com">
-    <link rel="dns-prefetch" href="https://images.outbrain.com">
-    <link rel="dns-prefetch" href="https://log.outbrain.com">
-    <link rel="dns-prefetch" href="https://amplifypixel.outbrain.com">
-    <link rel="dns-prefetch" href="https://odb.outbrain.com">
-    <link rel="dns-prefetch" href="https://js-sec.indexww.com">
-    <link rel="dns-prefetch" href="https://as-sec.casalemedia.com">
-    <link rel="dns-prefetch" href="https://as.casalemedia.com">
-    <link rel="dns-prefetch" href="https://sofia.trustx.org">
-    <link rel="dns-prefetch" href="https://c.amazon-adsystem.com">
-    <link rel="dns-prefetch" href="https://s.amazon-adsystem.com">
-    <link rel="dns-prefetch" href="https://aax.amazon-adsystem.com">
-    <link rel="dns-prefetch" href="https://t.teads.tv">
-    <script src="https://www.washingtonpost.com/wp-stat/ad/zeus/wp-ad.min.js" async></script>
-    <script>
-      window.wp_pb = window.wp_pb || {
-        pageName: "article-lifestyle",
-        pageId: "r08eSKG9hDierr",
-        contextPath: "/pb",
-        isAdmin: false,
-        layoutEngineName: "off",
-        environment: "production",
-        resourceToken: "201905231727ET",
-        zeusDefer: "",
-        contentFormat: "ans",
-        outputType: "default-article",
-        canonical_url: "https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/",
-        desktopNotifications: "off",
-        adExperience: "default"
-      };
-    </script>
-    <script>
-      (function() {
-        var adfreeCookie = document.cookie.match(/wapo_actmgmt=(\b|.*\|)(NOADS\:1|EU_NOADS:1)(\b|\|)([^;]*);/);
-        var adfreeParam = /_=(.*)is_ad_measure(&*)/.test(location.search) ? "NOADS:1" : "";
-        window.wp_pb.adExperience = adfreeParam || adfreeCookie && adfreeCookie[2] || "default"
-      })();
-    </script>
-    <script defer src="/pb/gr/ro/default-article/r08eSKG9hDierr/load_immediately/9af97774e9.js?_=c043f"></script>
-    <script defer src="https://www.washingtonpost.com/wp-stat/pb/features/page/pmbl.js"></script>
-    <script defer src="/pb/gr/ro/default-article/r08eSKG9hDierr/load_immediately/950c1cee31.js?_=c043f"></script>
-    <script>
-      window.pbExternalResourcesLoaded = window.pbExternalResourcesLoaded || new Array;
-      window.pbHeadResourceGroups = window.pbHeadResourceGroups || new Array;
-      pbHeadResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "css",
-        "fileType": "css"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/css/latest/headerfonts-nobinaries.0.latest.css?_\x3d78145");
-      pbExternalResourcesLoaded.push("/pb/resources/css/latest/headerfonts-nobinaries.1.latest.css?_\x3d78145");
-      pbExternalResourcesLoaded.push("/pb/resources/css/latest/headerfonts-nobinaries.2.latest.css?_\x3d78145");
-      pbExternalResourcesLoaded.push("/pb/resources/css/html5reset.css?_\x3d7c726");
-      pbExternalResourcesLoaded.push("/pb/resources/assets/fonts/custom/latest/css/icons.css?_\x3db82e6");
-      pbExternalResourcesLoaded.push("/pb/resources/css/pbCore.css?_\x3d146b1");
-      pbExternalResourcesLoaded.push("/pb/resources/css/voltron-perf.css?_\x3d50a90");
-      pbExternalResourcesLoaded.push("/pb/resources/css/refresh-perf.css?_\x3d7c726");
-      pbExternalResourcesLoaded.push("/pb/resources/css/loadAsync.css?_\x3ddd2a8");
-      pbExternalResourcesLoaded.push("/pb/resources/css/global-notification.css?_\x3d3deda");
-      pbExternalResourcesLoaded.push("/pb/resources/css/bootstrap-cols.css?_\x3dcab65");
-      pbExternalResourcesLoaded.push("/pb/resources/css/article-layout.css?_\x3d7c726");
-      pbExternalResourcesLoaded.push("/pb/resources/css/article-layout-features.css?_\x3dda9d2");
-      pbExternalResourcesLoaded.push("/pb/resources/css/inline-content.css?_\x3de273d");
-      pbHeadResourceGroups.push({
-        "resourceType": "pageResources",
-        "name": "style.css",
-        "fileType": "css"
-      });
-      pbHeadResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "load_immediately",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/js/jquery/latest/jquery.js?_\x3db45ba");
-      pbExternalResourcesLoaded.push("/pb/resources/wp_import/wp_import.js?_\x3dbf2b9");
-      pbExternalResourcesLoaded.push("/pb/resources/js/polyfills.min.js?_\x3db72b3");
-      pbExternalResourcesLoaded.push("/pb/resources/js/event-controller.v2.js?_\x3d7ea6e");
-      pbExternalResourcesLoaded.push("/pb/resources/js/event-queue.js?_\x3db1774");
-      pbExternalResourcesLoaded.push("/pb/resources/js/pbCore.article.js?_\x3d8d21e");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/pbStaticMethodsEssentials.js?_\x3d3ad7f");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/pbStaticMethodsAsync.js?_\x3d3deda");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/mobile-detection.js?_\x3d8c659");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/console/console.noop.js?_\x3d8d21e");
-      pbExternalResourcesLoaded.push("/pb/resources/js/jqModal.js?_\x3d26a28");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/mobile-detection-classes.js?_\x3d454aa");
-      pbExternalResourcesLoaded.push("/pb/resources/js/plugins/plugin.jquery.cookie-1.0.0.js?_\x3db8874");
-      pbExternalResourcesLoaded.push("/pb/resources/js/plugins/plugin.jquery.in-viewport-1.0.0.js?_\x3dbddae");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/syncRplampr.js?_\x3dcde33");
-      pbExternalResourcesLoaded.push("https://www.washingtonpost.com/wp-stat/pb/features/page/pmbl.js");
-      pbExternalResourcesLoaded.push("/pb/resources/js/utils/trigger.js?_\x3d48057");
-      pbHeadResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "pwapi-production",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("https://www.washingtonpost.com/wp-stat/pwapi/prod/wpPwapi2-min.js");
-      pbHeadResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "headjs",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/js/noop.js?_\x3dd47ff");
-      pbExternalResourcesLoaded.push("/pb/resources/js/article-layout-headjs.js?_\x3d26cc0");
-    </script>
-    <script>
-      (function() {
-        function init() {
-          var sub = document.cookie.match(/rplsb=([1])\b/);
-          var wapo_sub = document.cookie.match(/wapo_actmgmt=(\b|.*\|)(isub:(\d))(\b|\|)([^;]*);/) ? RegExp.$3 : "";
-          var isSubscriber = sub || wapo_sub === "1" ? true : false;
-          var isEUUser = document.cookie.match(/wp_gdpr=([1]+)/) ? true : false;
-          if (isSubscriber || isEUUser) return;
-          window.TWP = window.TWP || {};
-          TWP.Data = TWP.Data || {};
-          TWP.Data.Tracking = TWP.Data.Tracking || {};
-          TWP.Data.Tracking.props = TWP.Data.Tracking.props || {};
-          callAd().then(function(response) {
-            try {
-              var responseJson =
-                JSON.parse(response.responseText);
-              TWP.Data.Tracking.props.propensity = responseJson.value
-            } catch (err) {}
-          }, function(response) {
-            try {} catch (err) {}
-          })
-        }
-        function callAd() {
-          return new Promise(function(resolve, reject) {
-            var iu = encodeURI("/701/swg-pts"),
-              sz = encodeURI("1x1"),
-              c = Math.floor(Math.random() * 1E15),
-              tz = -(new Date).getTimezoneOffset(),
-              ref = null,
-              dcCookie = document.cookie.match(/__gads=([^;]+)/) ? RegExp.$1 : "";
-            if (document.referrer) ref = document.referrer.match(/:\/\/(.[^/]+)/)[1];
-            var adTag = "https://pubads.g.doubleclick.net/gampad/adx?iu\x3d" +
-              iu + "\x26sz\x3d" + sz + "\x26c\x3d" + c + "\x26tile\x3d1\x26u_tz\x3d" + tz + (ref != null ? "\x26ref\x3d" + ref : "") + (dcCookie ? "\x26cookie\x3d" + dcCookie : "");
-            var options = {
-              "method": "GET"
-            };
-            makeCall(adTag, options).then(function(response) {
-              resolve(response)
-            }, function(response) {
-              reject(response)
-            })
-          })
-        }
-        function makeCall(url, options, body) {
-          defaultOptions = {
-            "method": "GET",
-            "async": true,
-            "withCredentials": true
-          };
-          options = options || {};
-          options = Object.assign(defaultOptions, options);
-          return new Promise(function(resolve, reject) {
-            try {
-              var xhr = new XMLHttpRequest;
-              xhr.withCredentials = options.withCredentials;
-              xhr.open(options.method, url, options.async);
-              if (options.contentType) xhr.setRequestHeader("Content-Type", options.contentType);
-              xhr.onload = function() {
-                resolve(xhr)
-              };
-              xhr.onerror = function() {
-                reject(xhr)
-              };
-              xhr.send(body)
-            } catch (err) {
-              reject(err)
-            }
-          })
-        }
-        try {
-          init()
-        } catch (err) {}
-      })();
-    </script>
-    <script>
-      (function() {
-        if (window.BOOMR && window.BOOMR.version) return;
-        var dom, doc, where, iframe = document.createElement("iframe"),
-          win = window;
-        function boomerangSaveLoadTime(e) {
-          win.BOOMR_onload = e && e.timeStamp || (new Date).getTime()
-        }
-        if (win.addEventListener) win.addEventListener("load", boomerangSaveLoadTime, false);
-        else if (win.attachEvent) win.attachEvent("onload", boomerangSaveLoadTime);
-        iframe.src = "javascript:false";
-        iframe.title = "";
-        iframe.role = "presentation";
-        (iframe.frameElement || iframe).style.cssText = "width:0;height:0;border:0;display:none;";
-        where = document.getElementsByTagName("script")[0];
-        where.parentNode.insertBefore(iframe, where);
-        try {
-          doc = iframe.contentWindow.document
-        } catch (e) {
-          dom = document.domain;
-          iframe.src = "javascript:var d\x3ddocument.open();d.domain\x3d'" + dom + "';void(0);";
-          doc = iframe.contentWindow.document
-        }
-        doc.open()._l = function() {
-          var js = this.createElement("script");
-          if (dom) this.domain = dom;
-          js.id = "boomr-if-as";
-          js.src = "https://c.go-mpulse.net/boomerang/" + "W8234-EWWKH-SQWJU-EAC6K-7AE5Z";
-          BOOMR_lstart = (new Date).getTime();
-          this.body.appendChild(js)
-        };
-        doc.write('\x3cbody onload\x3d"document._l();"\x3e');
-        doc.close()
-      })();
-    </script>
-    <script>
-      (function(w) {
-        if (!w) return;
-        BOOMR = w.BOOMR || {};
-        BOOMR.plugins = BOOMR.plugins || {};
-        BOOMR.plugins.DuplicateTimersToBeacon = {
-          varsAdded: [],
-          onBeforeBeacon: function(beaconData) {
-            var tOther = beaconData ? beaconData.t_other : false;
-            if (tOther) {
-              var tOthers = tOther.split(",");
-              for (var i = 0; i < tOthers.length; i++) {
-                var nameValue = tOthers[i].split("|");
-                if (nameValue[0].indexOf("custom") === 0) {
-                  beaconData["timer_" + nameValue[0]] = nameValue[1];
-                  this.varsAdded.push("timer_" + nameValue[0])
-                }
-              }
-            }
-          },
-          init: function() {
-            BOOMR.subscribe("before_beacon",
-              this.onBeforeBeacon, {}, this);
-            BOOMR.subscribe("before_custom_beacon", this.onBeforeBeacon, {}, this);
-            BOOMR.subscribe("beacon", function() {
-              BOOMR.removeVar(this.varsAdded);
-              this.varsAdded = []
-            }, {}, this)
-          },
-          is_complete: function() {
-            return true
-          }
-        }
-      })(window);
-    </script>
-    <script>
-      var w = window;
-      if (w.performance || w.mozPerformance || w.msPerformance || w.webkitPerformance) {
-        var d = document;
-        AKSB = w.AKSB || {}, AKSB.q = AKSB.q || [], AKSB.mark = AKSB.mark || function(e, _) {
-            AKSB.q.push(["mark", e, _ || (new Date).getTime()])
-          }, AKSB.measure = AKSB.measure || function(e, _, t) {
-            AKSB.q.push(["measure", e, _, t || (new Date).getTime()])
-          }, AKSB.done = AKSB.done || function(e) {
-            AKSB.q.push(["done", e])
-          }, AKSB.mark("firstbyte", (new Date).getTime()), AKSB.prof = {
-            custid: "619110",
-            ustr: "",
-            originlat: "0",
-            clientrtt: "24",
-            ghostip: "92.123.73.236",
-            ipv6: false,
-            pct: "10",
-            clientip: "212.106.238.3",
-            requestid: "abb6f03",
-            region: "12561",
-            protocol: "",
-            blver: 14,
-            akM: "j",
-            akN: "ae",
-            akTT: "O",
-            akTX: "1",
-            akTI: "abb6f03",
-            ai: "403158",
-            ra: "false",
-            pmgn: "",
-            pmgi: "",
-            pmp: "",
-            qc: ""
-          },
-          function(e) {
-            var _ = d.createElement("script");
-            _.async = "async", _.src = e;
-            var t = d.getElementsByTagName("script"),
-              t = t[t.length - 1];
-            t.parentNode.insertBefore(_, t)
-          }(("https:" === d.location.protocol ? "https:" : "http:") + "//ds-aksb-a.akamaihd.net/aksb.min.js")
+
+      to {
+        opacity: 0
       }
-    </script>
-    <meta property="og:locale" content="en">
-    <meta property="og:url" content="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/?noredirect=on">
-    <link rel="canonical" href="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/?noredirect=on">
-  </head>
-  <body class="pb-theme-normal pb-full-fluid " data-no_ads="false">
-    <div style="width: 1px !important; height: 1px !important; position: absolute !important; left: -10000px !important; top: -1000px !important;" class="pub_300x250 pub_300x250m pub_728x90 text-ad textAd text_ad text_ads text-ads text-ad-links" id="wp-adb-c"></div>
-    <div id="pb-f-a"></div>
-    <div id="pb-root" class>
-      <div id="article-full-width-content">
-        <section id="top-furniture" class="layout">
-          <div class="pb-container">
-            <div id="f0haN1S9hDierr" class="pb-async pb-feature"></div>
-          </div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-page-header-v2" moat-id="page/header-v2" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="page/header-v2" data-pb-fingerprint="0fjQDbXsipi" id="fmzUVw19hDierr">
+    }
 
-            <!--[if IE 9]><style>#main-sections-nav.subNavigation{width:475px !important}#main-sections-nav{left:-250px !important;width:315px !important}#main-sections-nav-inner{position:absolute !important}#main-sections-nav.subNavigation #main-sections-nav-inner{width:550px !important;overflow-x:hidden !important}#main-sections-nav.subNavigation{width:470px !important}</style><![endif]-->
+    p[data-qa=disclaimer-description] [data-label=cta] {
+      transition: all 1s;
+      opacity: 1
+    }
 
-            <!--[if IE 9]><div id="page" class="ie ie9 "><![endif]-->
+    p[data-qa=disclaimer-description] [data-label=cta].o-0 {
+      animation: fadeout 1s
+    }
 
-            <!--[if IE 8]><div id="page" class="ie ie8 "><![endif]-->
+    .gallery,
+    .preview-gallery {
+      max-height: 500px;
+      min-height: 250px
+    }
 
-            <!--[if !IE]>
-<!-->
-            <div id="page" class="nie ">
+    .gallery .ad,
+    .gallery figure,
+    .gallery img,
+    .preview-gallery .ad,
+    .preview-gallery figure,
+    .preview-gallery img {
+      max-height: 500px
+    }
 
-              <!--<![endif]-->
-              <header id="wp-header" class="site-header fixed site-header-standard not-logged-in" data-beta-btn="true">
-                <nav id="nav-bar" class="top-nav" role="navigation">
-                  <div class="main-navigation">
-                    <div id="main-navigation-left" class="nav-item">
-                      <ul class="buttons-inline">
-                        <li class="search-form-item hidden-xs">
-                          <form id="search-form" method="get" class="search" action="//www.washingtonpost.com/newssearch/"> <input id="search-field" autocomplete="off" name="query" type="text" class="form-control closed" placeholder="Search"> <i id="search-btn" class="fa fa-search closed"></i> </form>
-                        </li>
-                        <li class="hidden-xs"> <a href="#" id="section-menu-btn" class="button section-menu-btn sections"> Sections <i class="fa fa-bars"></i> </a> </li>
-                        <li class="mobile-nav-button visible-xs"> <a href="#" class="section-menu-btn"> <i class="fa fa-bars mobile-hamburger-ic" id="mobile-hamburger-ic"></i> </a> </li>
-                        <li id="section-menu-home" class="menu hidden-xs hide"> <a href="https://www.washingtonpost.com/?tid=tst_homelink">Home</a> </li>
-                      </ul>
-                    </div>
-                    <div id="logo-in-nav" class="nav-item nav-display-show " itemprop="publisher" itemscope itemtype="https://schema.org/Organization"> <a href="https://www.washingtonpost.com" class="wp-logo-link" itemprop="logo" itemscope itemtype="https://schema.org/ImageObject"> <svg id="TWP_logo_svg" xmlns="http://www.w3.org/2000/svg" width="697.01" height="104.61" viewBox="0 0 697.01 104.61" aria-labelledby="TWP_logo_desc" role="img">
-                          <desc id="TWP_logo_desc">The Washington Post logo</desc>
-                          <path d="M39.2,32V68.6c4.7-2.8,7-6.8,8.7-12.1l1.2.6c-1.1,13.2-10.3,26-24.3,26S0,72.6,0,55.8C0,43,7.7,35.1,18.7,28.2a16.11,16.11,0,0,0-4.4-.6c-7.2,0-11.4,4.9-11.4,9.9H1.5a14.77,14.77,0,0,1-.1-2.1c0-9.3,5.5-19.7,16.9-19.7,7.3,0,12.9,6.7,21.4,6.7,4.3,0,6.7-1.6,8.4-5.3h1.2C49.2,23.6,47.3,29.9,39.2,32Zm-19-3.3C15.1,34,10.1,39.6,10.1,50.9c0,6.2,1.9,12.4,6.6,16.4l3.1-1.7V40.3L16.6,42l-1-1.6,15-8.4C26.8,31.2,23.7,29.7,20.2,28.7Zm17.1,3.7a17,17,0,0,1-2.3.1,17.52,17.52,0,0,1-4-.4V61.6l-12.8,7a15.57,15.57,0,0,0,9.9,3,22.58,22.58,0,0,0,9.2-2Zm44,9.2V75.9c0,9.6-8.51,16.11-18,18l-.6-1c4.7-2.3,7.8-6.41,7.8-11.41V45.7l-4.9-4.5L63,43.8V70.9l3,2.8v.4l-8.1,8.61L48.6,74.2v-.4L52.2,70V25.8L62.8,14.5l.2.1V41.2L71.7,32l8.7,7.9,2.7-2.6,1.31,1.3ZM97.91,62v4.5l9,7.1,7-7.3,1.3,1.3L101,82.8,88.21,72.6l-2.8,2.8-1.2-1.3,3.1-3.2V45.8L106.21,32l10.5,16.3Zm.2-22.6-.2.1V59.6l8.7-6.4Z" fill="#fff" />
-                          <path d="M180,82.71l-13.9-12-10.6,12L141.1,70.3V50.7h-2.8a3.89,3.89,0,0,0-4.1,3.5h-1a15.87,15.87,0,0,1-.5-3.8c0-2.6,1.1-9.4,8.4-9.4V25.8c0-5.9-3.9-6.2-3.9-11.3,0-5.7,5.4-11,15.3-14.5l.9.8c-3.3,1.6-6,3.6-6,7.9,0,6.6,6.4,4.9,6.4,15.3v4l11.7-12.3,12.3,12.1,11.6-12.1,11.2,11v37ZM165.4,32.8l-7-6.9-4.6,4.7V64.9l8.5,7.3,3.1-3.5ZM188,31.5l-5.6-5.6-4.3,4.3V64.8l9.8,8.6.1-.1Z" fill="#fff" />
-                          <path d="M232.8,82.71l-9.4-8.61h-.2l-8.3,8.61L204.8,73.8l-2.3,2.3-1.3-1.3,2.9-3V45.5l19-13.6,10.4,8.2,2.8-2.8,1.5,1.3L234.2,42V69.1l4.6,4.2,2.9-3,1.5,1.4ZM223.4,45.3l-8.3-6.5-.2.2V68.2l6.1,5.4,2.4-2.3ZM264,50.1h9.4V71.5L257.5,82.71a11.52,11.52,0,0,0-8.8-4.11c-3,0-5.4,1.4-7.8,4l-1.4-.5L253.3,62.3h-8.5V43.7L261.4,32c2,1.6,3.6,2.6,6.2,2.6a11.35,11.35,0,0,0,7.1-2.2l1,.7Zm-1.4,8.8h-4.7L246.8,74.8l.1.2a12.36,12.36,0,0,1,7.6-2.5,10.4,10.4,0,0,1,8,3.8l.1-.09ZM269,39.3a9.73,9.73,0,0,1-6.9,2.3,8.92,8.92,0,0,1-6.3-2.9l-.2.1V53.4h3.8l9.7-14Zm40,2.3V75.9c0,9.6-8.51,16.11-18,18l-.6-1c4.7-2.3,7.8-6.41,7.8-11.41V45.7l-4.9-4.5-2.6,2.6V70.9l3,2.8v.4l-8.1,8.61-9.3-8.51v-.4l3.6-3.8V25.8l10.6-11.3.2.1V41.2l8.7-9.2,8.71,7.9,2.7-2.6,1.3,1.3Zm19.6,41.11-8.3-7.61-2.8,2.8-1.3-1.3,3.3-3.4V44.7l-3.6-3.3-2.7,2.6-1.3-1.3L322,32l7.6,6.9,2.7-2.8,1.4,1.4-3.4,3.4V69.5l4.2,3.9,3-3.1,1.3,1.4Zm-2.9-51.61-8.2-7.5,7.5-8,8.2,7.5Z" fill="#fff" />
-                          <path d="M371.8,82.71l-8.7-7.91V45.6l-4.7-4.4L355,44.7V70.8l3.1,2.9v.4l-8.2,8.61-9.3-8.51v-.3l3.6-3.8V44.9l-4.1-3.7-3,3-1.4-1.3L345.9,32l9.1,8.1v2L364.5,32l8.7,7.8,2.9-2.9,1.3,1.4-3.5,3.5v28l3.9,3.7,3.3-3.4,1.2,1.3Zm43-41V75.6c0,5.2,2.9,5,2.9,8.9,0,4.51-6.5,8.71-16.5,16.21-3.3-3.6-5.6-5.1-8.7-5.1a19.85,19.85,0,0,0-10.7,3.6l-1-.8L394.5,82.3l-9-7.09-2.9,2.89-1.3-1.3,3.4-3.5V45.5l19-13.6,10.2,8,3-2.9,1.3,1.3Zm-7.7,41.71c-2.5-1.61-3.1-3.31-3.1-7.61V74.3L387.9,93l.1.1c3.2-1.9,5.6-3.1,10.3-3.1,4,0,6.9,1.7,9.5,4,1.9-1.6,3.3-3.2,3.3-5.7C411.1,86.31,409.6,85,407.1,83.41ZM404,45.3l-8.3-6.5-.2.2V69.7l5.9,4.6,2.6-3Zm31.5,37.41-8.8-6.91L424,78.5l-1.3-1.29L425.8,74V39.4H420l-.2-.2,3.5-5.2h2.5V27.3L436.4,16l.2.2V34h8l.2.2-3.5,5.2h-4.7V69.7l4.8,3.7,3.3-3.4,1.3,1.4ZM479.21,42.6V70.3l-16.9,12.5L450,73.5l-2.8,2.8L445.9,75l3.2-3.3v-27L466.81,32l11.4,8.9,2.9-2.9,1.3,1.4Zm-10.8,3L460,39l-.09.1V68.9l8.5,6.4Zm50.4,37-8.7-7.9V45.5l-4.7-4.4L502,44.6V70.7l3.1,2.9V74l-8.2,8.61-9.3-8.51v-.3l3.6-3.8V44.8l-4.1-3.7-3,3-1.4-1.3,10.2-10.9L502,40v2l9.5-10.1,8.7,7.8,2.9-2.9,1.3,1.4-3.5,3.5v28l3.9,3.7,3.3-3.4,1.2,1.3Z" fill="#fff" />
-                          <path d="M580.2,82.71a12.91,12.91,0,0,0-6.3-4.61V98.91l-.2.1-5.5-5.1-11.6,10.7-.2-.1V77.6a18.83,18.83,0,0,0-10.2,6.61l-.8-.5c.7-7.71,4.5-13.41,11-15.61V48.6h-2.1a5.25,5.25,0,0,0-5.3,4.2h-1.2a12.28,12.28,0,0,1-.7-4.6c0-4.9,3.3-8.6,8.7-8.6h.6V28.8l-3.6-3.2L550,28.4l-1.4-1.3,11.1-11.4,9.4,8.6v9.8L572,31V19.5h1.9V29l12.5-13.3L597.7,26V69.5ZM572,32.9l-2.9,3V92.21l2.9,2.7Zm13.1-2.3-5.9-5.4-5.3,5.6V67.1c4.7.6,8.2,2.2,11.1,5.3l.1-.1Zm48.7,12V70.3L616.9,82.8l-12.3-9.3-2.8,2.8L600.5,75l3.2-3.3v-27L621.4,32l11.4,8.9,2.9-2.9,1.3,1.4Zm-10.8,3L614.6,39l-.1.1V68.9l8.5,6.4Zm35.6,4.5H668V71.5L652.1,82.71a11.52,11.52,0,0,0-8.8-4.11c-3,0-5.4,1.4-7.8,4l-1.4-.5L647.9,62.3h-8.5V43.7L656,32c2,1.6,3.6,2.6,6.2,2.6a11.38,11.38,0,0,0,7.11-2.2l1,.7Zm-1.4,8.8h-4.7L641.4,74.8l.1.2a12.36,12.36,0,0,1,7.6-2.5,10.4,10.4,0,0,1,8,3.8l.1-.09Zm6.41-19.6a9.78,9.78,0,0,1-6.91,2.3,8.92,8.92,0,0,1-6.3-2.9l-.2.1V53.4H654l9.7-14Zm22.9,43.41-8.8-6.91L675,78.5l-1.3-1.29,3.1-3.21V39.4H671l-.2-.2,3.5-5.2h2.5V27.3L687.41,16l.2.2V34h8l.2.2-3.5,5.2h-4.7V69.7l4.8,3.7,3.3-3.4,1.3,1.4Z" fill="#fff" />
-                        </svg>
-                        <meta itemprop="url" content="https://www.washingtonpost.com/pb/resources/img/thewashingtonpost-white-2x.png">
-                        <meta itemprop="width" content="200">
-                        <meta itemprop="height" content="40">
-                        <div class="tagline-wrapper"> <span class="header-tagline">Democracy Dies in Darkness</span> </div>
-                      </a>
-                      <meta itemprop="name" content="washingtonpost">
-                    </div>
-                    <div id="main-navigation-right" class="nav-item">
-                      <div class="mobile-settings-button"> <a href="#" id="settings-nav-btn"> <span class="fa fa-user"></span> </a> </div>
-                      <div class="sign-up-buttons">
-                        <ul class="button-group" id="logged-in-status">
-                          <li id="nav-subscribe" class="hidden"> <a class="button subscribe ab-test-sub-btn blue-bkg" href="https://subscribe.washingtonpost.com/acquisition/?nid=top_pb_subscribe&promo=o3&oscode=RPWH&destination=/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/&tid=nav_subscribe_logged_out"> <span class="ab-lbl">Try 1 month for $1</span> </a> </li>
-                          <li id="nav-user" class="hidden-xs" data-show-identity="true" data-menu="user-menu"> <a class="button"> <span class="username">Username</span> <span class="fa fa-user"></span> </a> </li>
-                          <li class="nav-sign-in hidden"> <a id="sign-in-link" href="https://subscribe.washingtonpost.com/loginregistration/index.html?tid=nav_sign_in" class="button"> <span class="username">Sign In</span> <span class="fa fa-user"></span> </a>
-                            <hr class="separator">
-                          </li>
-                          <div class="visible-xs">
-                            <ul class="site-info">
-                              <li class="my-post"><a href="https://www.washingtonpost.com/my-post?tid=nav_acctmgnt_menu">My Post<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                              <li class="reading-list"><a href="https://www.washingtonpost.com/my-post/#/my-reading-list?tid=nav_acctmgnt_menu">My Reading List<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                              <li class="account-menu"><a href="https://subscribe.washingtonpost.com/profile/#/?destination=https://www.washingtonpost.com/?refresh=true&tid=nav_acctmgnt_menu">Account Settings<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                              <li><a href="https://subscribe.washingtonpost.com/newsletters?tid=nav_acctmgnt_menu">Newsletters & alerts<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                              <li><a href="https://subscribe.washingtonpost.com/gift?promo=g_d&tid=nav_acctmgnt_menu">Gift subscriptions<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                              <li><a href="http://help.washingtonpost.com/ics/support/ticketnewwizard.asp?tid=nav_acctmgnt_menu">Contact us<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                              <li><a href="http://help.washingtonpost.com/ics/support/KBSplash.asp?tid=nav_acctmgnt_menu">Help desk<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                            </ul>
-                          </div>
-                        </ul>
-                      </div>
-                      <div id="slug_88x31" data-ad-type="88x31" style="display:none;"></div>
-                    </div>
-                  </div>
-                </nav>
-                <div id="user-menu" class="nav-menu">
-                  <ul class="user-info" data-sub-href="https://subscribe.washingtonpost.com/acquisition/?nid=top_pb_subscribe&promo=o5&oscode=RPWH&destination=/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/&tid=nav_subscribe_logged_in" data-sub-text="Try 1 month for $1"></ul>
-                  <ul class="site-info">
-                    <li class="my-post"><a href="https://www.washingtonpost.com/my-post?tid=nav_acctmgnt_menu">My Post<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                    <li class="reading-list"><a href="https://www.washingtonpost.com/my-post/#/my-reading-list?tid=nav_acctmgnt_menu">My Reading List<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                    <li class="account-menu"><a href="https://subscribe.washingtonpost.com/profile/#/?destination=https://www.washingtonpost.com/?refresh=true&tid=nav_acctmgnt_menu">Account Settings<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                    <li><a href="https://subscribe.washingtonpost.com/newsletters?tid=nav_acctmgnt_menu">Newsletters & alerts<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                    <li><a href="https://subscribe.washingtonpost.com/gift?promo=g_d&tid=nav_acctmgnt_menu">Gift subscriptions<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                    <li><a href="http://help.washingtonpost.com/ics/support/ticketnewwizard.asp?tid=nav_acctmgnt_menu">Contact us<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                    <li><a href="http://help.washingtonpost.com/ics/support/KBSplash.asp?tid=nav_acctmgnt_menu">Help desk<i class="fa fa-angle-right main-nav-angle"></i></a></li>
-                  </ul>
-                </div>
-              </header>
-            </div>
+    .gallery .ad.fullscreen,
+    .gallery figure.fullscreen,
+    .gallery img.fullscreen,
+    .preview-gallery .ad.fullscreen,
+    .preview-gallery figure.fullscreen,
+    .preview-gallery img.fullscreen {
+      height: 100vh;
+      max-height: 100vh
+    }
 
-            <!--[if IE 8]><div id="main-sections-nav" class="sections-nav ie8"><![endif]-->
+    .gallery .icon-chevron-left,
+    .gallery .icon-chevron-right,
+    .preview-gallery .icon-chevron-left,
+    .preview-gallery .icon-chevron-right {
+      filter: drop-shadow(0 0 4px rgba(0, 0, 0, .5))
+    }
 
-            <!--[if IE 9]><div id="main-sections-nav" class="sections-nav ie9"><![endif]-->
+    .gallery wp-ad,
+    .preview-gallery wp-ad {
+      height: 1px;
+      width: 1px
+    }
 
-            <!--[if !IE]>
-<!-->
-            <div id="main-sections-nav" class="sections-nav hide-subscribe-left-nav">
+    .hp-top-nav-menu:last-child {
+      margin-right: 24px
+    }
 
-              <!--<![endif]-->
-              <div id="main-sections-nav-inner" class="sections-nav unfetched-menu ">
-                <div id="sections-menu-off-canvas-alt">
-                  <ul class="side-nav">
-                    <li id="nav-screenreader-link" class="main-nav nav-screenreader-link"> <a class="main-nav-item screenreader-link" target="_self" href="http://www.washingtonpost.com/pb/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/?outputType=accessibility&nid=menu_nav_accessibilityforscreenreader">Accessibility for screenreader</a> </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-            <div id="wp-logo-for-print"> <img class="unprocessed" data-hi-res-src="https://www.washingtonpost.com/pb/resources/img/washingtonpost_black_32.png" alt="The Washington Post"> </div>
-          </div>
-          <div id="fZ4p1229hDierr" class="pb-async pb-feature"></div>
-          <div id="f0WSVQ99hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-ad-interstitial" moat-id="ad/interstitial" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="ad/interstitial" data-pb-fingerprint="0f8HpfNxcqR" id="f0Qxh4J9hDierr">
-            <div class="zeus-ads-fixed" id="zeus-ads-fixed">
-              <div class="ad-interstitial">
-                <wp-ad id="slug_interstitial"></wp-ad>
-              </div>
-            </div>
-            <script>
-              (function() {
-                if (!document.getElementById("article-full-width-content")) {
-                  var container = document.getElementById("zeus-ads-fixed"),
-                    parent = document.body;
-                  parent.insertBefore(container, parent.firstChild)
-                }
-              })();
-            </script>
-          </div>
-          <div class="pb-container"> </div>
-        </section>
-      </div>
-      <div id="article-standard-content" class="clear">
-        <section id="top-content" class="col-xs-12 layout">
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-ad-leaderboard" moat-id="ad/leaderboard" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="ad/leaderboard" data-pb-fingerprint="0fSQDbXsipr" id="fXC3wI19hDierr">
-            <div class="leaderboard ad-hideable">
-              <wp-ad id="slug_leaderboard" class="pb-ad-container"></wp-ad>
-              <div class="leaderboard-close fa"></div>
-            </div>
-            <div class="mobile-fixed ad-hideable">
-              <div id="slug_t" data-ad-type="t" class="pb-ad-container-mobile" style="display:none;"> </div>
-            </div>
-            <script>
-              (function() {
-                TWP = window.TWP || {};
-                TWP.Features = TWP.Features || {};
-                TWP.Features.Ad = TWP.Features.Ad || {};
-                TWP.Features.Ad.Leaderboard = {};
-                TWP.Features.Ad.Leaderboard.viewability = false;
-                TWP.Features.Ad.Leaderboard.sticky = true;
-                TWP.Features.Ad.Leaderboard.belowSharebar = false
-              })();
-            </script>
-          </div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-article-article-topper" moat-id="article/article-topper" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="article/article-topper" data-pb-fingerprint="0faWpqkNKqf" id="faPYeH19hDierr">
-            <div class="border-bottom-off border-bottom-100-pct">
-              <div id="article-topper" class="article-topper ">
-                <div class="headline-kicker"><a class="kicker-link" href="http://www.washingtonpost.com/news/the-intersect">Internet Culture</a></div>
-                <div id="topper-headline-wrapper">
-                  <div class="topper-headline">
-                    <h1 data-pb-field="custom.topperDisplayName" itemprop="headline">Twitter says goodbye to all ‘.@’</h1>
-                  </div>
-                  <div id="save_pennant_wrapper" style="display:none;" data-canonical-url="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/">
-                    <div class="save-pennant unsaved active" data-action="save" data-update-action="saved">
-                      <div class="pennant-icon fa fa-plus-alt"></div>
-                      <div class="pennant-text">Add to list</div>
-                    </div>
-                    <div class="save-pennant saved" data-action="unsave" data-update-action="unsaved">
-                      <div class="pennant-icon fa fa-check-alt"></div>
-                      <div class="pennant-text">In my list</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="clear"></div>
-              </div>
-            </div>
-          </div>
-          <div class="pb-container"> </div>
-        </section>
-        <section id="main-content" class="col-xl-9 col-lg-8 col-md-8 col-sm-12 col-xs-12 col-xs-offset-0 col-sm-offset-0 col-md-offset-0 col-lg-offset-0 layout">
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-article-article-deck" moat-id="article/article-deck" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="article/article-deck" data-pb-fingerprint="0fWUbLkNKq0" id="fuFSQl19hDierr"> </div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-article-article-body" moat-id="article/article-body" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="article/article-body" data-pb-fingerprint="0fDDVXkNKqc" id="flCmvB19hDierr">
-            <div id="article-body" class="article-body content-format-ans ">
-              <article itemprop="articleBody" class="paywall">
-                <div data-elm-loc="0" class="inline-content inline-photo inline-photo-normal "> <a name="G3HCEPO6HY2YTJA4TBWWWXGYPA"></a> <img class src="https://www.washingtonpost.com/resizer/5nFcoIV4KQAkWpUGzzpE9GRhV-0=/960x0/arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg" data-hi-res-src="https://www.washingtonpost.com/resizer/5nFcoIV4KQAkWpUGzzpE9GRhV-0=/960x0/arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg" srcset="https://www.washingtonpost.com/resizer/RQX1Gqg3PCipSwsaIhSJOw8SHYY=/480x0/arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg 480w,https://www.washingtonpost.com/resizer/5nFcoIV4KQAkWpUGzzpE9GRhV-0=/960x0/arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg 960w" sizes="(min-width: 768px) 50vw, 100vw"><br> <span class="pb-caption">(Leon Neal/AFP/Getty Images)</span> </div>
-                <div class="author-sig-line-wrapper">
-                  <div class="author-sig-line">
-                    <div class="author-byline ">
-                      <div class="author-wrapper" data-authorname="Abby Ohlheiser">
-                        <div class="author-info"> <span class="by-lbl">By</span> <a class="author-name" href="https://www.washingtonpost.com/people/abby-ohlheiser/"> Abby Ohlheiser</a> </div>
-                        <div class="author-hover-card">
-                          <div class="content ">
-                            <div class="author-headshot"> <a href="https://www.washingtonpost.com/people/abby-ohlheiser/"> <img class="unprocessed _1-to-1 placeholder " src="https://www.washingtonpost.com/resizer/yAFxThroW-CI5t-yu8Q6FsF7kHI=/1x1/www.washingtonpost.com/pb/resources/img/spacer.gif" data-hi-res-src="https://www.washingtonpost.com/resizer/m2eHMoHk0xhs6WUkVcECn6zElRQ=/90x90/s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png" data-low-res-src="https://www.washingtonpost.com/resizer/5vbpPrOTbNGC1coxYh0t4-xbzvE=/29x29/s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png" data-raw-src="https://s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png" data-threshold="29"> </a> </div> <a class="author-name" href="https://www.washingtonpost.com/people/abby-ohlheiser/"> Abby Ohlheiser</a>
-                            <div class="author-bio">Reporter covering digital culture </div>
-                            <div class="social-links"> <a href="mailto:abigail.ohlheiser@washpost.com?subject='Twitter says goodbye to all ‘.@’'"><span class="social-lbl">Email </span><i class="fa fa-envelope"></i></a> <a href="https://www.washingtonpost.com/people/abby-ohlheiser/"><span>Bio</span> <i class="fa fa-external-link-alt"></i></a> <a href="https://twitter.com/abbyohlheiser">Follow <i class="fa fa-twitter"></i> </a> </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div> <span class="author-timestamp" itemprop="datePublished" content="2016-05-24T02:20-500">May 24, 2016</span>
-                </div>
-                <p data-elm-loc="1">Twitter announced a plan to make itself simpler Tuesday by, among other things, removing the need for a popular, improvised equivalent of a stage whisper.  The changes are the latest iteration of the microblogging site’s attempts to make itself more appealing to new users. For instance, a few months ago, <a href="https://www.washingtonpost.com/news/the-intersect/wp/2015/11/03/twitter-just-eliminated-the-favorite-and-replaced-it-with-heart-shaped-likes/">it changed its “favorite” button</a> — a way to interact with a tweet without actually writing a reply — to the more universally understood “like” button.</p>
-                <p data-elm-loc="2">The company clearly believes that it needs to change some things to attract and keep new users, but doesn’t seem inclined to change anything so radically that it would upset loyalists enough for them to leave. That being said, pretty much any change to Twitter has the effect of upsetting its biggest fans<em> a little</em>: when “fav” became “like” last year, many hard-core users freaked out a bit, before adjusting to the fact that one of the site’s buttons had changed from a star to a heart and it was fine. A <a href="https://www.washingtonpost.com/news/the-intersect/wp/2016/01/06/twitters-rumored-character-limit-change-is-bad-news-for-artists-and-botmakers/">rumored plan to dramatically increase Twitter’s character limits</a>, however, crossed that line, and <a href="http://techcrunch.com/2016/03/18/jack-dorsey-140-characters/">Twitter’s chief executive Jack Dorsey eventually disavowed it</a>.</p>
-                <p data-elm-loc="3" class="interstitial-link "><i>[<a href="https://www.washingtonpost.com/news/the-switch/wp/2016/05/24/congrats-twitter-some-people-are-actually-happy-about-your-latest-changes/">Congrats, Twitter! Some people are actually happy about your latest changes.</a>]</i></p>
-                <p data-elm-loc="4">While incremental, the newest round of changes — rolling out in the coming months, Twitter says — will eliminate some of the creative workarounds Twitter’s users have developed to get the most out of the 140-character limited platform. In other words, tweets will be longer, but not in the way that everyone feared. “You can already do a lot in a Tweet, but we want you to be able to do even more,” <a href="https://blog.twitter.com/express-even-more-in-140-characters">Twitter’s announcement reads</a>. My colleague Hayley Tsukayama<a href="https://www.washingtonpost.com/news/the-switch/wp/2016/05/24/congrats-twitter-some-people-are-actually-happy-about-your-latest-changes/"> has a full-run down</a> of all the announced changes at The Switch.</p>
-                <p data-elm-loc="5">A couple of tweaks to what “counts” towards Twitter’s short character limit will expand the length of tweets without going too crazy. Other announced changes will tweak the reach of some tweets. That includes one of the more interesting changes, which will largely eliminate the need for the “.@,” a weird, organic solution to one of Twitter’s quirks. Unfortunately, the change isn’t explained very clearly in Twitter’s announcement, so we’ve done our best to break down what will — and won’t — be changing below.</p>
-                <div data-elm-loc="6" class="inline-content inline-video">
-                  <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false pb-feature pb-layout-item pb-f-posttv-powa-promo" moat-id="posttv/powa-promo" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="posttv/powa-promo" data-pb-fingerprint="0feVqnYdtrC" id> <textarea id="powa-embedHtml-a7b621ae-685a-11e5-bdb6-6861f4521205" hidden style="display: none">   <div class="posttv-video-embed powa" data-org="wapo" data-uuid="a7b621ae-685a-11e5-bdb6-6861f4521205" data-ad-bar="1" data-playthrough="1" data-blurb="1" data-object-id="560d6132e4b01e7190724342" data-youtube-id="7Bo_NH-upJQ" data-live="0" data-aspect-ratio="0.5625">
- <!--script type="text/javascript" src="https://d1pz6dax0t5mop.cloudfront.net/prod/PoWaLoaderWapo.js?_=20181113" async></script--> </div>
-</textarea>
-                    <div class="powa-boot-url" data-powa-boot-url="https://d1pz6dax0t5mop.cloudfront.net/v/1.5.13/powaBoot.js" hidden style="display: none"></div>
-                    <div style="padding-bottom: 56.25%">
-                      <div class="powa-promo powa-top-left-thing" data-uuid="a7b621ae-685a-11e5-bdb6-6861f4521205" data-element-index="6"></div>
-                      <div class="powa-player-goes-here powa-top-left-thing" data-uuid="a7b621ae-685a-11e5-bdb6-6861f4521205"></div>
-                    </div>
-                    <script src="https://d2p9l91d5g68ru.cloudfront.net/VideoAnalytics/v/0.0.13/VideoAnalytics.js" async data-video-analytics-js data-powa-script onload="this.setAttribute('data-load',true)" onerror="this.setAttribute('data-error',true)"> </script>
-                  </div>
-                  <link href="/pb/gr/f/default-article/posttv/powa-promo/style.css?_=36acc" rel="stylesheet" media="none" onload="if(media!='all')media='all'">
-                  <script defer src="/pb/gr/f/default-article/posttv/powa-promo/render.js?_=36acc"></script>
-                </div>
-                <p data-elm-loc="7">See, Twitter doesn’t display every tweet of yours to all your followers. Anything that begins with an “@” is treated like a reply, and has a pretty limited reach. You’ll see @-beginning tweets only if both the person tagged and the person tweeting are people you follow. In recent years, Twitter has started to separate out “reply” tweets more and more. When several tweets written as replies to previous ones become a longer conversation, Twitter <a href="https://blog.twitter.com/2013/keep-up-with-conversations-on-twitter">bundles it for you</a> and shows it to you as a linked string of tweets.</p>
-                <p data-elm-loc="8" class="interstitial-link "><i>[<a href="https://www.washingtonpost.com/news/the-intersect/wp/2016/03/07/a-short-history-of/?tid=sm_tw">The ‘@’ symbol was almost lost to history. Here’s how Ray Tomlinson saved it.</a>]</i></p>
-                <p data-elm-loc="9">But not every tweet that begins with an “@” is actually a reply to another user. Sometimes the tweet is simply a sentence that begins with a reference to another user. Other times, it’s a stage whisper: The tweet is addressed to one person, but it’s meant for everyone to see. To get around the fact that Twitter automatically limits the reach of and “@”-leading tweets, even if they’re not actually meant as a reply to a previous tweet, many users put a single character, usually an “.” right at the beginning, to prevent Twitter from handling it like a reply. Celebrities do this a lot:</p>
-                <p data-elm-loc="11">But “.@” no more! Twitter will now automatically show those stage whisper tweets to all your followers — so long as it’s not tweeted in reply to something else. Those actual replies will remain limited in reach, in the same way they are now. But Twitter has a way to make sure you can force all your followers to see your witty comeback, should you wish to do that.</p>
-                <p data-elm-loc="12">Introducing the self-retweet, or a new thing Twitter is allowing its users to do to draw attention to their own tweets and replies. Once Twitter enables the retweet function for all users to use on their own tweets, Twitter says, “you can easily Retweet or Quote Tweet yourself when you want to share a new reflection or feel like a really good one went unnoticed,” Twitter’s announcement explains.</p>
-                <p data-elm-loc="13" class="interstitial-link "><i>[<a href="https://www.washingtonpost.com/news/the-intersect/wp/2016/03/21/the-surprising-truth-about-how-twitter-has-changed-your-brain/">The surprising truth about how Twitter has changed your brain</a>]</i></p>
-                <p data-elm-loc="14">Like that “.@” elimination, the self-retweet isn’t the result of a totally new invention. It’s already possible to place a link to your own tweet in a new one. Some users have taken to replying to their own tweets over the course of many days to revive the entire thread for their followers as a bundled conversation. And there’s always the manual retweet, although these days that’s considered to be <a href="https://www.buzzfeed.com/katienotopoulos/the-latest-twitter-trend-manual-retweet-shaming?utm_term=.bwLLgPqPN#.brpJYeNeA">a very bad thing to do on Twitter</a>. The self-retweet change simply makes it easier to do something its users were doing already.</p>
-                <p data-elm-loc="15">Will hard-core users still “.@” for old time’s sake? probably, for a little bit. But longtime users are used to adapting to Twitter’s attempts to absorb the organic, creative workarounds to the platform’s limitations in the past. Twitter didn’t always allow users to post photos, so someone made TwitPic. Twitter then made the service irrelevant in 2011, when it <a href="https://blog.twitter.com/2011/searchphotos">announced a new capacity</a> to host photo and video itself. Twitter didn’t always automatically shorten URLs, so users used link shorteners to minimize the number of characters a link ate up. Now, Twitter <a href="https://twitter.com/twitter/status/735153337746653184">won’t count media attachments</a> towards the character limit.</p>
-                <p data-elm-loc="16">Since the changes haven’t even rolled out yet, it’s too early to bury the “.@” next to the manual retweet in the graveyard of obsolete Twitter conventions. But it’s not long for this world.</p>
-                <p data-elm-loc="17"><strong>Liked that? try these:</strong></p>
-                <ul data-elm-loc="18">
-                  <li><strong><a href="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/03/the-pre-twitter-history-of-twitters-favorite-insult/">The pre-Twitter history of Twitter’s favorite insult </a></strong></li>
-                  <li><strong><a href="https://www.washingtonpost.com/news/the-intersect/wp/2016/02/11/the-internets-top-dog-rater-keeps-disappearing-from-twitter/">The Internet’s most famous dog rater keeps disappearing from Twitter</a></strong></li>
-                  <li><strong><a href="https://www.washingtonpost.com/news/the-intersect/wp/2014/05/23/what-happens-when-everyword-ends/">A eulogy for @everyword</a></strong></li>
-                </ul>
-              </article>
-              <div class="clear"></div>
-            </div>
-          </div>
-          <div id="fjmMms19hDierr" class="pb-async pb-feature"></div>
-          <div id="fr8I2t19hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-article-article-author-bio" moat-id="article/article-author-bio" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="article/article-author-bio" data-pb-fingerprint="0fReOBlNKqz" id="f0ZPcLY9hDierr">
-            <div class="pb-author-sig-line-wrapper pb-author-post-body">
-              <div class="pb-author-sig-line">
-                <div class="pb-author-byline">
-                  <div class="pb-author-wrapper" data-authorname="Abby Ohlheiser">
-                    <div class="pb-author-headshot"><a href="https://www.washingtonpost.com/people/abby-ohlheiser/" class="headshot-link"><img class="unprocessed _1-to-1 placeholder pb-headshot" src="https://www.washingtonpost.com/resizer/yAFxThroW-CI5t-yu8Q6FsF7kHI=/1x1/www.washingtonpost.com/pb/resources/img/spacer.gif" data-hi-res-src="https://www.washingtonpost.com/resizer/XVDX0zjUWUn5yp2rh10lzdaJNcs=/60x60/s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png" data-low-res-src="https://www.washingtonpost.com/resizer/C5GNdRmBXcryUXLGUAzdijF1sbU=/19x19/s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png" data-raw-src="https://s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png" data-threshold="19"></a></div>
-                    <div class="pb-author-info"> <a class="pb-author-name" href="https://www.washingtonpost.com/people/abby-ohlheiser/"> Abby Ohlheiser</a> <span class="pb-author-role">Abby Ohlheiser covers digital culture for The Washington Post. She was previously a general assignment reporter for The Post, focusing on national breaking news and religion. <a class="twitter-link" href="https://twitter.com/abbyohlheiser"> Follow <i class="fa fa-twitter"></i> </a> </span> </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div id="f0eOpVB9hDierr" class="pb-async pb-feature"></div>
-          <div id="f0iZ4Qj9hDierr" class="pb-async pb-feature"></div>
-          <div id="fI4HaU19hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-tools-feature-loader" moat-id="tools/feature-loader" data-chain-name="no-name" data-feature-name="outbrain-loader" data-feature-id="tools/feature-loader" data-pb-fingerprint="0fuyDdW0xq7" id="fogWta29hDierr">
-            <div data-conditionsurl="/pb/resources/conditions/outbrain.json" class="feature-loader-config" style="display: none;"></div>
-          </div>
-          <div id="fkynm719hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-tools-feature-loader" moat-id="tools/feature-loader" data-chain-name="no-name" data-feature-name="comments-loader" data-feature-id="tools/feature-loader" data-pb-fingerprint="0fdQDbXsipZ" id="fPYaMn19hDierr">
-            <div data-conditionsurl="/resources/conditions/comments.json" data-contenturi="/pb/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/" class="feature-loader-config" style="display: none;"></div>
-          </div>
-          <div class="pb-container"> </div>
-        </section>
-        <section id="right-rail" class="col-xl-3 col-lg-4 col-md-4 col-sm-10 col-xs-10 col-xs-offset-1 col-sm-offset-1 col-md-offset-0 layout">
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-ad-flex" moat-id="ad/flex" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="ad/flex" data-pb-fingerprint="0fKQDbXsip9" id="f9hLdN19hDierr">
-            <wp-ad id="slug_flex_ss_bb_hp" class="pb-ad-container border-bottom-airy border-bottom-" data-ad-type="flex_ss_bb_hp"></wp-ad>
-            <script>
-              (function() {
-                TWP = window.TWP || {};
-                TWP.Features = TWP.Features || {};
-                TWP.Features.Ad = TWP.Features.Ad || {};
-                TWP.Features.Ad.flexAd = {};
-                TWP.Features.Ad.flexAd.sticky = true
-              })();
-            </script>
-          </div>
-          <div id="ftnL3829hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-ad-flex-2" moat-id="ad/flex-2" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="ad/flex-2" data-pb-fingerprint="0fkQDbXsip4" id="fuWjCI19hDierr">
-            <wp-ad id="slug_flex_ss_bb_hp_2" class="pb-ad-container border-bottom-airy border-bottom-" data-ad-type-placeholder="flex_ss_bb_hp|2" data-ad-delivery="vi"></wp-ad>
-          </div>
-          <div class="pb-container">
-            <div id="f0pq90L9hDierr" class="pb-async pb-feature"></div>
-          </div>
-          <div id="f5Gy9L19hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-ad-flex-4" moat-id="ad/flex-4" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="ad/flex-4" data-pb-fingerprint="0fxD2bQBPq5" id="fR11I429hDierr">
-            <wp-ad id="slug_flex_ss_bb_hp_4" class="pb-ad-container border-bottom-hairline border-bottom-100-pct" data-ad-type-placeholder="flex_flex_ss_bb_hp|4" data-ad-delivery="vi"></wp-ad>
-          </div>
-          <div id="fBHtB619hDierr" class="pb-async pb-feature"></div>
-          <div id="fcTchR19hDierr" class="pb-async pb-feature"></div>
-          <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false full pb-feature pb-layout-item pb-f-ad-flex-3" moat-id="ad/flex-3" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="ad/flex-3" data-pb-fingerprint="0fVQDbXsipy" id="f0dKJWh9hDierr">
-            <wp-ad id="slug_flex_ss_bb_hp_3" class="pb-ad-container border-bottom-airy border-bottom-" data-ad-type-placeholder="flex_ss_bb_hp|3" data-ad-delivery="vi"></wp-ad>
-            <script>
-              (function() {
-                TWP = window.TWP || {};
-                TWP.Features = TWP.Features || {};
-                TWP.Features.Ad = TWP.Features.Ad || {};
-                TWP.Features.Ad.flexAd3 = {};
-                TWP.Features.Ad.flexAd3.sticky = true
-              })();
-            </script>
-          </div>
-          <div class="pb-container"> </div>
-        </section>
-        <section id="bottom-content" class="col-xs-12 layout">
-          <div id="f0LPMZR9hDierr" class="pb-async pb-feature"></div>
-          <div class="pb-container"> </div>
-        </section>
-        <section id="bottom-furniture" class="col-xs-12 layout">
-          <div class="pb-container">
-            <div id="f07w5A49hDierr" class="pb-async pb-feature"></div>
-            <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate-false pb-f-async-false pb-feature pb-layout-item pb-f-bi-abtest" moat-id="bi/abtest" data-chain-name="no-name" data-feature-name="no-name" data-feature-id="bi/abtest" data-pb-fingerprint="0fZQDbXsipz" id="f0wD1gq9hDierr">
-              <script id="_$wapodarwintoolkitcode">
-                ! function() {
-                  (function(e, t) {
-                    function a(e) {
-                      return function(t, a, n) {
-                        if (a) e[t] = {
-                          when: function() {
-                            try {
-                              return a.call(e[t])
-                            } catch (e) {
-                              return console && console.warn('[when()@VisitorSegment("' + t + '")]', "Continuing despite error.", e), null
-                            }
-                          },
-                          setup: function() {
-                            try {
-                              return n.call(e[t])
-                            } catch (e) {
-                              return console && console.warn('[setup()@VisitorSegment("' + t + '")]', "Continuing despite error.", e), null
-                            }
-                          }
-                        }, n && (e[t]._setupResult = !!e[t].call(e[t]));
-                        else if (e[t]) return e[t].when.call(e[t], e[t]._setupResult)
-                      }
-                    }
-                    function n() {
-                      var e = navigator.userAgent;
-                      return !!(e.match(/Android/i) || e.match(/webOS/i) || e.match(/iPhone/i) || e.match(/iPad/i) || e.match(/iPod/i) || e.match(/BlackBerry/i) || e.match(/Kindle/i) || e.match(/Windows Phone/i) || e.match(/IEMobile/i))
-                    }
-                    function i(e) {
-                      var t = localStorage.getItem("_vsData") || "{}";
-                      return JSON.parse(t)[e]
-                    }
-                    function r(e, t) {
-                      var a = localStorage.getItem("_vsData") || "{}",
-                        a = JSON.parse(a);
-                      a[e] = t, t = JSON.stringify(a), localStorage.removeItem("_vsData"), localStorage.setItem("_vsData", t)
-                    }
-                    var o = e._vsdata = e._vsdata || {},
-                      s = function(e, t, n) {
-                        return a(o).call(this,
-                          e, t, n)
-                      };
-                    s.clone = function(e) {
-                      var t;
-                      if (e)
-                        if (null === o || "object" != typeof o) t = o;
-                        else {
-                          e = o.constructor();
-                          for (t in o) o.hasOwnProperty(t) && (e[t] = o[t]);
-                          t = e
-                        }
-                      else t = o;
-                      return a(t)
-                    };
-                    var c = {};
-                    s.resolve = function(e, t) {
-                      c[e] || (c[e] = []), setTimeout(function() {
-                        c[e].resolved = !0, c[e].argsobj = t;
-                        var a, n, i = c[e];
-                        for (n = 0; i.length, a = i[n]; n++) a.fn(t)
-                      }, 0)
-                    }, s.done = function(e, t) {
-                      e && t && (c[e] || (c[e] = []), c[e].resolved ? t(c[e].argsobj) : "function" == typeof t && c[e].push({
-                        fn: t
-                      }))
-                    }, s.Deferred = function(e) {
-                      this.done = function(t) {
-                          s.done(e, t)
-                        },
-                        this.resolve = function(t) {
-                          s.resolve(e, t)
-                        }
-                    }, s("desktop", function() {
-                      return !n()
-                    }), s("!mobile", function() {
-                      return !s("mobile")
-                    }), s("mobile", function() {
-                      return n()
-                    }), s("touch", function() {
-                      return !!("ontouchstart" in e)
-                    }), s("!touch", function() {
-                      return !s("touch")
-                    }), s("first_visit", function() {
-                      var e = i("first_time_start"),
-                        t = i("first_time_end");
-                      return e && !t && 18E5 <= (new Date).getTime() - (new Date(e)).getTime() ? (r("first_time_end", !0), !1) : e ? !t : (r("first_time_start", (new Date).getTime()), !0)
-                    }), e.VisitorSegment = s
-                  })(window),
-                  function(e, t, a) {
-                    function i(e, t) {
-                      function n(e) {
-                        this.$dw = i, this.length = 0, this._add = function(e, t) {
-                          var a = t.length;
-                          return p.each(e, function(e, n) {
-                            t[a + e] = n, t.length++
-                          }), t
-                        }, this._add(e, this), this.toArray = function() {
-                          var e = [];
-                          for (var t in this) this[t] instanceof i.Variant && e.push(this[t]);
-                          return e
-                        }
-                      }
-                      this._id = a, this._config = {}, this._testData = {}, this._ignoreBlacklist = a, this._state = "uninitialized", this._handlers = [], this._dispatches = {}, this._id = e || this._id, this._visitor = t || new this.Visitor({}, n), f[this._id] = this,
-                        this._handlers = v[this._id] || this._handlers, n.prototype = this.$plugins;
-                      var i = this;
-                      this._makeResult = function(e) {
-                        var t = e || [];
-                        return t.constructor !== Array && (t = [t]), new n(t)
-                      }
-                    }
-                    function r(e, t, a, i) {
-                      var r = [];
-                      return p.each(t, function(e, t) {
-                        var a = t.customOptions,
-                          i = "";
-                        if (a)
-                          for (n in a) a.hasOwnProperty(n) && (i += [n, a[n]].join("\x3d"));
-                        r.push(t.name + i)
-                      }), [e, r.sort().join(""), !!a, i].join("")
-                    }
-                    function o(e, t, a) {
-                      var n;
-                      return p.each(e, function(e, i) {
-                        if (i[t] == a) return n = i, !1
-                      }), n
-                    }
-                    function s(e) {
-                      if (!e) throw new Error("invalid name");
-                      return e.toLowerCase()
-                    }
-                    function c(e) {
-                      return {
-                        name: "Dw__" + e,
-                        visit: "Dw__" + e + "__visit",
-                        blacklisted: "Dw__" + e + "__blstd",
-                        compute: "Dw__" + e + "__cmpted",
-                        hash: "Dw__" + e + "__hash",
-                        phash: "Dw__" + e + "__phash"
-                      }
-                    }
-                    function l() {
-                      return Math.random(0, 1)
-                    }
-                    function m(e, t, a) {
-                      return e >= t && e <= a
-                    }
-                    function u(e, t) {
-                      var a, n = {};
-                      for (a in e[t]) "boolean" == typeof e[t][a] && (n[a] = !!e[t][a]);
-                      return n
-                    }
-                    function d(t) {
-                      var a, n, i, r = t || {},
-                        o = 0,
-                        s = [];
-                      for (n in r) i = e(n), i = i && i.constructor == Boolean, i && s.push(n), r.hasOwnProperty(n) && (a = a || !!r[n] && !!i, r[n] &&
-                        o++);
-                      return {
-                        match: s,
-                        value: !(0 !== o ? !a : 1 == Object.keys(r).length)
-                      }
-                    }
-                    var p = {
-                        each: function(e, t) {
-                          for (var a, n = 0; n < e.length && ("boolean" != typeof(a = t(n, e[n])) || a); n++);
-                        },
-                        remove: function(e, t) {
-                          return t > -1 && e.splice(t, 1), e
-                        },
-                        addClass: function(e, t) {
-                          e.classList.add(t)
-                        },
-                        removeClass: function(e, t) {
-                          e.classList.remove(t)
-                        }
-                      },
-                      v = {};
-                    if (t._dw && t._dw.constructor === Array) {
-                      for (var h = 0; h < t._dw.length; h++) v[t._dw[h][0]] || (v[t._dw[h][0]] = []), v[t._dw[h][0]].push(t._dw[h].slice(1, t._dw[h].length));
-                      t._dw.$plugins && (i.prototype.$plugins =
-                        t._dw.$plugins)
-                    }
-                    var f = {};
-                    t._dw = i, i.prototype.collections = function(e) {
-                        if (!e) return this._collections;
-                        this._collections = e
-                      }, i.prototype.init = function() {
-                        function e() {
-                          t.applyData.call(t, t.collections.call(t)), "initialized" != t._state && t.dispatch.call(t, "ready"), t._state = "initialized", t.dispatch.call(t, "init")
-                        }
-                        this.disabled = !this.collections(), this.dispatch("before");
-                        var t = this;
-                        this.deferSegments() ? this.push(["segments-done", e]) : e()
-                      }, i.prototype.config = function(e) {
-                        this._config.trackValueDelimiter = e.trackValueDelimiter,
-                          this._config.deferSegments = e.deferSegments, this.collections(e.collections || [])
-                      }, i.prototype.version = function() {
-                        return "2.0.0"
-                      }, i.prototype.id = function() {
-                        return this._id
-                      }, i.prototype.push = function(e) {
-                        this._dispatches[e[0]] && e[1] && e[1](this, this._dispatches[e[0]] ? this._dispatches[e[0]].data : a), this._handlers.push(e)
-                      }, i.prototype.dispatch = function(e, t) {
-                        var a = this;
-                        this._dispatches[e] = {
-                          ts: (new Date).getTime(),
-                          data: t
-                        }, this._handlers.length && p.each(this._handlers, function(t, n) {
-                          n[0] == e && n[1] && n[1](a, a._dispatches[e].data)
-                        })
-                      },
-                      i.prototype.state = function() {
-                        return this._state
-                      }, i.prototype.trackValueDelimiter = function() {
-                        return this._config.trackValueDelimiter
-                      }, i.prototype.deferSegments = function() {
-                        return this._config.deferSegments
-                      }, i.prototype.applyData = function(e) {
-                        var t;
-                        this.disabled || !this._detectLocalStorage() || this._isOptOut() || (t = this._datastore = {
-                            tests: []
-                          }, this._ignoreBlacklist = this._getLocalItem("Dw__ib"), p.each(e || [], function(e, a) {
-                            "boolean" != typeof a.disabled || a.disabled || Array.prototype.push.apply(t.tests, a.tests)
-                          }),
-                          this.collection(t))
-                      }, i.prototype.collection = function(e) {
-                        function t(e) {
-                          if (!e.name) throw new Error("missing name");
-                          var t = new this.Test(e, this);
-                          switch (0 == Object.keys(t).length && t.constructor == Object || (this._testData[e.name] = t), t.state) {
-                            case "registered":
-                              this.dispatch("variant-register", e.name);
-                              break;
-                            case "deregistered":
-                              this.dispatch("variant-deregister", e.name);
-                              break;
-                            case "persisted":
-                              this.dispatch("variant-persist", e.name)
-                          }
-                          return this.dispatch("variant-done", e.name), t
-                        }
-                        var a, n = this,
-                          i = [],
-                          r = [];
-                        e.disabled ||
-                          (a = e.tests || [], p.each(a, function(e, t) {
-                            t["x-linked"] ? i.push(t) : r.push(t)
-                          }), p.each(i, function(e, a) {
-                            if (a = t.call(n, a), a.variation && a.variation.run) return !1
-                          }), p.each(r, function(e, a) {
-                            t.call(n, a)
-                          }))
-                      }, i.prototype.ignoreBlacklist = function(e) {
-                        e ? (this._ignoreBlacklist = "yes", this._setLocalItem("Dw__ib", "yes")) : (this._ignoreBlacklist = a, this._removeLocalItem("Dw__ib"))
-                      }, i.prototype.optOut = function() {
-                        this._setLocalItem("Dw__OO", "yes")
-                      }, i.prototype.getVariant = function(e, t, n) {
-                        function i(e) {
-                          var a = !r.disabled && r._testData[e] || {},
-                            n = a.variation || new r.Variant(a, r);
-                          return t || !a.variation || n.historic || (n.historic = !0), n
-                        }
-                        var r = this;
-                        if ("." == e[0]) return this.$commands[e].call(this);
-                        e = e.constructor !== Array ? [e] : e;
-                        var o = [];
-                        return p.each(e, function(e, t) {
-                          var n = r.getTest(t),
-                            s = r._testData[t],
-                            c = s && s.variation ? s.variation.historic : a;
-                          r._testData[t] = new r.Test(n._originalData, r), r._testData[t].variation && (r._testData[t].variation.historic = c), o.push(i(t))
-                        }), n ? o : this._makeResult(o)
-                      }, i.prototype.use = function(e) {
-                        this.getVariant(e, !1, !1)
-                      }, i.prototype.get =
-                      function(e) {
-                        return this.getVariant(e, !1, !1)
-                      }, i.prototype.getTestOf = function(e) {
-                        return e.getTest()
-                      }, i.prototype.getToolkitOf = function(e) {
-                        return e.getToolkit()
-                      }, i.prototype.set = function(e, t) {
-                        var a = f[this.id()];
-                        a && 0 == this.find({
-                          name: e,
-                          run: !0
-                        }).length && (a._mset = a._mset || {}, a._mset[e] = {}, a._mset[e][t] = !0)
-                      }, i.prototype.$commands = {
-                        ".get_history": function() {
-                          return this.find({
-                            historic: !0
-                          })
-                        }
-                      }, i.prototype.segment = e, i.prototype.find = function(e) {
-                        var t = this,
-                          a = e || {},
-                          n = [];
-                        return p.each(this.collections(), function(e,
-                          i) {
-                          p.each(i.tests, function(e, i) {
-                            var r = 0,
-                              o = t.getVariant(i.name, !0, !0)[0];
-                            for (var s in a) a[s] instanceof RegExp ? (a[s].test(i[s]) || "string" == typeof o.name && a[s].test(o[s])) && r++ : (i[s] === a[s] || "string" == typeof o.name && o[s] === a[s]) && r++;
-                            r == Object.keys(a).length && n.push(o)
-                          })
-                        }), this._makeResult(n)
-                      }, i.prototype.clear = function() {
-                        delete f[this.id()]._mset;
-                        var e = this;
-                        p.each(this.collections(), function(t, a) {
-                          p.each(a.tests, function(t, a) {
-                            e._deregisterVariant(a.name)
-                          })
-                        })
-                      }, i.prototype.$handlers = {
-                        applyClass: function(e,
-                          t, a) {
-                          p.removeClass(this, "dw-not-loaded"), p.addClass(this, "dw-" + t + "-" + a + "-" + e)
-                        }
-                      }, i.prototype.applyClass = function(e, t, a) {
-                        var n = function(e) {
-                            var t = e.split(".");
-                            return {
-                              test: t[0],
-                              variant: t[1]
-                            }
-                          }(t),
-                          i = this.getVariant(n.test),
-                          r = i.is(n.variant);
-                        n.test && n.variant && (this.$handlers.applyClass.call(e, r, n.test, n.variant), a && a.call(e, r, n.test, n.variant))
-                      }, i.prototype.$plugins = i.prototype.$plugins || {}, i.prototype.$plugins.add = function(e) {
-                        return e = "string" == typeof e ? this.$dw.getVariant(e) : e, this.$dw._makeResult(this._add(e,
-                          this)), this
-                      }, i.prototype.$plugins.is = function(e) {
-                        function t(e, t) {
-                          return !!e && e === t.name
-                        }
-                        var a = !!this.length;
-                        return p.each(this, function(n, i) {
-                          t(e, i) || (a = !1)
-                        }), a
-                      }, i.prototype.$plugins.clear = function(e) {
-                        var t = this.$dw;
-                        p.each(this, function(e, a) {
-                          t._deregisterVariant(a.$tc.name)
-                        })
-                      }, i.prototype.$plugins.has = function(e) {
-                        function t(e, t) {
-                          return !!e && e === t.name
-                        }
-                        var a = !1;
-                        return p.each(this, function(n, i) {
-                          t(e, i) && (a = !0)
-                        }), a
-                      }, i.prototype.$plugins.toTrackVar = function(e, t, a) {
-                        function n(e, a) {
-                          if (a.trackvars) {
-                            var n = [],
-                              i = e || (a.trackvars[0] ? a.trackvars[0].name : "");
-                            return p.each(a.trackvars, function(e, t) {
-                              s(i) === s(t.name) && n.push(t.value)
-                            }), (n = n.join(o)) && (t ? t + o : "") + n
-                          }
-                        }
-                        var i = this.$dw,
-                          r = [],
-                          o = a || i.trackValueDelimiter();
-                        return p.each(this, function(t, a) {
-                          var i = n(e, a);
-                          i && r.push(i)
-                        }), r.join(o)
-                      }, i.prototype.$plugins.getTrackVar = i.prototype.$plugins.toTrackVar, i.prototype._deregisterVariant = function(e) {
-                        var t = c(e);
-                        this._removeLocalItem(t.name), this._removeLocalItem(t.visit), this._removeLocalItem(t.blacklisted), this._removeLocalItem(t.compute),
-                          this._removeLocalItem(t.hash), this._removeLocalItem(t.phash)
-                      }, i.prototype._detectLocalStorage = function() {
-                        var e = "_adwi_";
-                        try {
-                          return this._setLocalItem(e, e), this._removeLocalItem(e), !0
-                        } catch (e) {
-                          return !1
-                        }
-                      }, i.prototype._isOptOut = function() {
-                        return "yes" == this._getLocalItem("Dw__OO")
-                      }, i.prototype._removeLocalItem = function(e) {
-                        var t = [e, this.id()].join("|");
-                        localStorage.removeItem(t)
-                      }, i.prototype._getLocalItem = function(e) {
-                        var t = [e, this.id()].join("|");
-                        try {
-                          return localStorage.getItem(t)
-                        } catch (e) {
-                          return null
-                        }
-                      },
-                      i.prototype._setLocalItem = function(e, t) {
-                        var n = [e, this.id()].join("|");
-                        this._getLocalItem(n) && this._removeLocalItem(n);
-                        try {
-                          return localStorage.setItem(n, t)
-                        } catch (e) {
-                          return a
-                        }
-                      }, i.prototype.getTest = function(e) {
-                        return this._testData[e] || new this.Test({}, this)
-                      }, i.prototype.visitor = function() {
-                        return this._visitor
-                      }, i.prototype.Visitor = function(e, t) {
-                        this.has = function(e) {
-                          function a(e) {
-                            var t = e instanceof i.prototype.Variant ? e.getTest() : e || {};
-                            return "registered" == t.state || "persisted" == t.state
-                          }
-                          var n;
-                          return t &&
-                            e instanceof t ? p.each(e.toArray(), function(e, t) {
-                              if (!(n = a(t))) return !1
-                            }) : n = a(e), n
-                        }
-                      }, i.prototype.Variant = function(e, t) {
-                        var a = e || {};
-                        this.nocollect = !a.collect, this.historic = a.historic || !1, this.run = a.run || !1;
-                        var n = a.variation || {};
-                        this.getTest = function() {
-                          return t.getTest(a.name)
-                        }, this.name = n.name || "", this.trackvars = n.track || [], this.customOptions = n.customOptions || {}
-                      }, i.prototype.Test = function(e, t) {
-                        var n = e.name || "",
-                          i = c(n),
-                          r = e.increment || 0,
-                          o = e.variations || [],
-                          s = e["x-persist"] || !1,
-                          l = e.blacklist && e.blacklist.referrers || [],
-                          m = "yes" == t._getLocalItem(i.blacklisted),
-                          p = {
-                            domains: l,
-                            segment: u(e, "segment")
-                          };
-                        this._originalData = e, this.data = function(e, t) {
-                          if (t == a) return this._originalData[e];
-                          this._originalData[e] = t
-                        }, this.getToolkit = function() {
-                          return t
-                        };
-                        var v = d(p.segment);
-                        this.segments = p.segment ? v.match : [];
-                        var h = !!p.segment && v.value;
-                        m || t._getLocalItem(i.blacklisted) || (m = t._isBlacklisted(p.domains) || !h, t._setLocalItem(i.blacklisted, m ? "yes" : "no"));
-                        var f = !!o.length,
-                          y = o.length && new t.Variant(t._registerVariant(n, o, m, r, h, s), t);
-                        this.name =
-                          n, f && e.active && !y.nocollect && (this.variation = y);
-                        var _ = f && e.active ? e.defaultTrack : [];
-                        m && Array.prototype.push.apply(_, e.blacklist ? e.blacklist.track : []), (_.length && y.nocollect || !f || !y || !h) && (this.variation = new t.Variant({
-                          name: n,
-                          variation: {
-                            track: h ? _ : []
-                          }
-                        }, t)), f && y && h ? y && y.run ? this.state = "registered" : this.state = "persisted" : (t._deregisterVariant(n), this.state = "deregistered")
-                      }, i.prototype._registerVariant = function(e, t, a, n, i, s) {
-                        var u = c(e),
-                          d = {
-                            cur: s ? r(e, [], !1, n) : r(e, t, a, n),
-                            old: s ? this._getLocalItem(u.phash) : this._getLocalItem(u.hash)
-                          },
-                          v = this._getLocalItem(u.name),
-                          h = "yes" == this._getLocalItem(u.visit),
-                          y = "yes" == this._getLocalItem(u.compute),
-                          _ = function(e, t) {
-                            var e = parseFloat(e.customOptions.target),
-                              t = parseFloat(t.customOptions.target);
-                            return e < t ? -1 : e > t ? 1 : 0
-                          },
-                          g = f[this.id()],
-                          k = o(t, "name", v),
-                          b = !(!i || (y || a || "string" == typeof v || k) && (!y || d.cur == d.old));
-                        if (b)
-                          if (g._mset && g._mset[e]) p.each(t, function(t, a) {
-                            g._mset[e][a.name] && (k = a)
-                          });
-                          else {
-                            t.sort(_);
-                            var w = [],
-                              C = 0,
-                              x = 0;
-                            p.each(t, function(e, t) {
-                              var a = t.customOptions && t.customOptions.target;
-                              if (a) {
-                                a = parseFloat(a) / 100, C += a;
-                                var n = {
-                                  value: [x, C]
-                                };
-                                x += a, w.push(n)
-                              }
-                            });
-                            var L = l();
-                            p.each(w, function(e, t) {
-                              m(L, t.value[0], t.value[1]) && (v = e)
-                            }), k = t[v]
-                          } k ? this._setLocalItem(u.name, k.name) : this._setLocalItem(u.name, "_default"), this._setLocalItem(u.visit, "yes"), this._setLocalItem(u.compute, "yes"), this._setLocalItem(u.hash, d.cur), this._setLocalItem(u.phash, d.cur);
-                        var O = k && (!a || h) && {
-                          name: e,
-                          variation: k,
-                          collect: !0
-                        };
-                        return O || (O = {
-                          name: e
-                        }), O.run = b, O
-                      }, i.prototype._isBlacklisted = function(e) {
-                        function t(e) {
-                          return e.replace(/\./g,
-                            "\\.").replace(/\-/g, "\\-")
-                        }
-                        function a(e) {
-                          var a = new RegExp("^(http://)?(www\\.)?" + t(e), "gi");
-                          return !e && !document.referrer || (e && document.referrer.match(a) || []).length > 0
-                        }
-                        var n, i = e || [];
-                        return this._ignoreBlacklist || p.each(i, function(e, t) {
-                          return !(n = a(t))
-                        }), n
-                      }, e("darwin-toolkit:v2.0.0", function() {
-                        return !0
-                      }), t._dw.push = function(e) {
-                        f[e[0]] ? (f[e[0]]._dispatches[e[1]] && e[2] && e[2](f[e[0]]), f[e[0]]._handlers.push(e.slice(1, e.length))) : (v[e[0]] || (v[e[0]] = []), v[e[0]].push(e.slice(1, e.length)))
-                      }, t._dw
-                  }(VisitorSegment,
-                    this),
-                  function(e) {
-                    var t = new e("global"),
-                      a = {};
-                    a.trackValueDelimiter = ",", a.deferSegments = !0, a.collections = [{
-                      name: "recommendation",
-                      disabled: !1,
-                      tests: [{
-                        name: "recommendation-influencersexperiments",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 2,
-                        segment: {},
-                        _token: "107657",
-                        variations: [{
-                          customOptions: {
-                            target: "10"
-                          },
-                          name: "influencers",
-                          track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "recommendation-influencersexperiments:influencers"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "recommendation-influencersexperiments:influencers"
-                            },
-                            {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "recommendation-influencersexperiments-107657"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "recommendation-influencersexperiments-107657"
-                            }
-                          ]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "recommendation-influencersexperiments:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "recommendation-influencersexperiments:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "recommendation-influencersexperiments-107657"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "recommendation-influencersexperiments-107657"
-                        }]
-                      }]
-                    }, {
-                      name: "article",
-                      disabled: !1,
-                      tests: [{
-                        name: "article-mostReadOpinion",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {},
-                        _token: "e1236d",
-                        variations: [],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-mostReadOpinion:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-mostReadOpinion:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-mostReadOpinion-e1236d"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-mostReadOpinion-e1236d"
-                        }]
-                      }, {
-                        name: "article-oneClickNL",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {
-                          "not logged in mobile": !0
-                        },
-                        _token: "60e020",
-                        variations: [{
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "visual",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-oneClickNL:visual"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-oneClickNL:visual"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-oneClickNL-60e020"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-oneClickNL-60e020"
-                          }]
-                        }, {
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "oneClick",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-oneClickNL:oneClick"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-oneClickNL:oneClick"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-oneClickNL-60e020"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-oneClickNL-60e020"
-                          }]
-                        }, {
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "oneClickAlt",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-oneClickNL:oneClickAlt"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-oneClickNL:oneClickAlt"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-oneClickNL-60e020"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-oneClickNL-60e020"
-                          }]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-oneClickNL:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-oneClickNL:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-oneClickNL-60e020"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-oneClickNL-60e020"
-                        }]
-                      }, {
-                        name: "article-breakingnews",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {
-                          desktop: !0
-                        },
-                        _token: "3d7545",
-                        variations: [{
-                            customOptions: {
-                              target: "34"
-                            },
-                            name: "nobreakingnews",
-                            track: [{
-                                name: "list1",
-                                dynamic: !1,
-                                value: "article-breakingnews:nobreakingnews"
-                              },
-                              {
-                                name: "prop56",
-                                dynamic: !1,
-                                value: "article-breakingnews:nobreakingnews"
-                              }, {
-                                name: "list1",
-                                dynamic: !1,
-                                value: "article-breakingnews-3d7545"
-                              }, {
-                                name: "prop56",
-                                dynamic: !1,
-                                value: "article-breakingnews-3d7545"
-                              }
-                            ]
-                          }, {
-                            customOptions: {
-                              target: "33"
-                            },
-                            name: "sectionbreakingnews",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-breakingnews:sectionbreakingnews"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-breakingnews:sectionbreakingnews"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-breakingnews-3d7545"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-breakingnews-3d7545"
-                            }]
-                          },
-                          {
-                            customOptions: {
-                              target: "33"
-                            },
-                            name: "allbreakingnews",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-breakingnews:allbreakingnews"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-breakingnews:allbreakingnews"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-breakingnews-3d7545"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-breakingnews-3d7545"
-                            }]
-                          }
-                        ],
-                        defaultTrack: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-breakingnews:default"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-breakingnews:default"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-breakingnews-3d7545"
-                          },
-                          {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-breakingnews-3d7545"
-                          }
-                        ]
-                      }, {
-                        name: "article-mostReadNum",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {},
-                        _token: "c331cb",
-                        variations: [{
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "ten",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-mostReadNum:ten"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-mostReadNum:ten"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "article-mostReadNum-c331cb"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "article-mostReadNum-c331cb"
-                          }]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-mostReadNum:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-mostReadNum:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-mostReadNum-c331cb"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-mostReadNum-c331cb"
-                        }]
-                      }, {
-                        name: "article-curatedContent",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 1,
-                        segment: {},
-                        _token: "7d2dac",
-                        variations: [{
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "enabledhpfirst",
-                            track: [{
-                                name: "list1",
-                                dynamic: !1,
-                                value: "article-curatedContent:enabledhpfirst"
-                              },
-                              {
-                                name: "prop56",
-                                dynamic: !1,
-                                value: "article-curatedContent:enabledhpfirst"
-                              }, {
-                                name: "list1",
-                                dynamic: !1,
-                                value: "article-curatedContent-7d2dac"
-                              }, {
-                                name: "prop56",
-                                dynamic: !1,
-                                value: "article-curatedContent-7d2dac"
-                              }
-                            ]
-                          }, {
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "enabledprfirst",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-curatedContent:enabledprfirst"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-curatedContent:enabledprfirst"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-curatedContent-7d2dac"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-curatedContent-7d2dac"
-                            }]
-                          },
-                          {
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "enabledhponly",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-curatedContent:enabledhponly"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-curatedContent:enabledhponly"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "article-curatedContent-7d2dac"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "article-curatedContent-7d2dac"
-                            }]
-                          }
-                        ],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-curatedContent:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-curatedContent:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "article-curatedContent-7d2dac"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "article-curatedContent-7d2dac"
-                        }]
-                      }]
-                    }, {
-                      name: "modal",
-                      disabled: !1,
-                      tests: [{
-                        name: "modal-adblock_v1",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 6,
-                        segment: {
-                          adblock_generic: !0
-                        },
-                        _token: "61f727",
-                        variations: [{
-                          customOptions: {
-                            target: "95"
-                          },
-                          name: "enabled",
-                          track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v1:enabled"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v1:enabled"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v1-61f727"
-                            },
-                            {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v1-61f727"
-                            }
-                          ]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "modal-adblock_v1:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "modal-adblock_v1:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "modal-adblock_v1-61f727"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "modal-adblock_v1-61f727"
-                        }]
-                      }, {
-                        name: "modal-adblock_v2",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "1",
-                        increment: 0,
-                        segment: {
-                          adblock_generic: !0
-                        },
-                        _token: "275edf",
-                        variations: [{
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "var1",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v2:var1"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v2:var1"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v2-275edf"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v2-275edf"
-                            }]
-                          }, {
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "var2",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v2:var2"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v2:var2"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v2-275edf"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v2-275edf"
-                            }]
-                          },
-                          {
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "var3",
-                            track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v2:var3"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v2:var3"
-                            }, {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "modal-adblock_v2-275edf"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "modal-adblock_v2-275edf"
-                            }]
-                          }, {
-                            customOptions: {
-                              target: "25"
-                            },
-                            name: "controlvar",
-                            track: [{
-                                name: "list1",
-                                dynamic: !1,
-                                value: "modal-adblock_v2:controlvar"
-                              }, {
-                                name: "prop56",
-                                dynamic: !1,
-                                value: "modal-adblock_v2:controlvar"
-                              }, {
-                                name: "list1",
-                                dynamic: !1,
-                                value: "modal-adblock_v2-275edf"
-                              },
-                              {
-                                name: "prop56",
-                                dynamic: !1,
-                                value: "modal-adblock_v2-275edf"
-                              }
-                            ]
-                          }
-                        ],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "modal-adblock_v2:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "modal-adblock_v2:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "modal-adblock_v2-275edf"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "modal-adblock_v2-275edf"
-                        }]
-                      }]
-                    }, {
-                      name: "video",
-                      disabled: !1,
-                      tests: [{
-                        name: "video-adtimeout",
-                        active: !1,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 3,
-                        segment: {},
-                        _token: "397458",
-                        variations: [{
-                          customOptions: {
-                            target: "10"
-                          },
-                          name: "8s",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "video-adtimeout:8s"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "video-adtimeout:8s"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "video-adtimeout-397458"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "video-adtimeout-397458"
-                          }]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "video-adtimeout:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "video-adtimeout:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "video-adtimeout-397458"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "video-adtimeout-397458"
-                        }]
-                      }]
-                    }, {
-                      name: "upgrade",
-                      disabled: !1,
-                      tests: [{
-                        name: "upgrade-teaser",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 2,
-                        segment: {},
-                        _token: "b68e2b",
-                        variations: [],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "upgrade-teaser:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "upgrade-teaser:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "upgrade-teaser-b68e2b"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "upgrade-teaser-b68e2b"
-                        }]
-                      }, {
-                        name: "upgrade-toolkit_v110",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {},
-                        _token: "fe334d",
-                        variations: [{
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "variant_1",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "upgrade-toolkit_v110:variant_1"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "upgrade-toolkit_v110:variant_1"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "upgrade-toolkit_v110-fe334d"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "upgrade-toolkit_v110-fe334d"
-                          }]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "upgrade-toolkit_v110:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "upgrade-toolkit_v110:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "upgrade-toolkit_v110-fe334d"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "upgrade-toolkit_v110-fe334d"
-                        }]
-                      }, {
-                        name: "upgrade-remindmelater",
-                        active: !0,
-                        "x-persist": !1,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 1,
-                        segment: {},
-                        _token: "6270be",
-                        variations: [{
-                          customOptions: {
-                            target: "100"
-                          },
-                          name: "remindmelater",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "upgrade-remindmelater:remindmelater"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "upgrade-remindmelater:remindmelater"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "upgrade-remindmelater-6270be"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "upgrade-remindmelater-6270be"
-                          }]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "upgrade-remindmelater:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "upgrade-remindmelater:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "upgrade-remindmelater-6270be"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "upgrade-remindmelater-6270be"
-                        }]
-                      }]
-                    }, {
-                      name: "nav",
-                      disabled: !1,
-                      tests: [{
-                        name: "nav-notiJewel",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {},
-                        _token: "4e2542",
-                        variations: [{
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "jewel",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "nav-notiJewel:jewel"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "nav-notiJewel:jewel"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "nav-notiJewel-4e2542"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "nav-notiJewel-4e2542"
-                          }]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "nav-notiJewel:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "nav-notiJewel:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "nav-notiJewel-4e2542"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "nav-notiJewel-4e2542"
-                        }]
-                      }, {
-                        name: "nav-SubscribeButtonColor",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {
-                          desktop: !0
-                        },
-                        _token: "ac4076",
-                        variations: [{
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "Color1_Blue",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor:Color1_Blue"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor:Color1_Blue"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor-ac4076"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor-ac4076"
-                          }]
-                        }, {
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "Color2_BlueText",
-                          track: [{
-                            name: "list1",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor:Color2_BlueText"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor:Color2_BlueText"
-                          }, {
-                            name: "list1",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor-ac4076"
-                          }, {
-                            name: "prop56",
-                            dynamic: !1,
-                            value: "nav-SubscribeButtonColor-ac4076"
-                          }]
-                        }, {
-                          customOptions: {
-                            target: "25"
-                          },
-                          name: "Color3_BlackText",
-                          track: [{
-                              name: "list1",
-                              dynamic: !1,
-                              value: "nav-SubscribeButtonColor:Color3_BlackText"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "nav-SubscribeButtonColor:Color3_BlackText"
-                            },
-                            {
-                              name: "list1",
-                              dynamic: !1,
-                              value: "nav-SubscribeButtonColor-ac4076"
-                            }, {
-                              name: "prop56",
-                              dynamic: !1,
-                              value: "nav-SubscribeButtonColor-ac4076"
-                            }
-                          ]
-                        }],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "nav-SubscribeButtonColor:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "nav-SubscribeButtonColor:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "nav-SubscribeButtonColor-ac4076"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "nav-SubscribeButtonColor-ac4076"
-                        }]
-                      }, {
-                        name: "nav-homeLink",
-                        active: !0,
-                        "x-persist": !0,
-                        "x-status": "1",
-                        "x-linked": "0",
-                        increment: 0,
-                        segment: {
-                          desktop: !0
-                        },
-                        _token: "51c40b",
-                        variations: [],
-                        defaultTrack: [{
-                          name: "list1",
-                          dynamic: !1,
-                          value: "nav-homeLink:default"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "nav-homeLink:default"
-                        }, {
-                          name: "list1",
-                          dynamic: !1,
-                          value: "nav-homeLink-51c40b"
-                        }, {
-                          name: "prop56",
-                          dynamic: !1,
-                          value: "nav-homeLink-51c40b"
-                        }]
-                      }]
-                    }], t.config(a), this.__dwCallback__ ? this.__dwCallback__(t) : t.init()
-                  }(this._dw)
-                }();
-              </script>
-            </div>
-            <div class="moat-trackable pb-f-theme-normal pb-f-dehydrate- pb-f-async- pb-feature pb-layout-item pb-f-page-contextual-linking" moat-id="page/contextual-linking" data-chain-name="no-name" data-feature-name="contextual-linking" data-feature-id="page/contextual-linking" data-pb-fingerprint="0fii9DjtHq4" id="ffhI7w19hDierr">
-              <script>
-                try {
-                  if (wp_meta_data) {
-                    if (!wp_meta_data.contextualLinking) wp_meta_data.contextualLinking = {};
-                    (function() {
-                      wp_meta_data.contextualLinking.matches = []
-                    })()
-                  }
-                } catch (e) {};
-              </script>
-            </div>
-          </div>
-          <div id="fV9Lht19hDierr" class="pb-async pb-feature"></div>
-          <div class="pb-container"> </div>
-        </section>
-      </div>
-    </div>
-    <script>
-      (function() {
-        window.pbExternalResourcesLoaded = window.pbExternalResourcesLoaded || new Array;
-        window.pbTwpGlobalResourceGroups = window.pbTwpGlobalResourceGroups || new Array;
-        var isInitAnalytics = true;
-        var version = "",
-          env = "production",
-          fileList = [];
-        fileList.push("https://www.washingtonpost.com/wp-stat/analytics/latest/main.js?token\x3d201905231727ET");
-        fileList.push("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/conf-production/b5411285f6.js?_\x3df7342");
-        pbTwpGlobalResourceGroups.push({
-          "resourceType": "externalResources",
-          "name": "conf-production",
-          "fileType": "js"
-        });
-        pbExternalResourcesLoaded.push("/pb/resources/js/conf/production/conf.js?_\x3df7342");
-        var isLogged = document.cookie.match(/wpnisecure=([^;]+)/) ? true : false;
-        var sub = document.cookie.match(/rplsb=([1])\b/);
-        var wapo_sub = document.cookie.match(/wapo_actmgmt=(\b|.*\|)(isub:(\d))(\b|\|)([^;]*);/) ? RegExp.$3 : "";
-        var isSubscriber = sub || wapo_sub === "1" ? true : false;
-        if (!isSubscriber) {
-          fileList.push("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/identity-management-anon/2abcb5f7c0.js?_\x3dc355b");
-          pbTwpGlobalResourceGroups.push({
-            "resourceType": "externalResources",
-            "name": "identity-management-anon",
-            "fileType": "js"
-          });
-          pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/subscribe-with-google.js?_\x3d3ad7f");
-          pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/universal-signin-widget.js?_\x3dd950e")
-        }
-        fileList.push("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/identity-management-core/2595e79995.js?_\x3d7e3cd");
-        pbTwpGlobalResourceGroups.push({
-          "resourceType": "externalResources",
-          "name": "identity-management-core",
-          "fileType": "js"
-        });
-        pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/util-user-2.0.0.js?_\x3df738c");
-        pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/util.identity-management-2.0.0.js?_\x3d1e17d");
-        if (navigator.userAgent && /iPad|iPhone|iPod/.test(navigator.userAgent)) {
-          fileList.push("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/identity-management-mobile/676bfb953c.js?_\x3d778e4");
-          pbTwpGlobalResourceGroups.push({
-            "resourceType": "externalResources",
-            "name": "identity-management-mobile",
-            "fileType": "js"
-          });
-          pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/cookie-backup.js?_\x3d778e4")
-        }
-        if (isLogged) {
-          fileList.push("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/identity-management-nr/cb63500865.js?_\x3d778e4");
-          pbTwpGlobalResourceGroups.push({
-            "resourceType": "externalResources",
-            "name": "identity-management-nr",
-            "fileType": "js"
-          });
-          pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/news-reader.js?_\x3d778e4")
-        }
-        fileList.push("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/identity-management-osn/32792e74a4.js?_\x3da7490");
-        pbTwpGlobalResourceGroups.push({
-          "resourceType": "externalResources",
-          "name": "identity-management-osn",
-          "fileType": "js"
-        });
-        pbExternalResourcesLoaded.push("/pb/resources/js/identity-management/on-site-messaging.js?_\x3da7490");
-        var gdpr_cookie = document.cookie.match(/wp_gdpr=([1^]+)/) ? RegExp.$1 : null;
-        if (gdpr_cookie && gdpr_cookie === "1") {
-          fileList.unshift("//www.washingtonpost.com/pb/gr/c/default-article/r08eSKG9hDierr/eu-cookie-banner/87811ab41e.js?_\x3d3b3a5");
-          pbTwpGlobalResourceGroups.push({
-            "resourceType": "externalResources",
-            "name": "eu-cookie-banner",
-            "fileType": "js"
-          });
-          pbExternalResourcesLoaded.push("/pb/resources/js/utils/eu-cookie-banner.js?_\x3d3b3a5")
-        }
-        if (document.addEventListener) document.addEventListener("pb-core-loaded", function() {
-          wp_import.valor(true);
-          wp_import(fileList).always(function() {
-            isInitAnalytics && window.TWP && TWP.Analytics && TWP.Analytics.init({
-              trackScrolling: {
-                omniture: false
-              },
-              snowflake: true,
-              suppressTrackPageLoad: window.wp_pb.isPwa === "true" && !wp_pb.StaticMethods.isPageHydrated() ? true : false
-            })
-          })
-        });
-        else if (document.attachEvent) document.attachEvent("onreadystatechange",
-          function() {
-            if (document.readyState === "complete" || document.readyState === "interactive") {
-              document.detachEvent("onreadystatechange", arguments.callee);
-              wp_import.valor(true);
-              wp_import(fileList).always(function() {
-                isInitAnalytics && window.TWP && TWP.Analytics && TWP.Analytics.init({
-                  trackScrolling: {
-                    omniture: false
-                  },
-                  snowflake: true,
-                  suppressTrackPageLoad: window.wp_pb.isPwa === "true" && !wp_pb.StaticMethods.isPageHydrated() ? true : false
-                })
-              })
-            }
-          })
-      })();
-    </script>
-    <style>
-      .o_rpoawabc {
-        z-index: 134217726
+    .hp-top-nav-menu a {
+      color: #f0f0f0
+    }
+
+    .hp-top-nav-menu a:hover {
+      color: #fff
+    }
+
+    .article-body h3,
+    .article-body h4,
+    .article-body h5 {
+      font-family: Postoni, BodoniSvtyTwoITCTT-Book, georgia, serif;
+      line-height: 1.25
+    }
+
+    .article-body h3 {
+      font-size: 1.75rem
+    }
+
+    .article-body h4,
+    .article-body h5 {
+      font-size: 1.5rem
+    }
+
+    .inline-story div[data-qa=timestamp] {
+      line-height: 1
+    }
+
+    .kicker {
+      font-size: 1rem;
+      line-height: 1.25
+    }
+
+    .kicker-label:before {
+      border-radius: 50%;
+      height: 4px;
+      width: 4px;
+      background-color: #666;
+      vertical-align: middle;
+      display: inline-block;
+      content: "";
+      margin-left: 8px;
+      margin-right: 8px
+    }
+
+    .article-body p a:hover,
+    .link:hover {
+      color: #3d73d5
+    }
+
+    .link-hover-underline:hover {
+      text-decoration: underline
+    }
+
+    .hover-inherit:hover {
+      color: inherit
+    }
+
+    .article-body p a {
+      border-bottom: 1px solid #d5d5d5
+    }
+
+    .article-body .byline a {
+      border-color: #aaa
+    }
+
+    .article-body .inline-byline a {
+      border-color: #d5d5d5
+    }
+
+    .latest-update-link {
+      border-bottom: 1px solid #d5d5d5
+    }
+
+    .interstitial:before {
+      content: "["
+    }
+
+    .interstitial:after {
+      content: "]"
+    }
+
+    .fadeout {
+      overflow: hidden;
+      position: relative
+    }
+
+    .fadeout:before {
+      content: "";
+      height: 50%;
+      bottom: 0;
+      width: 100%;
+      position: absolute;
+      background: linear-gradient(180deg, hsla(0, 0%, 100%, 0), 30%, #fff)
+    }
+
+    .link-box .text-preview {
+      max-height: 380px
+    }
+
+    .list {
+      padding-left: 16px
+    }
+
+    .list-unstyled {
+      list-style-type: none;
+      margin: 0;
+      padding: 0
+    }
+
+    .magnet svg {
+      transition: opacity .2s cubic-bezier(.33, 1, .68, 1)
+    }
+
+    .hover-blue:hover {
+      color: #1955a5
+    }
+
+    .tooltip {
+      filter: drop-shadow(#adadad 0 2px 10px)
+    }
+
+    .tooltip:before {
+      content: "";
+      position: absolute;
+      border-style: solid
+    }
+
+    .tooltip-bottom:before,
+    .tooltip-top:before {
+      width: 0;
+      height: 0
+    }
+
+    .tooltip-right {
+      left: 100%;
+      padding: 24px
+    }
+
+    .tooltip-right:before {
+      left: -14px;
+      top: calc(50% - 10px);
+      border-width: 10px 14px 10px 0;
+      border-color: transparent #fff transparent transparent
+    }
+
+    .tooltip-top {
+      bottom: 90%;
+      padding: 16px
+    }
+
+    .tooltip-top:before {
+      bottom: -14px;
+      border-width: 14px 10px 0;
+      border-color: #fff transparent transparent
+    }
+
+    .tooltip-bottom {
+      padding: 16px
+    }
+
+    .tooltip-bottom:before {
+      top: -14px;
+      border-width: 0 10px 14px;
+      border-color: transparent transparent #fff
+    }
+
+    .kicker-tooltip {
+      left: -20px
+    }
+
+    .kicker-tooltip:before {
+      left: 40px
+    }
+
+    .pullquote {
+      font-size: 1.25rem
+    }
+
+    .pullquote blockquote {
+      margin: 16px 0 0;
+      line-height: 1.25
+    }
+
+    .pullquote blockquote:before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 32px;
+      height: 4px;
+      background-color: #000
+    }
+
+    @keyframes blink {
+      0% {
+        opacity: 1
       }
-      .o_rpoawabc .gumuvxhbcyr__yvh_dal {
-        position: fixed;
-        z-index: 536870906;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background-color: rgba(0, 0, 0, .5);
-        display: table
+
+      50% {
+        opacity: .1
       }
-      .o_rpoawabc .gumuvxhbcyr__yvh_dal>div:first-child {
-        display: flex;
-        flex-direction: column;
-        background-color: #1955a5;
-        max-width: 400px;
-        height: 100%;
-        position: fixed;
-        left: 0;
-        border-radius: 0;
-        margin-right: auto;
-        margin-left: auto;
-        padding-left: 40px;
-        padding-right: 40px;
-        padding-bottom: 40px
+
+      to {
+        opacity: 1
       }
-      .o_rpoawabc img {
-        max-width: 160px;
-        height: auto;
-        text-align: left;
-        margin-top: -4px;
+    }
+
+    .dot-xxs-gray-dark:before {
+      background-color: #666
+    }
+
+    .dot-xxs-gray-dark:before,
+    .dot-xxs-gray-darkest:before {
+      border-radius: 50%;
+      height: 4px;
+      width: 4px;
+      vertical-align: middle;
+      display: inline-block;
+      content: "";
+      margin-left: 8px;
+      margin-right: 8px
+    }
+
+    .dot-xxs-gray-darkest:before {
+      background-color: #2a2a2a
+    }
+
+    .dot-xs-red {
+      top: 50%
+    }
+
+    .dot-xs-red:before {
+      border-radius: 50%;
+      height: 8px;
+      width: 8px;
+      background-color: #d8070e;
+      vertical-align: middle;
+      display: inline-block;
+      content: "";
+      margin-left: 16px;
+      margin-right: 16px
+    }
+
+    .dot-xs-red.blink {
+      animation: blink 2s ease-in-out infinite alternate
+    }
+
+    .dot-xs-red:before {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      margin-left: 0
+    }
+
+    .facebook {
+      fill: #3b5998
+    }
+
+    .facebook:hover {
+      background-color: #3b5998;
+      border-color: #3b5998
+    }
+
+    .twitter {
+      fill: #55acee
+    }
+
+    .twitter:hover {
+      background-color: #55acee;
+      border-color: #55acee
+    }
+
+    .mail {
+      fill: #d8070e
+    }
+
+    .mail:hover {
+      background-color: #d8070e;
+      border-color: #d8070e
+    }
+
+    .linkedin {
+      fill: #0077b5
+    }
+
+    .linkedin:hover {
+      background-color: #0077b5;
+      border-color: #0077b5
+    }
+
+    .pinterest {
+      fill: #bd081c
+    }
+
+    .pinterest:hover {
+      background-color: #bd081c;
+      border-color: #bd081c
+    }
+
+    .table {
+      border-collapse: collapse
+    }
+
+    .table .td,
+    .table .th {
+      min-width: 50px;
+      line-height: 1.3
+    }
+
+    .table .td.no-wrap,
+    .table .th.no-wrap {
+      white-space: nowrap
+    }
+
+    .table .td.sticky-adjacent-column,
+    .table .td.sticky-column,
+    .table .th.sticky-adjacent-column,
+    .table .th.sticky-column {
+      width: 160px;
+      min-width: 160px
+    }
+
+    .table .td.sticky-column,
+    .table .th.sticky-column {
+      background-color: #fff;
+      left: 0
+    }
+
+    .search-form input {
+      outline: none;
+      box-shadow: none;
+      height: 34px;
+      line-height: 20px;
+      transition: all .25s cubic-bezier(.49, .37, .45, .71)
+    }
+
+    .radio-button,
+    input[type=radio] {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 20px;
+      height: 20px
+    }
+
+    .radio-button::-ms-check,
+    input[type=radio]::-ms-check {
+      box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, .5);
+      border: #d5d5d5;
+      background-color: #fff;
+      color: #fff
+    }
+
+    .radio-button:checked,
+    input[type=radio]:checked {
+      box-shadow: inset 0 0 .7px #000;
+      border: 6px solid #1955a5
+    }
+
+    .radio-button:checked::-ms-check,
+    input[type=radio]:checked::-ms-check {
+      box-shadow: inset 0 0 .7px #000;
+      border: 6px solid #1955a5
+    }
+
+    .radio-button:focus,
+    input[type=radio]:focus {
+      outline: none
+    }
+
+    .form-input {
+      height: 40px
+    }
+
+    .form-input-error {
+      outline: 0;
+      border: 1px solid #d8070e
+    }
+
+    .form-input-valid:focus {
+      outline: 0;
+      border: 1px solid #3d73d5
+    }
+
+    .form-input::placeholder {
+      color: #d5d5d5
+    }
+
+    .checkbox {
+      -webkit-appearance: none;
+      width: 20px;
+      height: 20px;
+      outline: none
+    }
+
+    input[type=checkbox]:checked {
+      background-color: #1955a5
+    }
+
+    input[type=checkbox]:checked:after {
+      content: url(/dr/resources/images/svgs/check.svg);
+      position: absolute;
+      width: 16px;
+      height: 16px;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%)
+    }
+
+    .list-hide-bullets {
+      list-style: none
+    }
+
+    .diamond-blt {
+      --spacing: 1em;
+      margin-left: calc(1*var(--spacing))
+    }
+
+    .diamond-blt:before {
+      content: "\25C6";
+      font-size: .55em;
+      font-style: normal;
+      position: absolute;
+      left: calc(-1.75*var(--spacing));
+      top: 7px;
+      color: #2a2a2a
+    }
+
+    .sectionnav .vertical-logo {
+      max-width: 127px;
+      min-width: 127px
+    }
+
+    @keyframes slidein {
+      0% {
+        margin-left: -80px
+      }
+
+      to {
+        margin-left: 0
+      }
+    }
+
+    @keyframes fadein {
+      0% {
+        opacity: 0
+      }
+
+      to {
+        opacity: 1
+      }
+    }
+
+    .utility-bar {
+      opacity: 0;
+      margin-left: -80px;
+      animation: slidein 1s ease .5s forwards, fadein 1s ease 1s forwards;
+      width: 48px
+    }
+
+    .utility-bar.fixed {
+      top: 60px
+    }
+
+    .utility-bar .utility-bar__item {
+      transition: background-color .2s ease-in-out
+    }
+
+    .utility-bar .utility-bar__item:hover {
+      background-color: #f0f0f0
+    }
+
+    .side-nav__menu-item:hover {
+      background-color: #000;
+      position: relative
+    }
+
+    .side-nav__menu-item a:hover {
+      color: inherit
+    }
+
+    .side-nav__submenu {
+      border-radius: 3px;
+      box-shadow: 0 0 16px 0 rgba(42, 42, 42, .5)
+    }
+
+    .side-nav__submenu li a:hover {
+      background-color: #f0f0f0
+    }
+
+    .side-nav__scroll-container {
+      scrollbar-width: none;
+      -ms-overflow-style: none
+    }
+
+    .side-nav__scroll-container::-webkit-scrollbar {
+      width: 0
+    }
+
+    .side-nav__submenu-arrow {
+      width: 0;
+      height: 0;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent;
+      border-right: 14px solid #fff;
+      top: 10px;
+      left: 236px
+    }
+
+    .copy-text:hover {
+      background-color: #d5d5d5
+    }
+
+    :root {
+      font-size: 16px
+    }
+
+    body,
+    figure,
+    p {
+      margin: 0
+    }
+
+    body {
+      font-family: Franklin, Arial, Helvetica, sans-serif
+    }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      margin: 0
+    }
+
+    button {
+      display: inline-block;
+      background-color: inherit;
+      border-color: inherit;
+      border-style: inherit;
+      padding: inherit;
+      font: inherit;
+      color: inherit;
+      text-transform: inherit
+    }
+
+    button:focus {
+      outline: none
+    }
+
+    input {
+      font: inherit;
+      -webkit-appearance: none
+    }
+
+    figure {
+      -webkit-margin-before: 0;
+      -webkit-margin-after: 0;
+      -webkit-margin-start: 0;
+      -webkit-margin-end: 0
+    }
+
+    blockquote {
+      margin-block-start: 0;
+      margin-block-end: 0;
+      margin-inline-start: 0;
+      margin-inline-end: 0
+    }
+
+    a {
+      text-decoration: none;
+      color: #1955a5
+    }
+
+    .border-box {
+      box-sizing: border-box
+    }
+
+    div[data-oembed-type=youtube] {
+      overflow: hidden;
+      padding-bottom: 56.25%;
+      position: relative;
+      height: 0
+    }
+
+    div[data-oembed-type=youtube] iframe {
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: 100%;
+      position: absolute
+    }
+
+    .raw-html iframe {
+      max-width: 100%
+    }
+
+    @media only screen and (min-width:768px) and (max-width:1023px) {
+      h1 {
+        font-size: 2.5rem
+      }
+
+      h2 {
+        font-size: 1.25rem
+      }
+
+      .mr-lg-m {
+        margin-right: var(--lg)
+      }
+
+      .-mr-lg-m {
+        margin-right: calc(-1*var(--lg))
+      }
+
+      .pr-md-md {
+        padding-right: var(--md)
+      }
+
+      .pr-lg-md {
+        padding-right: var(--lg)
+      }
+
+      .pl-0-md {
+        padding-left: 0
+      }
+
+      .pl-md-md {
+        padding-left: var(--md)
+      }
+
+      .pl-lg-md {
+        padding-left: var(--lg)
+      }
+
+      .font-copy {
+        font-size: var(--font-size-small)
+      }
+
+      .col-span-12-md {
+        grid-column: span 12/span 12
+      }
+
+      .col-span-3-md {
+        grid-column: span 3/span 3
+      }
+
+      .col-end-3-md {
+        grid-column-end: 3
+      }
+
+      .col-span-8-md {
+        grid-column: span 8/span 8
+      }
+
+      .col-span-4-md {
+        grid-column: span 4/span 4
+      }
+
+      .article-body h3,
+      .pullquote {
+        font-size: var(--font-size-medium)
+      }
+
+      .dn-m {
+        display: none
+      }
+    }
+
+    @media only screen and (min-width:1024px) {
+      h1 {
+        font-size: 3.5rem
+      }
+
+      h2 {
+        font-size: 1.5rem
+      }
+
+      .mt-md-l {
+        margin-top: var(--md)
+      }
+
+      .-mt-md-l {
+        margin-top: calc(-1*var(--md))
+      }
+
+      .pt-0-lg {
+        padding-top: 0
+      }
+
+      .pr-lg-lg {
+        padding-right: var(--lg)
+      }
+
+      .pl-sm-lg {
+        padding-left: var(--sm)
+      }
+
+      .font-copy {
+        font-size: var(--font-size-small)
+      }
+
+      .font-md-l {
+        font-size: var(--font-size-medium)
+      }
+
+      .font-xxxs-l {
+        font-size: var(--font-size-xxxs)
+      }
+
+      .w-0-l {
+        width: 0
+      }
+
+      .w-100-l {
+        width: 100%
+      }
+
+      .mw-0-lg {
+        max-width: 0
+      }
+
+      .mw-fit-content-lg {
+        max-width: fit-content
+      }
+
+      .col-span-12-lg {
+        grid-column: span 12/span 12
+      }
+
+      .col-span-3-lg {
+        grid-column: span 3/span 3
+      }
+
+      .col-end-3-lg {
+        grid-column-end: 3
+      }
+
+      .col-span-8-lg {
+        grid-column: span 8/span 8
+      }
+
+      .col-span-4-lg {
+        grid-column: span 4/span 4
+      }
+
+      .article-body h3,
+      .pullquote {
+        font-size: var(--font-size-medium-variant-three)
+      }
+
+      .overflow-visible-lg {
+        overflow: visible
+      }
+
+      .b-l {
+        border: 1px solid var(--gray-lighter)
+      }
+
+      .bb-l {
+        border-right: 0
+      }
+
+      .bb-l,
+      .br-l {
+        border-left: 0;
+        border-top: 0
+      }
+
+      .br-l {
+        border-bottom: 0
+      }
+
+      .dn-l {
+        display: none
+      }
+
+      .grid-l {
+        display: grid
+      }
+
+      .dib-l {
+        display: inline-block
+      }
+
+      .db-l {
         display: block
       }
-      .o_rpoawabc>div>div>div:nth-child(1) {
-        background: none;
-        border-bottom: 2px solid #093b7b;
-        padding-top: 50px;
-        padding-bottom: 18px;
-        text-align: right;
-        font-family: "FranklinITCProLight", "Helvetica Neue", "Helvetica Neue Light", Helvetica, Arial, "Lucida Grande", sans-serif
+
+      .mt-md-l {
+        margin-top: 24px
       }
-      .o_rpoawabc>div>div>div:nth-child(1) a {
-        text-align: right;
-        text-decoration: none;
-        font-size: 14px;
-        color: #fff
+
+      .o-0-l {
+        opacity: 0
       }
-      .o_rpoawabc>div>div>div:nth-child(1) a:hover {
-        text-decoration: underline;
-        opacity: 0.7
+
+      .o-100-l {
+        opacity: 1
       }
-      .o_rpoawabc>div>div>div:nth-child(2) {
-        padding-left: 4px;
-        padding-right: 4px;
-        margin-top: 84px
+
+      .visible-l {
+        visibility: visible
       }
-      .o_rpoawabc h3 {
-        text-align: left;
-        font-size: 32px;
-        line-height: 34px;
-        color: #fff;
-        font-style: normal;
-        font-weight: 400;
-        width: 100%;
-        margin: auto;
-        font-family: "PostoniWide", Georgia, serif
+
+      .hidden-l {
+        visibility: hidden
       }
-      .o_rpoawabc>div>div>div:nth-child(3) {
-        font-size: 20px;
-        color: #fff;
-        line-height: 28px;
-        text-align: left;
-        margin-top: 14px;
-        font-family: "FranklinITCProLight", "Helvetica Neue", "Helvetica Neue Light", Helvetica, Arial, "Lucida Grande", sans-serif
+
+      .flex-l {
+        display: flex
       }
-      .o_rpoawabc>div>div>div:nth-child(3),
-      .o_rpoawabc>div>div>div:nth-child(4),
-      .o_rpoawabc>div>div>div:nth-child(5),
-      .o_rpoawabc>div>div>div:nth-child(6) {
-        padding-left: 4px;
-        padding-right: 4px
+    }
+
+    @media only screen and (min-width:768px) {
+      .ma-0-ns {
+        margin: 0
       }
-      .o_rpoawabc>div>div>div:nth-child(4) {
-        border-radius: 2px;
-        text-align: center;
-        padding: 16px 2px;
-        background-color: #fff;
-        border: 1px solid #f1f1f1;
-        box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .25);
-        text-decoration: none;
-        margin-top: 34px
+
+      .mt-0-ns {
+        margin-top: 0
       }
-      .o_rpoawabc>div>div>div:nth-child(4) a {
-        font-size: 16px;
-        color: #2a2a2a;
-        font-weight: 400;
-        font-family: "FranklinITCProBold", "Helvetica Neue", "Helvetica Neue Light", Helvetica, Arial, "Lucida Grande", sans-serif
+
+      .mt-lg-ns {
+        margin-top: var(--lg)
       }
-      .o_rpoawabc .subscribe-link:hover {
-        color: #1955a5
+
+      .-mt-lg-ns {
+        margin-top: calc(-1*var(--lg))
       }
-      .o_rpoawabc>div>div>div:nth-child(5) {
-        margin-top: 16px;
-        font-family: "FranklinITCProLight", "Helvetica Neue", "Helvetica Neue Light", Helvetica, Arial, "Lucida Grande", sans-serif
+
+      .mt-xl-ns {
+        margin-top: var(--xl)
       }
-      .o_rpoawabc>div>div>div:nth-child(5) a,
-      .o_rpoawabc>div>div>div:nth-child(6) a {
-        text-decoration: underline;
-        font-size: 16px;
-        opacity: .7;
-        line-height: 20px;
-        text-align: center;
-        padding: 10px 2px;
-        color: #fff;
+
+      .-mt-xl-ns {
+        margin-top: calc(-1*var(--xl))
+      }
+
+      .mr-auto-ns {
+        margin-right: auto
+      }
+
+      .mr-xs-ns {
+        margin-right: var(--xs)
+      }
+
+      .-mr-xs-ns {
+        margin-right: calc(-1*var(--xs))
+      }
+
+      .mr-sm-ns {
+        margin-right: var(--sm)
+      }
+
+      .-mr-sm-ns {
+        margin-right: calc(-1*var(--sm))
+      }
+
+      .mr-lg-ns {
+        margin-right: var(--lg)
+      }
+
+      .-mr-lg-ns {
+        margin-right: calc(-1*var(--lg))
+      }
+
+      .ml-auto-ns {
+        margin-left: auto
+      }
+
+      .ml-xs-ns {
+        margin-left: var(--xs)
+      }
+
+      .-ml-xs-ns {
+        margin-left: calc(-1*var(--xs))
+      }
+
+      .ml-sm-ns {
+        margin-left: var(--sm)
+      }
+
+      .-ml-sm-ns {
+        margin-left: calc(-1*var(--sm))
+      }
+
+      .ml-lg-ns {
+        margin-left: var(--lg)
+      }
+
+      .-ml-lg-ns {
+        margin-left: calc(-1*var(--lg))
+      }
+
+      .mb-0-ns {
+        margin-bottom: 0
+      }
+
+      .mb-md-ns {
+        margin-bottom: var(--md)
+      }
+
+      .-mb-md-ns {
+        margin-bottom: calc(-1*var(--md))
+      }
+
+      .mb-sm-ns {
+        margin-bottom: var(--sm)
+      }
+
+      .-mb-sm-ns {
+        margin-bottom: calc(-1*var(--sm))
+      }
+
+      .mb-xxl-ns {
+        margin-bottom: var(--xxl)
+      }
+
+      .-mb-xxl-ns {
+        margin-bottom: calc(-1*var(--xxl))
+      }
+
+      .pr-sm-ns {
+        padding-right: var(--sm)
+      }
+
+      .pa-0-ns {
+        padding: 0
+      }
+
+      .pa-sm-ns {
+        padding: var(--sm)
+      }
+
+      .pl-0-ns {
+        padding-left: 0
+      }
+
+      .pl-lg-ns {
+        padding-left: var(--lg)
+      }
+
+      .pl-md-ns {
+        padding-left: var(--md)
+      }
+
+      .pr-0-ns {
+        padding-right: 0
+      }
+
+      .pr-xs-ns {
+        padding-right: var(--xs)
+      }
+
+      .pr-lg-ns {
+        padding-right: var(--lg)
+      }
+
+      .pr-md-ns {
+        padding-right: var(--md)
+      }
+
+      .pb-0-ns {
+        padding-bottom: 0
+      }
+
+      .pb-sm-ns {
+        padding-bottom: var(--sm)
+      }
+
+      .pb-md-ns {
+        padding-bottom: var(--md)
+      }
+
+      .pb-lg-ns {
+        padding-bottom: var(--lg)
+      }
+
+      .pb-xl-ns {
+        padding-bottom: var(--xl)
+      }
+
+      .pb-xxl-ns {
+        padding-bottom: var(--xxl)
+      }
+
+      .pt-0-ns {
+        padding-top: 0
+      }
+
+      .pt-xs-ns {
+        padding-top: var(--xs)
+      }
+
+      .pt-sm-ns {
+        padding-top: var(--sm)
+      }
+
+      .pt-md-ns {
+        padding-top: var(--md)
+      }
+
+      .pt-lg-ns {
+        padding-top: var(--lg)
+      }
+
+      .pt-xl-ns {
+        padding-top: var(--xl)
+      }
+
+      .header-nav .btn-gray {
+        background-color: #2a2a2a;
+        border-color: #666
+      }
+
+      .font-xxxs-ns {
+        font-size: var(--font-size-xxxs)
+      }
+
+      .font-xs-ns {
+        font-size: 1.125rem
+      }
+
+      .left-ns {
+        text-align: left
+      }
+
+      .center-ns {
+        text-align: center
+      }
+
+      .right-ns {
+        text-align: right
+      }
+
+      .shadow-light-ns {
+        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .05)
+      }
+
+      .w-50-ns {
+        width: 50%
+      }
+
+      .w-auto-ns {
+        width: auto
+      }
+
+      .mw-unset-ns {
+        max-width: unset
+      }
+
+      .mw-300-ns {
+        max-width: 300px
+      }
+
+      .minw-200-ns {
+        min-width: 200px
+      }
+
+      .pad-left-title {
+        margin-left: 32px
+      }
+
+      .flex-row-reverse-ns {
+        flex-direction: row-reverse
+      }
+
+      .bb-ns {
+        border-left-color: var(--gray-lighter);
+        border-bottom: 1px solid;
+        border-bottom-color: var(--gray-lighter);
+        border-right-color: var(--gray-lighter);
+        border-top-color: var(--gray-lighter)
+      }
+
+      .b-none-ns {
+        border: 0
+      }
+
+      .dn-ns {
+        display: none
+      }
+
+      .dib-ns {
+        display: inline-block
+      }
+
+      .db-ns {
         display: block
       }
-      .o_rpoawabc>div>div>div:nth-child(5) a:hover {
-        background-color: inherit;
-        color: #fff;
-        border: none;
-        box-shadow: none
+
+      .flex-ns {
+        display: flex
       }
-      .o_rpoawabc>div>div>div:nth-child(6) {
-        font-size: 16px;
-        color: #fff;
-        margin-top: auto;
-        text-align: center;
-        font-family: "FranklinITCProLight", "Helvetica Neue", "Helvetica Neue Light", Helvetica, Arial, "Lucida Grande", sans-serif
+
+      .flex-ns-row {
+        flex-direction: row
       }
-      .o_rpoawabc>div>div>div:nth-child(6) a {
-        padding-top: 2px
+
+      .inline-flex-ns {
+        display: inline-flex
       }
-      .o_rpoawabc .logo {
+
+      .inline-flex-ns-column {
+        flex-direction: column
+      }
+
+      .inline-flex-ns-row {
+        flex-direction: row
+      }
+
+      .inline-flex-ns-1 {
+        flex: 1
+      }
+
+      .items-ns-center {
+        align-items: center
+      }
+
+      .items-ns-end {
+        align-items: flex-end
+      }
+
+      .justify-center-ns {
+        justify-content: center
+      }
+
+      .fl-ns {
         float: left
       }
-      @media only screen and (max-width:767px) {
-        .o_rpoawabc .gumuvxhbcyr__yvh_dal {
-          top: 60px
-        }
-        .o_rpoawabc .gumuvxhbcyr__yvh_dal>div:first-child {
-          max-width: 100%;
-          padding-bottom: 60px;
-          padding-left: 20px;
-          padding-right: 20px
-        }
-        .o_rpoawabc>div>div>div:nth-child(1) {
-          padding-top: 17px;
-          padding-bottom: 10px
-        }
-        .o_rpoawabc>div>div>div:nth-child(2) {
-          margin-top: 40px
-        }
-        .o_rpoawabc .logo {
-          display: none
-        }
-        .o_rpoawabc .link {
-          text-align: center
-        }
-        .o_rpoawabc h3 {
-          font-size: 30px;
-          text-align: center
-        }
-        .o_rpoawabc>div>div>div:nth-child(3) {
-          text-align: center;
-          font-size: 18px;
-          line-height: 24px;
-          margin-top: 9px
-        }
-        .o_rpoawabc>div>div>div:nth-child(4) {
-          margin-top: 16px
-        }
-        .o_rpoawabc>div>div>div:nth-child(4) a {
-          font-size: 18px
-        }
-        .o_rpoawabc>div>div>div:nth-child(5) {
-          margin-top: 6px
-        }
-        .o_rpoawabc>div>div>div:nth-child(5) a,
-        .o_rpoawabc>div>div>div:nth-child(6),
-        .o_rpoawabc>div>div>div:nth-child(6) a {
-          font-size: 14px;
-          line-height: 18px
-        }
-        .o_rpoawabc>div>div>div:nth-child(6) {
-          margin-bottom: 10px
-        }
+
+      .fr-ns {
+        float: right
       }
-    </style>
-    <div class="o_rpoawabc" style="display:none;">
-      <div class="gumuvxhbcyr__yvh_dal">
-        <div>
-          <div>
-            <div class="logo"><a href="https://www.washingtonpost.com/"><img data-image="https://www.washingtonpost.com/resizer/FCZNCYXcoUN55RbTtYJLNtwZuPk=/288x0/www.washingtonpost.com/resources/img/drawbridge/TWP_logo@2x.png" src="https://www.washingtonpost.com/resizer/FCZNCYXcoUN55RbTtYJLNtwZuPk=/288x0/www.washingtonpost.com/resources/img/drawbridge/TWP_logo@2x.png" alt="logo"></a></div>
-            <div class="link"><a href="https://www.washingtonpost.com/subscribe/signin/?next_url=">Subscriber sign in</a></div>
+
+      .overflow-hidden-ns {
+        overflow: hidden
+      }
+
+      .absolute-ns {
+        position: absolute
+      }
+
+      .bl-ns {
+        border-left: 1px solid var(--gray-lighter)
+      }
+
+      .b-ns {
+        border: 1px solid var(--gray-lighter)
+      }
+    }
+
+    @media only screen and (min-width:1200px) {
+      .header-nav .gift-offer .db-xl {
+        display: block
+      }
+
+      .header-nav .gift-offer .flex-xl {
+        display: flex
+      }
+    }
+
+    @media only screen and (max-width:767px) {
+      .font-sm-md3 {
+        font-size: var(--font-size-medium-variant-three)
+      }
+
+      .font-xxs-s {
+        font-size: var(--font-size-xxs)
+      }
+
+      .w-33-s {
+        width: 33%
+      }
+
+      .w-100-s {
+        width: 100%
+      }
+
+      .left-0-s {
+        left: 0
+      }
+
+      .right-0-s {
+        right: 0
+      }
+
+      .brad-sm-0 {
+        border-radius: 0
+      }
+
+      .bt-sm {
+        border-top: 1px solid #d5d5d5
+      }
+
+      .bb-sm {
+        border-bottom: 1px solid var(--gray-lighter)
+      }
+    }
+
+    @media only screen and (max-width:1023px) {
+      .mw-unset-nl {
+        max-width: unset
+      }
+    }
+
+    @media print {
+      @page {
+        margin: 16px 0
+      }
+
+      body {
+        display: inline
+      }
+
+      .hide-for-print {
+        display: none
+      }
+
+      .show-for-print {
+        display: block
+      }
+
+      p {
+        page-break-inside: avoid
+      }
+
+      .pb-md {
+        padding-bottom: 10px
+      }
+
+      .author-name,
+      .byline,
+      .display-date,
+      .font-copy,
+      a,
+      a span {
+        color: #000;
+        font-size: 14px
+      }
+    }
+
+    @media (hover:hover) {
+      .dn-h {
+        display: none
+      }
+    }
+
+    @media only screen and (min-width:768px) and (max-width:1023px) {
+      .grid {
+        padding: 0 5vw;
+        grid-column-gap: 0
+      }
+
+      .grid-item--cols-start-md-1 {
+        -ms-grid-column: 1
+      }
+
+      .grid-item--cols-start-md-2 {
+        -ms-grid-column: 2
+      }
+
+      .grid-item--cols-start-md-3 {
+        -ms-grid-column: 3
+      }
+
+      .grid-item--cols-start-md-4 {
+        -ms-grid-column: 4
+      }
+
+      .grid-item--cols-start-md-5 {
+        -ms-grid-column: 5
+      }
+
+      .grid-item--cols-start-md-6 {
+        -ms-grid-column: 6
+      }
+
+      .grid-item--cols-start-md-7 {
+        -ms-grid-column: 7
+      }
+
+      .grid-item--cols-start-md-8 {
+        -ms-grid-column: 8
+      }
+
+      .grid-item--cols-start-md-9 {
+        -ms-grid-column: 9
+      }
+
+      .grid-item--cols-start-md-10 {
+        -ms-grid-column: 10
+      }
+
+      .grid-item--cols-start-md-11 {
+        -ms-grid-column: 11
+      }
+
+      .grid-item--cols-start-md-12 {
+        -ms-grid-column: 12
+      }
+
+      .grid-item--cols-md-1 {
+        -ms-grid-column-span: 1;
+        grid-column-end: span 1
+      }
+
+      .grid-item--cols-md-2 {
+        -ms-grid-column-span: 2;
+        grid-column-end: span 2
+      }
+
+      .grid-item--cols-md-3 {
+        -ms-grid-column-span: 3;
+        grid-column-end: span 3
+      }
+
+      .grid-item--cols-md-4 {
+        -ms-grid-column-span: 4;
+        grid-column-end: span 4
+      }
+
+      .grid-item--cols-md-5 {
+        -ms-grid-column-span: 5;
+        grid-column-end: span 5
+      }
+
+      .grid-item--cols-md-6 {
+        -ms-grid-column-span: 6;
+        grid-column-end: span 6
+      }
+
+      .grid-item--cols-md-7 {
+        -ms-grid-column-span: 7;
+        grid-column-end: span 7
+      }
+
+      .grid-item--cols-md-8 {
+        -ms-grid-column-span: 8;
+        grid-column-end: span 8
+      }
+
+      .grid-item--cols-md-9 {
+        -ms-grid-column-span: 9;
+        grid-column-end: span 9
+      }
+
+      .grid-item--cols-md-10 {
+        -ms-grid-column-span: 10;
+        grid-column-end: span 10
+      }
+
+      .grid-item--cols-md-11 {
+        -ms-grid-column-span: 11;
+        grid-column-end: span 11
+      }
+
+      .grid-item--cols-md-12 {
+        -ms-grid-column-span: 12;
+        grid-column-end: span 12
+      }
+
+      .grid-item--rows-start-md-1 {
+        -ms-grid-row: 1
+      }
+
+      .grid-item--rows-start-md-2 {
+        -ms-grid-row: 2
+      }
+
+      .grid-item--rows-start-md-3 {
+        -ms-grid-row: 3
+      }
+
+      .grid-item--rows-start-md-4 {
+        -ms-grid-row: 4
+      }
+
+      .grid-item--rows-start-md-5 {
+        -ms-grid-row: 5
+      }
+
+      .grid-item--rows-start-md-6 {
+        -ms-grid-row: 6
+      }
+
+      .grid-item--rows-start-md-7 {
+        -ms-grid-row: 7
+      }
+
+      .grid-item--rows-start-md-8 {
+        -ms-grid-row: 8
+      }
+
+      .grid-item--rows-start-md-9 {
+        -ms-grid-row: 9
+      }
+
+      .grid-item--rows-start-md-10 {
+        -ms-grid-row: 10
+      }
+
+      .grid-item--rows-start-md-11 {
+        -ms-grid-row: 11
+      }
+
+      .grid-item--rows-start-md-12 {
+        -ms-grid-row: 12
+      }
+
+      .grid-item--rows-md-1 {
+        -ms-grid-row-span: 1;
+        grid-row-end: span 1
+      }
+
+      .grid-item--rows-md-2 {
+        -ms-grid-row-span: 2;
+        grid-row-end: span 2
+      }
+
+      .grid-item--rows-md-3 {
+        -ms-grid-row-span: 3;
+        grid-row-end: span 3
+      }
+
+      .grid-item--rows-md-4 {
+        -ms-grid-row-span: 4;
+        grid-row-end: span 4
+      }
+
+      .grid-item--rows-md-5 {
+        -ms-grid-row-span: 5;
+        grid-row-end: span 5
+      }
+
+      .grid-item--rows-md-6 {
+        -ms-grid-row-span: 6;
+        grid-row-end: span 6
+      }
+
+      .grid-item--rows-md-7 {
+        -ms-grid-row-span: 7;
+        grid-row-end: span 7
+      }
+
+      .grid-item--rows-md-8 {
+        -ms-grid-row-span: 8;
+        grid-row-end: span 8
+      }
+
+      .grid-item--rows-md-9 {
+        -ms-grid-row-span: 9;
+        grid-row-end: span 9
+      }
+
+      .grid-item--rows-md-10 {
+        -ms-grid-row-span: 10;
+        grid-row-end: span 10
+      }
+
+      .grid-item--rows-md-11 {
+        -ms-grid-row-span: 11;
+        grid-row-end: span 11
+      }
+
+      .grid-item--rows-md-12 {
+        -ms-grid-row-span: 12;
+        grid-row-end: span 12
+      }
+
+      .article-body h3 {
+        font-size: 2rem
+      }
+
+      .article-body h4,
+      .article-body h5,
+      .pullquote {
+        font-size: 1.5rem
+      }
+    }
+
+    @media only screen and (min-width:1024px) {
+      .grid {
+        padding: 0 8vw;
+        grid-column-gap: 32px
+      }
+
+      .grid-item--cols-start-lg-1 {
+        -ms-grid-column: 1
+      }
+
+      .grid-item--cols-start-lg-2 {
+        -ms-grid-column: 2
+      }
+
+      .grid-item--cols-start-lg-3 {
+        -ms-grid-column: 3
+      }
+
+      .grid-item--cols-start-lg-4 {
+        -ms-grid-column: 4
+      }
+
+      .grid-item--cols-start-lg-5 {
+        -ms-grid-column: 5
+      }
+
+      .grid-item--cols-start-lg-6 {
+        -ms-grid-column: 6
+      }
+
+      .grid-item--cols-start-lg-7 {
+        -ms-grid-column: 7
+      }
+
+      .grid-item--cols-start-lg-8 {
+        -ms-grid-column: 8
+      }
+
+      .grid-item--cols-start-lg-9 {
+        -ms-grid-column: 9
+      }
+
+      .grid-item--cols-start-lg-10 {
+        -ms-grid-column: 10
+      }
+
+      .grid-item--cols-start-lg-11 {
+        -ms-grid-column: 11
+      }
+
+      .grid-item--cols-start-lg-12 {
+        -ms-grid-column: 12
+      }
+
+      .grid-item--cols-lg-1 {
+        -ms-grid-column-span: 1;
+        grid-column-end: span 1
+      }
+
+      .grid-item--cols-lg-2 {
+        -ms-grid-column-span: 2;
+        grid-column-end: span 2
+      }
+
+      .grid-item--cols-lg-3 {
+        -ms-grid-column-span: 3;
+        grid-column-end: span 3
+      }
+
+      .grid-item--cols-lg-4 {
+        -ms-grid-column-span: 4;
+        grid-column-end: span 4
+      }
+
+      .grid-item--cols-lg-5 {
+        -ms-grid-column-span: 5;
+        grid-column-end: span 5
+      }
+
+      .grid-item--cols-lg-6 {
+        -ms-grid-column-span: 6;
+        grid-column-end: span 6
+      }
+
+      .grid-item--cols-lg-7 {
+        -ms-grid-column-span: 7;
+        grid-column-end: span 7
+      }
+
+      .grid-item--cols-lg-8 {
+        -ms-grid-column-span: 8;
+        grid-column-end: span 8
+      }
+
+      .grid-item--cols-lg-9 {
+        -ms-grid-column-span: 9;
+        grid-column-end: span 9
+      }
+
+      .grid-item--cols-lg-10 {
+        -ms-grid-column-span: 10;
+        grid-column-end: span 10
+      }
+
+      .grid-item--cols-lg-11 {
+        -ms-grid-column-span: 11;
+        grid-column-end: span 11
+      }
+
+      .grid-item--cols-lg-12 {
+        -ms-grid-column-span: 12;
+        grid-column-end: span 12
+      }
+
+      .grid-item--rows-start-lg-1 {
+        -ms-grid-row: 1
+      }
+
+      .grid-item--rows-start-lg-2 {
+        -ms-grid-row: 2
+      }
+
+      .grid-item--rows-start-lg-3 {
+        -ms-grid-row: 3
+      }
+
+      .grid-item--rows-start-lg-4 {
+        -ms-grid-row: 4
+      }
+
+      .grid-item--rows-start-lg-5 {
+        -ms-grid-row: 5
+      }
+
+      .grid-item--rows-start-lg-6 {
+        -ms-grid-row: 6
+      }
+
+      .grid-item--rows-start-lg-7 {
+        -ms-grid-row: 7
+      }
+
+      .grid-item--rows-start-lg-8 {
+        -ms-grid-row: 8
+      }
+
+      .grid-item--rows-start-lg-9 {
+        -ms-grid-row: 9
+      }
+
+      .grid-item--rows-start-lg-10 {
+        -ms-grid-row: 10
+      }
+
+      .grid-item--rows-start-lg-11 {
+        -ms-grid-row: 11
+      }
+
+      .grid-item--rows-start-lg-12 {
+        -ms-grid-row: 12
+      }
+
+      .grid-item--rows-lg-1 {
+        -ms-grid-row-span: 1;
+        grid-row-end: span 1
+      }
+
+      .grid-item--rows-lg-2 {
+        -ms-grid-row-span: 2;
+        grid-row-end: span 2
+      }
+
+      .grid-item--rows-lg-3 {
+        -ms-grid-row-span: 3;
+        grid-row-end: span 3
+      }
+
+      .grid-item--rows-lg-4 {
+        -ms-grid-row-span: 4;
+        grid-row-end: span 4
+      }
+
+      .grid-item--rows-lg-5 {
+        -ms-grid-row-span: 5;
+        grid-row-end: span 5
+      }
+
+      .grid-item--rows-lg-6 {
+        -ms-grid-row-span: 6;
+        grid-row-end: span 6
+      }
+
+      .grid-item--rows-lg-7 {
+        -ms-grid-row-span: 7;
+        grid-row-end: span 7
+      }
+
+      .grid-item--rows-lg-8 {
+        -ms-grid-row-span: 8;
+        grid-row-end: span 8
+      }
+
+      .grid-item--rows-lg-9 {
+        -ms-grid-row-span: 9;
+        grid-row-end: span 9
+      }
+
+      .grid-item--rows-lg-10 {
+        -ms-grid-row-span: 10;
+        grid-row-end: span 10
+      }
+
+      .grid-item--rows-lg-11 {
+        -ms-grid-row-span: 11;
+        grid-row-end: span 11
+      }
+
+      .grid-item--rows-lg-12 {
+        -ms-grid-row-span: 12;
+        grid-row-end: span 12
+      }
+
+      .article-body h3 {
+        font-size: 2rem
+      }
+
+      .article-body h4 {
+        font-size: 1.75rem
+      }
+
+      .article-body h5 {
+        font-size: 1.5rem
+      }
+
+      .inline-story h2 {
+        font-size: 2rem
+      }
+
+      .next-up-text {
+        width: 60%
+      }
+
+      .next-up-image {
+        width: 40%
+      }
+
+      .pullquote {
+        font-size: 2rem
+      }
+    }
+
+    @media only screen and (max-width:767px) {
+      .byline .author-text {
+        font-size: .875rem
+      }
+
+      .gallery .ad,
+      .gallery figure,
+      .preview-gallery .ad,
+      .preview-gallery figure {
+        margin-right: auto;
+        margin-left: auto
+      }
+
+      .article-body h3,
+      .article-body h4,
+      .article-body h5 {
+        padding-top: 32px
+      }
+
+      .kicker {
+        font-size: .875rem
+      }
+    }
+
+    @media only screen and (max-width:1023px) {
+      .inline-story div[data-qa=timestamp] {
+        font-size: 1.125rem
+      }
+    }
+
+    @media (hover:hover) {
+      .tooltip {
+        transition: visibility 0s linear .2s
+      }
+    }
+
+    @media only screen and (min-width:768px) {
+
+      .table .td.sticky-adjacent-column,
+      .table .td.sticky-column,
+      .table .th.sticky-adjacent-column,
+      .table .th.sticky-column {
+        width: 200px;
+        min-width: 200px
+      }
+
+      .newsletter-form {
+        max-width: 60%
+      }
+
+      .sectionnav .vertical-logo {
+        max-width: 232px
+      }
+
+      .elex-cta {
+        font-size: 1rem
+      }
+    }
+  </style>
+  <script
+    id="wpMetaData">var wpMetaData = { "ct_tags": "Social media,online media", "sct_tags": "default", "content_section": "technology", "commercial_node": "/technology", "content_type": "blog", "canonical_url": "https://www.washingtonpost.com/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/", "domain": "https://www.washingtonpost.com", "subType": "" }; window.consumers = []; window.registerPwapiConsumer = function (callback) { window.consumers.push(callback) }</script>
+  <script src="https://www.washingtonpost.com/wp-stat/pwapi/prod/fusion/pwapi-proxy.min.js" async=""></script>
+  <link rel="dns-prefetch" href="https://adserver-us.adtech.advertising.com">
+  <link rel="dns-prefetch" href="https://secure.adnxs.com">
+  <link rel="dns-prefetch" href="https://bidder.criteo.com">
+  <link rel="dns-prefetch" href="https://static.criteo.net">
+  <link rel="dns-prefetch" href="https://cdn.krxd.net">
+  <link rel="dns-prefetch" href="https://widgets.outbrain.com">
+  <link rel="dns-prefetch" href="https://images.outbrain.com">
+  <link rel="dns-prefetch" href="https://log.outbrain.com">
+  <link rel="dns-prefetch" href="https://amplifypixel.outbrain.com">
+  <link rel="dns-prefetch" href="https://odb.outbrain.com">
+  <link rel="dns-prefetch" href="https://js-sec.indexww.com">
+  <link rel="dns-prefetch" href="https://as-sec.casalemedia.com">
+  <link rel="dns-prefetch" href="https://as.casalemedia.com">
+  <link rel="dns-prefetch" href="https://sofia.trustx.org">
+  <link rel="dns-prefetch" href="https://c.amazon-adsystem.com">
+  <link rel="dns-prefetch" href="https://s.amazon-adsystem.com">
+  <link rel="dns-prefetch" href="https://aax.amazon-adsystem.com">
+  <link rel="dns-prefetch" href="https://t.teads.tv">
+  <link rel="dns-prefetch" href="https://beacon.krxd.net">
+  <link rel="preconnect" href="https://browser.sentry-cdn.com">
+  <link rel="preconnect" href="https://js.sentry-cdn.com">
+  <link rel="preconnect" href="https://www.google-analytics.com">
+  <link rel="preconnect" href="https://www.googletagmanager.com">
+  <link rel="preconnect" href="https://adservice.google.com">
+  <link rel="preconnect" href="https://metrics.washingtonpost.com">
+  <script crossorigin="anonymous" defer=""
+    src="https://polyfill.io/v3/polyfill.min.js?features=Array.isArray%2CArray.prototype.%40%40iterator%2CArray.prototype.entries%2CArray.prototype.every%2CArray.prototype.filter%2CArray.prototype.forEach%2CArray.prototype.includes%2CArray.prototype.indexOf%2CArray.prototype.lastIndexOf%2CArray.prototype.keys%2CArray.prototype.map%2CArray.prototype.reduce%2CArray.prototype.reduceRight%2CArray.prototype.some%2CArray.prototype.values%2CDate.now%2CDate.prototype.toISOString%2CFunction.prototype.bind%2CFunction.prototype.name%2CMath.acosh%2CMath.atanh%2CMath.asinh%2CMath.cbrt%2CMath.clz32%2CMath.cosh%2CMath.expm1%2CMath.fround%2CMath.hypot%2CMath.imul%2CMath.log10%2CMath.log1p%2CMath.log2%2CMath.sign%2CMath.sinh%2CMath.tanh%2CMath.trunc%2CNumber.parseFloat%2CNumber.parseInt%2CObject.values%2CObject.create%2CObject.defineProperties%2CObject.defineProperty%2CObject.freeze%2CObject.getOwnPropertyDescriptor%2CObject.getOwnPropertyNames%2CObject.getPrototypeOf%2CObject.is%2CObject.keys%2CObject.seal%2CObject.setPrototypeOf%2CRegExp.prototype.flags%2CString.prototype.%40%40iterator%2CSymbol.hasInstance%2CSymbol.isConcatSpreadable%2CSymbol.iterator%2CSymbol.match%2CSymbol.replace%2CSymbol.search%2CSymbol.species%2CSymbol.split%2CSymbol.toPrimitive%2CSymbol.toStringTag%2CSymbol.unscopables"></script>
+  <script>window.wpAdFusion = { "author": ["Abby Ohlheiser"], "commercialNode": "/technology", "firstPubDate": "2016-05-24T18:20:48Z", "keywords": ["twitter", ".@ twitter", "twitter replies", "twitter character limit"], "pageId": "news_32_15491", "clavis": { "auxiliaries": ["8z8", "5k4", "wkq", "7aq", "34n", "ieb", "vat", "ngs", "l7l", "zhn", "zwn", "xzm", "4em", "i7i", "vfq", "9xx", "xyt", "7rl", "wxg", "oq2", "0hv", "mgr", "7nc", "ft0", "r5x", "w5n", "n0e", "f79", "n95", "r6u", "w4t", "97K", "sqb", "gno", "WC9", "0KS", "FTM", "F85", "BUM", "PKT", "q15", "IAJ", "0GA", "GQP", "IAM", "4ld", "6yp", "dya", "zk5", "erz", "hws", "54y", "3uh", "1nw", "muj"], "auxiliary_names": ["Sensitive1", "China_HongKong Exclusion 12-12-14", "Science, Health & Technology", "Sensitive 2", "Social Media", "Companies", "TV and Movies", "Macys", "Ahld", "Emissions", "Murdoch neg", "IC - JPMC - Decisive Action", "IC - JPMC - Houston", "IC - JPMC - Entrepreneures", "IC - JPMC - Detroits Comeback", "Exn neg", "food safety neg", "Icahn neg", "Apple Content", "IC-JPMC-Mothers to Mentors", "IC-JPMC-Tech Savvy", "IC-JPMC-Detroit", "emails - neg", "IC-JPMC-Detroit (2)", "Young Professional / International Businessman", "Qualcomm Smart Cities", "IC-Allstate-MM", "Johnnie Walker", "BofA Dashboard Auxiliary", "jb kws", "gldmn kws", "Travel TG", "Entrepreneurship", "Space", "Election 2016", "Sub: Neutral", "Corporate Responsibility", "Boeing Targeting 6.8.17", "api kws", "bp kws", "Siemens", "Audi kw list", "BofA Audience 101017", "intel kw", "aig kws", "IC-Rackspace-2017", "IC-Raytheon-12.2017", "Discover: Aux 2: Keywords & Topics", "Discover: Aux 3: Keywords & Topics", "Discovery: Aux 8: Keywords & Topics", "Business", "Tech", "New Auxiliary 561", "apple kws", "ggl kws"], "ct": ["jp", "us"], "keywords": ["twitter", "tweet", "Twitter", "reply", "user", "change", "users", "button", "tweets", "way", "person", "reach", "announcement", "link", "plan", "changes", "need", "character", "anything", "fact", "bit", "lot", "everyone", "retweet", "platform"], "topics": ["Companies", "Social Media"] }, "section": "technology", "subsection": "", "tags": ["Social media", "online media"] }</script>
+  <script src="https://www.washingtonpost.com/zeus/main.js" async=""></script>
+  <script>window.pageType = "article"</script>
+  <script>window.dataLayer = window.dataLayer || [];</script>
+  <script>< !--Google Tag Manager-- >
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || []; w[l].push({
+          'gtm.start':
+            new Date().getTime(), event: 'gtm.js'
+        }); var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+            'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-WHNNX8B');</script>
+  <script>
+    < !--Google Optimize-- >
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || []; w[l].push({
+          'optimize.start':
+            new Date().getTime(), event: 'optimize.js'
+        }); var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src =
+            'https://www.googleoptimize.com/optimize.js?id=' + i + dl; j.addEventListener('load', function () {
+              window.optLoad = true;
+            });
+        j.addEventListener('error', function () {
+          window.optLoad = false;
+        }); f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-TB6VDCH');</script>
+  <script>
+    window.Fusion = {
+      template: "template/article-mono",
+      deployment: "DR-prod-622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba"
+    };
+    window.pageType = "article";
+  </script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <meta name="next-head-count" content="2">
+  <link rel="preload"
+    href="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/pages/%5B...all%5D.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/pages/_app.module.js"
+    as="script" crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/chunks/framework.4370e18122abbe0cbfe9.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/chunks/commons.bbf28d5ca380de8c8a53.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload"
+    href="/_next/static/chunks/30cd56ec8b4292fd1d19f6bfd4b67b1689d06305.fbe3db9814b1fd316b2f.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/runtime/webpack-503a898abacb4f6ee260.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/chunks/framework.4370e18122abbe0cbfe9.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/chunks/commons.bbf28d5ca380de8c8a53.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload"
+    href="/_next/static/chunks/ea3f3c9376134bde2ad6392f973353ef8165b1fa.ae13968471fc68c12bdd.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload" href="/_next/static/runtime/main-58c9c6a0aea42808e6d2.module.js" as="script"
+    crossorigin="anonymous">
+  <link rel="preload"
+    href="/_next/static/chunks/f17dffc46075aac6ebb2b8b9ff0ad166c18d91ba.15be5738a8c07c994443.module.js" as="script"
+    crossorigin="anonymous">
+  <script>!function (e) { var n = "https://s.go-mpulse.net/boomerang/"; if ("False" == "True") e.BOOMR_config = e.BOOMR_config || {}, e.BOOMR_config.PageParams = e.BOOMR_config.PageParams || {}, e.BOOMR_config.PageParams.pci = !0, n = "https://s2.go-mpulse.net/boomerang/"; if (window.BOOMR_API_key = "2L2Z6-GDWNL-RH2G3-MVS3W-7M6WF", function () { function e() { if (!o) { var e = document.createElement("script"); e.id = "boomr-scr-as", e.src = window.BOOMR.url, e.async = !0, i.parentNode.appendChild(e), o = !0 } } function t(e) { o = !0; var n, t, a, r, d = document, O = window; if (window.BOOMR.snippetMethod = e ? "if" : "i", t = function (e, n) { var t = d.createElement("script"); t.id = n || "boomr-if-as", t.src = window.BOOMR.url, BOOMR_lstart = (new Date).getTime(), e = e || d.body, e.appendChild(t) }, !window.addEventListener && window.attachEvent && navigator.userAgent.match(/MSIE [67]\./)) return window.BOOMR.snippetMethod = "s", void t(i.parentNode, "boomr-async"); a = document.createElement("IFRAME"), a.src = "about:blank", a.title = "", a.role = "presentation", a.loading = "eager", r = (a.frameElement || a).style, r.width = 0, r.height = 0, r.border = 0, r.display = "none", i.parentNode.appendChild(a); try { O = a.contentWindow, d = O.document.open() } catch (c) { n = document.domain, a.src = "javascript:var d=document.open();d.domain='" + n + "';void(0);", O = a.contentWindow, d = O.document.open() } if (n) d._boomrl = function () { this.domain = n, t() }, d.write("<bo" + "dy onload='document._boomrl();'>"); else if (O._boomrl = function () { t() }, O.addEventListener) O.addEventListener("load", O._boomrl, !1); else if (O.attachEvent) O.attachEvent("onload", O._boomrl); d.close() } function a(e) { window.BOOMR_onload = e && e.timeStamp || (new Date).getTime() } if (!window.BOOMR || !window.BOOMR.version && !window.BOOMR.snippetExecuted) { window.BOOMR = window.BOOMR || {}, window.BOOMR.snippetStart = (new Date).getTime(), window.BOOMR.snippetExecuted = !0, window.BOOMR.snippetVersion = 12, window.BOOMR.url = n + "2L2Z6-GDWNL-RH2G3-MVS3W-7M6WF"; var i = document.currentScript || document.getElementsByTagName("script")[0], o = !1, r = document.createElement("link"); if (r.relList && "function" == typeof r.relList.supports && r.relList.supports("preload") && "as" in r) window.BOOMR.snippetMethod = "p", r.href = window.BOOMR.url, r.rel = "preload", r.as = "script", r.addEventListener("load", e), r.addEventListener("error", function () { t(!0) }), setTimeout(function () { if (!o) t(!0) }, 3e3), BOOMR_lstart = (new Date).getTime(), i.parentNode.appendChild(r); else t(!1); if (window.addEventListener) window.addEventListener("load", a, !1); else if (window.attachEvent) window.attachEvent("onload", a) } }(), "".length > 0) if (e && "performance" in e && e.performance && "function" == typeof e.performance.setResourceTimingBufferSize) e.performance.setResourceTimingBufferSize(); !function () { if (BOOMR = e.BOOMR || {}, BOOMR.plugins = BOOMR.plugins || {}, !BOOMR.plugins.AK) { var n = "" == "true" ? 1 : 0, t = "", a = "km2d7qqxgptvoycgj3ga-f-a0a5a287a-clientnsv4-s.akamaihd.net", i = { "ak.v": "30", "ak.cp": "914675", "ak.ai": parseInt("403158", 10), "ak.ol": "0", "ak.cr": 37, "ak.ipv": 4, "ak.proto": "h2", "ak.rid": "284472b", "ak.r": 27647, "ak.a2": n, "ak.m": "j", "ak.n": "essl", "ak.bpcip": "83.52.63.0", "ak.cport": 52784, "ak.gh": "104.113.250.46", "ak.quicv": "", "ak.tlsv": "tls1.3", "ak.0rtt": "", "ak.csrc": "-", "ak.acc": "", "ak.t": "1615220428", "ak.ak": "hOBiQwZUYzCg5VSAfCLimQ==ABrazUbUOLM0jBvmKhGY/zJl/w6LwIDsc48dM3Ci8XQzJ9r1Vnyiv5gmp8zNZUTmx6w33qNMcKsTmIAkyiU4CZ5OGBUqVXf6Z/XJyVu/75yimRWiNeyf6HTLVF/Uf0+ur9Epkc++uZvHDMXAvfgPI6kDbadvT+Wxh9Gd1A/Xt8vt+5FL8SkNOEfy3Qz7UEmYMfg4a4wbYBB7jXezb+HSb4bJ2mNBAPGzmZSJOinUhTQsqFL169sjcPhffmsWFxlBKqTONQnawn0nGSFlYDwFclmMvwuTYf0Cvp9jDlS0+J3q2/lAg5yaNsDVsZoxx1rPe6zrzv1d4flda8p2wIQI20zFg+3BZ9q4oG3gtSRlPICAVf6Ovv/JqB8m8YkYitzbHcJOzi0FEG8jtJaVB1Zm2ppeK5Ot/wjhWqL9NmFkWBo=", "ak.pv": "1528", "ak.dpoabenc": "" }; if ("" !== t) i["ak.ruds"] = t; var o = { i: !1, av: function (n) { var t = "http.initiator"; if (n && (!n[t] || "spa_hard" === n[t])) i["ak.feo"] = void 0 !== e.aFeoApplied ? 1 : 0, BOOMR.addVar(i) }, rv: function () { var e = ["ak.bpcip", "ak.cport", "ak.cr", "ak.csrc", "ak.gh", "ak.ipv", "ak.m", "ak.n", "ak.ol", "ak.proto", "ak.quicv", "ak.tlsv", "ak.0rtt", "ak.r", "ak.acc", "ak.t"]; BOOMR.removeVar(e) } }; BOOMR.plugins.AK = { akVars: i, akDNSPreFetchDomain: a, init: function () { if (!o.i) { var e = BOOMR.subscribe; e("before_beacon", o.av, null, null), e("onbeacon", o.rv, null, null), o.i = !0 } return this }, is_complete: function () { return !0 } } } }() }(window);</script>
+  <link href="https://s.go-mpulse.net/boomerang/2L2Z6-GDWNL-RH2G3-MVS3W-7M6WF" rel="preload" as="script"><iframe
+    src="about:blank" title="" loading="eager" style="width: 0px; height: 0px; border: 0px; display: none;"></iframe>
+  <script charset="utf-8" src="/_next/static/chunks/22.0c89353b3c06ea3e0df9.module.js"></script>
+  <script type="text/javascript" async="" src="//static.criteo.net/js/ld/publishertag.js"></script>
+  <script type="text/javascript" async="" src="//js-sec.indexww.com/ht/p/183960-49969200693724.js"></script>
+  <script type="text/javascript" async="" src="//cdn.krxd.net/controltag?confid=IbWIJ0xh"></script>
+  <script type="text/javascript" async=""
+    src="https://cdn.brandmetrics.com/survey/script/1ce8beea3b4c462193e67e1ee915a33b.js"></script>
+  <script type="text/javascript" async=""
+    src="//scripts.webcontentassessor.com/scripts/9d57e7ee386d4862ec551bf24731dadcab8a37c6f6580c8428470f6489c29264"></script>
+  <style type="text/css">
+    wp-ad {
+      display: block;
+    }
+  </style>
+  <script type="text/javascript" async="" src="//securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+  <script type="text/javascript" async="" src="//c.amazon-adsystem.com/aax2/apstag.js"></script>
+  <style type="text/css">
+    .appearance-none {
+      appearance: none
+    }
+  </style>
+  <style type="text/css">
+    .focus\:facebook:focus .facebook {
+      background-color: #3b5998;
+      border-color: #3b5998;
+      fill: #fff !important
+    }
+
+    .focus\:twitter:focus .twitter {
+      background-color: #55acee;
+      border-color: #55acee;
+      fill: #fff !important
+    }
+
+    .focus\:mail:focus .mail {
+      background-color: #d8070e;
+      border-color: #d8070e;
+      fill: #fff !important
+    }
+
+    .focus\:linkedin:focus .linkedin {
+      background-color: #0077b5;
+      border-color: #0077b5;
+      fill: #fff !important
+    }
+
+    .focus\:pinterest:focus .pinterest {
+      background-color: #bd081c;
+      border-color: #bd081c;
+      fill: #fff !important
+    }
+  </style>
+  <style type="text/css">
+    .tooltip-module_tooltip__kQEvC:before {
+      content: "";
+      position: absolute;
+      left: -14px;
+      top: calc(50% - 10px);
+      border-color: transparent #fff transparent transparent;
+      border-style: solid;
+      border-width: 10px 14px 10px 0;
+      filter: drop-shadow(hsla(0, 0%, 40%, .25) 0 2px 4px)
+    }
+
+    .tooltip-module_tooltip__kQEvC:after {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: calc(50% - 15px);
+      border-color: #fff;
+      border-style: solid;
+      border-width: 20px 15px 9px 0
+    }
+  </style>
+  <style type="text/css">
+    @keyframes slidein {
+      0% {
+        margin-left: -80px
+      }
+
+      to {
+        margin-left: 0
+      }
+    }
+
+    @keyframes fadein {
+      0% {
+        opacity: 0
+      }
+
+      to {
+        opacity: 1
+      }
+    }
+
+    .fade-in-left {
+      animation: slidein 1s ease .5s forwards, fadein 1s ease 1s forwards
+    }
+
+    .grid-cols-1 {
+      grid-template-columns: repeat(1, minmax(0, 1fr))
+    }
+  </style>
+  <style type="text/css">
+    .tooltip-module_tooltip__TM_YM {
+      display: none;
+      visibility: hidden
+    }
+
+    @media only screen and (max-width:767px) {
+      .tooltip-module_tooltip__TM_YM[data-show].tooltip-module_hideOnSmall__22oL5 {
+        display: none;
+        visibility: hidden
+      }
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-show] {
+      display: block;
+      visibility: visible
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-reference-hidden] {
+      visibility: hidden;
+      transition: opacity 1s 3s;
+      pointer-events: none;
+      opacity: 0
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=top]>.tooltip-module_arrow__2-JWx {
+      bottom: -10px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=bottom]>.tooltip-module_arrow__2-JWx {
+      top: -10px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=left]>.tooltip-module_arrow__2-JWx {
+      right: -10px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=right]>.tooltip-module_arrow__2-JWx {
+      left: -10px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=bottom]:before {
+      top: -15px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=right]:before {
+      left: -15px
+    }
+
+    .tooltip-module_tooltip__TM_YM:before {
+      content: "";
+      background: transparent;
+      width: 100%;
+      height: 115%;
+      position: absolute;
+      top: 0;
+      z-index: -1
+    }
+
+    .tooltip-module_arrow__2-JWx,
+    .tooltip-module_arrow__2-JWx:before {
+      position: absolute;
+      width: 20px;
+      height: 20px;
+      z-index: -1
+    }
+
+    .tooltip-module_arrow__2-JWx:before {
+      content: "";
+      transform: rotate(45deg);
+      background: #fff;
+      filter: drop-shadow(hsla(0, 0%, 40%, .25) 0 2px 4px)
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=bottom] .tooltip-module_arrow__2-JWx:after {
+      left: -12px;
+      top: 10px;
+      height: 18px;
+      width: 40px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=right] .tooltip-module_arrow__2-JWx:after {
+      left: 10px;
+      top: -7px;
+      height: 34px;
+      width: 18px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=left] .tooltip-module_arrow__2-JWx:after {
+      left: -25px;
+      top: -7px;
+      height: 38px;
+      width: 34px
+    }
+
+    .tooltip-module_tooltip__TM_YM[data-popper-placement^=top] .tooltip-module_arrow__2-JWx:after {
+      left: -14px;
+      top: -15px;
+      height: 25px;
+      width: 50px
+    }
+
+    .tooltip-module_arrow__2-JWx:after {
+      content: "";
+      position: absolute;
+      background: #fff
+    }
+  </style>
+  <script async="" src="https://www.washingtonpost.com/wp-stat/analytics/latest/main.js"></script>
+  <script async="" src="https://static.chartbeat.com/js/chartbeat.js"></script>
+  <style type="text/css">
+    .focus-highlight:focus {
+      outline: 1px auto -webkit-focus-ring-color
+    }
+
+    .will-change-height {
+      will-change: height
+    }
+  </style>
+</head>
+
+<body data-new-gr-c-s-check-loaded="14.997.0" data-gr-ext-installed="" style="overflow: auto;"
+  cz-shortcut-listen="true">
+  <div id="fusion-app" class="fusion-app"></div>
+  <div id="__next">
+    <div class="w-100" data-sc-v="4.13.3" data-sc-c="fixedheaderspacer" style="height: 60px;"></div>
+    <div class="scrollbar-width-none font-xxxs fixed" data-sc-v="4.13.3" data-sc-c="sidenavmenu"
+      style="top: 0px; left: 0px; transform: translate3d(-500px, 0px, 0px); transition: transform 500ms cubic-bezier(0.4, 0, 0.2, 1) 0s; bottom: 0px; width: 500px; height: 100%; overflow: auto; z-index: 6;">
+    </div>
+    <nav aria-label="Header Navigation"
+      class="z-7 header-nav bg-black flex hide-for-print items-center justify-center w-100 fixed" data-sc-v="4.13.3"
+      data-sc-c="basenav"><a href="#main-content"
+        class="skip-link sr-only sr-only-focusable white underline brad-md pa-lg border-box font-sans-serif font-bold"
+        data-sc-v="4.13.3" data-sc-c="skipnavlink">Skip to main content</a>
+      <div class="flex flex-1 ml-xs ml-sm-ns" style="line-height:60px;height:60px" data-sc-v="4.13.3"
+        data-sc-c="basenav">
+        <form id="search-form" method="get" class="search-form dn flex-ns items-center relative"
+          action="https://www.washingtonpost.com/newssearch/" role="search" data-sc-v="4.13.3" data-sc-c="search"><span
+            id="searchTitle" class="dn" data-sc-v="4.13.3" data-sc-c="_ref">Search Input</span><button type="submit"
+            name="btn-search" class="pa-0 btn btn-gray btn-sm dn dib-ns btn-show-search-input btn-gray"
+            data-sc-v="4.13.3" data-sc-c="search"><svg class="content-box fill-white va-m" width="16" height="16"
+              viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+              <title data-sc-v="4.13.3" data-sc-c="icon">search</title>
+              <path
+                d="M10.974 9.56l3.585 3.585-1.414 1.414-3.585-3.585a5.466 5.466 0 1 1 1.414-1.414zm-1.04-3.094a3.466 3.466 0 1 0-6.934 0 3.466 3.466 0 0 0 6.933 0z"
+                fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+            </svg></button></form>
+        <div class="ml-xs-ns dn db-ns flex-ns items-center" data-sc-v="4.13.3" data-sc-c="rendernavbutton"><button
+            data-qa="sc-header-sections-button" class="transition-color duration-400 ease-in-out btn btn-gray btn-sm">
+            <div class="flex-ns" data-sc-v="4.13.3" data-sc-c="navbutton"><span class="dn dib-ns mr-xs"
+                data-sc-v="4.13.3" data-sc-c="navbutton">Sections</span><svg
+                class="content-box fill-white menu va-m fill-white" width="16" height="16" viewBox="0 0 16 16"
+                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                <title data-sc-v="4.13.3" data-sc-c="icon">menu</title>
+                <path d="M15 12v2H1v-2h14zm-4-5v2H1V7h10zm4-5v2H1V2h14z" fill-rule="nonzero" data-sc-v="4.13.3"
+                  data-sc-c="icon"></path>
+              </svg></div>
+          </button></div>
+        <div class="ml-xs-ns dn-ns pa-0" data-sc-v="4.13.3" data-sc-c="rendernavbutton"><button
+            data-qa="sc-header-sections-button"
+            class="transition-color duration-400 ease-in-out btn btn-gray btn-sm btn-pa-0">
+            <div class="flex-ns" data-sc-v="4.13.3" data-sc-c="navbutton"><span class="dn dib-ns mr-xs"
+                data-sc-v="4.13.3" data-sc-c="navbutton">Sections</span><svg
+                class="content-box fill-white menu va-m fill-white" width="24" height="24" viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                <title data-sc-v="4.13.3" data-sc-c="icon">menu</title>
+                <path d="M22 18v2H2v-2h20zm-5-7v2H2v-2h15zm5-7v2H2V4h20z" fill-rule="nonzero" data-sc-v="4.13.3"
+                  data-sc-c="icon"></path>
+              </svg></div>
+          </button></div>
+      </div>
+      <div class="flex flex-1 justify-center z-1" data-sc-v="4.13.3" data-sc-c="basenav"><a
+          href="https://www.washingtonpost.com" class="center" data-sc-v="4.13.3" data-sc-c="headerlogo"><svg
+            viewBox="0 0 697.01 104.61" width="188" height="26" class="db">
+            <path fill="#fff"
+              d="M39.2 32v36.6c4.7-2.8 7-6.8 8.7-12.1l1.2.6c-1.1 13.2-10.3 26-24.3 26S0 72.6 0 55.8C0 43 7.7 35.1 18.7 28.2a16.11 16.11 0 00-4.4-.6c-7.2 0-11.4 4.9-11.4 9.9H1.5a14.77 14.77 0 01-.1-2.1c0-9.3 5.5-19.7 16.9-19.7 7.3 0 12.9 6.7 21.4 6.7 4.3 0 6.7-1.6 8.4-5.3h1.2c-.1 6.5-2 12.8-10.1 14.9zm-19-3.3C15.1 34 10.1 39.6 10.1 50.9c0 6.2 1.9 12.4 6.6 16.4l3.1-1.7V40.3L16.6 42l-1-1.6 15-8.4c-3.8-.8-6.9-2.3-10.4-3.3zm17.1 3.7a17 17 0 01-2.3.1 17.52 17.52 0 01-4-.4v29.5l-12.8 7a15.57 15.57 0 009.9 3 22.58 22.58 0 009.2-2zm44 9.2v34.3c0 9.6-8.51 16.11-18 18l-.6-1c4.7-2.3 7.8-6.41 7.8-11.41V45.7l-4.9-4.5-2.6 2.6v27.1l3 2.8v.4l-8.1 8.61-9.3-8.51v-.4l3.6-3.8V25.8l10.6-11.3.2.1v26.6l8.7-9.2 8.7 7.9 2.7-2.6 1.31 1.3zM97.91 62v4.5l9 7.1 7-7.3 1.3 1.3L101 82.8 88.21 72.6l-2.8 2.8-1.2-1.3 3.1-3.2V45.8l18.9-13.8 10.5 16.3zm.2-22.6l-.2.1v20.1l8.7-6.4zM180 82.71l-13.9-12-10.6 12-14.4-12.41V50.7h-2.8a3.89 3.89 0 00-4.1 3.5h-1a15.87 15.87 0 01-.5-3.8c0-2.6 1.1-9.4 8.4-9.4V25.8c0-5.9-3.9-6.2-3.9-11.3 0-5.7 5.4-11 15.3-14.5l.9.8c-3.3 1.6-6 3.6-6 7.9 0 6.6 6.4 4.9 6.4 15.3v4l11.7-12.3 12.3 12.1 11.6-12.1 11.2 11v37zM165.4 32.8l-7-6.9-4.6 4.7v34.3l8.5 7.3 3.1-3.5zm22.6-1.3l-5.6-5.6-4.3 4.3v34.6l9.8 8.6.1-.1zm44.8 51.21l-9.4-8.61h-.2l-8.3 8.61-10.1-8.91-2.3 2.3-1.3-1.3 2.9-3V45.5l19-13.6 10.4 8.2 2.8-2.8 1.5 1.3-3.6 3.4v27.1l4.6 4.2 2.9-3 1.5 1.4zm-9.4-37.41l-8.3-6.5-.2.2v29.2l6.1 5.4 2.4-2.3zm40.6 4.8h9.4v21.4l-15.9 11.21a11.52 11.52 0 00-8.8-4.11c-3 0-5.4 1.4-7.8 4l-1.4-.5 13.8-19.8h-8.5V43.7L261.4 32c2 1.6 3.6 2.6 6.2 2.6a11.35 11.35 0 007.1-2.2l1 .7zm-1.4 8.8h-4.7l-11.1 15.9.1.2a12.36 12.36 0 017.6-2.5 10.4 10.4 0 018 3.8l.1-.09zm6.4-19.6a9.73 9.73 0 01-6.9 2.3 8.92 8.92 0 01-6.3-2.9l-.2.1v14.6h3.8l9.7-14zm40 2.3v34.3c0 9.6-8.51 16.11-18 18l-.6-1c4.7-2.3 7.8-6.41 7.8-11.41V45.7l-4.9-4.5-2.6 2.6v27.1l3 2.8v.4l-8.1 8.61-9.3-8.51v-.4l3.6-3.8V25.8l10.6-11.3.2.1v26.6l8.7-9.2 8.71 7.9 2.7-2.6 1.3 1.3zm19.6 41.11l-8.3-7.61-2.8 2.8-1.3-1.3 3.3-3.4V44.7l-3.6-3.3-2.7 2.6-1.3-1.3L322 32l7.6 6.9 2.7-2.8 1.4 1.4-3.4 3.4v28.6l4.2 3.9 3-3.1 1.3 1.4zm-2.9-51.61l-8.2-7.5 7.5-8 8.2 7.5zm46.1 51.61l-8.7-7.91V45.6l-4.7-4.4-3.4 3.5v26.1l3.1 2.9v.4l-8.2 8.61-9.3-8.51v-.3l3.6-3.8V44.9l-4.1-3.7-3 3-1.4-1.3L345.9 32l9.1 8.1v2l9.5-10.1 8.7 7.8 2.9-2.9 1.3 1.4-3.5 3.5v28l3.9 3.7 3.3-3.4 1.2 1.3zm43-41V75.6c0 5.2 2.9 5 2.9 8.9 0 4.51-6.5 8.71-16.5 16.21-3.3-3.6-5.6-5.1-8.7-5.1a19.85 19.85 0 00-10.7 3.6l-1-.8 13.7-16.11-9-7.09-2.9 2.89-1.3-1.3 3.4-3.5V45.5l19-13.6 10.2 8 3-2.9 1.3 1.3zm-7.7 41.71c-2.5-1.61-3.1-3.31-3.1-7.61V74.3L387.9 93l.1.1c3.2-1.9 5.6-3.1 10.3-3.1 4 0 6.9 1.7 9.5 4 1.9-1.6 3.3-3.2 3.3-5.7 0-1.99-1.5-3.3-4-4.89zM404 45.3l-8.3-6.5-.2.2v30.7l5.9 4.6 2.6-3zm31.5 37.41l-8.8-6.91-2.7 2.7-1.3-1.29 3.1-3.21V39.4H420l-.2-.2 3.5-5.2h2.5v-6.7L436.4 16l.2.2V34h8l.2.2-3.5 5.2h-4.7v30.3l4.8 3.7 3.3-3.4 1.3 1.4zm43.71-40.11v27.7l-16.9 12.5L450 73.5l-2.8 2.8-1.3-1.3 3.2-3.3v-27L466.81 32l11.4 8.9 2.9-2.9 1.3 1.4zm-10.8 3L460 39l-.09.1v29.8l8.5 6.4zm50.4 37l-8.7-7.9V45.5l-4.7-4.4-3.41 3.5v26.1l3.1 2.9v.4l-8.2 8.61-9.3-8.51v-.3l3.6-3.8V44.8l-4.1-3.7-3 3-1.4-1.3 10.2-10.9L502 40v2l9.5-10.1 8.7 7.8 2.9-2.9 1.3 1.4-3.5 3.5v28l3.9 3.7 3.3-3.4 1.2 1.3zm61.39.11a12.91 12.91 0 00-6.3-4.61v20.81l-.2.1-5.5-5.1-11.6 10.7-.2-.1V77.6a18.83 18.83 0 00-10.2 6.61l-.8-.5c.7-7.71 4.5-13.41 11-15.61V48.6h-2.1a5.25 5.25 0 00-5.3 4.2h-1.2a12.28 12.28 0 01-.7-4.6c0-4.9 3.3-8.6 8.7-8.6h.6V28.8l-3.6-3.2-2.8 2.8-1.4-1.3 11.1-11.4 9.4 8.6v9.8L572 31V19.5h1.9V29l12.5-13.3L597.7 26v43.5zM572 32.9l-2.9 3v56.31l2.9 2.7zm13.1-2.3l-5.9-5.4-5.3 5.6v36.3c4.7.6 8.2 2.2 11.1 5.3l.1-.1zm48.7 12v27.7l-16.9 12.5-12.3-9.3-2.8 2.8-1.3-1.3 3.2-3.3v-27L621.4 32l11.4 8.9 2.9-2.9 1.3 1.4zm-10.8 3l-8.4-6.6-.1.1v29.8l8.5 6.4zm35.6 4.5h9.4v21.4l-15.9 11.21a11.52 11.52 0 00-8.8-4.11c-3 0-5.4 1.4-7.8 4l-1.4-.5 13.8-19.8h-8.5V43.7L656 32c2 1.6 3.6 2.6 6.2 2.6a11.38 11.38 0 007.11-2.2l1 .7zm-1.4 8.8h-4.7l-11.1 15.9.1.2a12.36 12.36 0 017.6-2.5 10.4 10.4 0 018 3.8l.1-.09zm6.41-19.6a9.78 9.78 0 01-6.91 2.3 8.92 8.92 0 01-6.3-2.9l-.2.1v14.6h3.8l9.7-14zm22.9 43.41l-8.8-6.91-2.71 2.7-1.3-1.29 3.1-3.21V39.4H671l-.2-.2 3.5-5.2h2.5v-6.7L687.41 16l.2.2V34h8l.2.2-3.5 5.2h-4.7v30.3l4.8 3.7 3.3-3.4 1.3 1.4z"
+              data-sc-v="4.13.3" data-sc-c="_ref2"></path>
+          </svg><span class="italic gray-light font-xxxxs font--body" data-sc-v="4.13.3"
+            data-sc-c="headerlogo">Democracy Dies in Darkness</span></a></div>
+      <div class="flex flex-1 justify-end mr-xs mr-sm-ns" data-sc-v="4.13.3" data-sc-c="basenav">
+        <div class="dn dib-ns ml-xs" data-sc-v="4.13.3" data-sc-c="rightsidesubscribebutton"><a data-qa="subs-offer"
+            class="transition-color duration-400 ease-in-out font-xxs center border-box lh-default dib pt-xxs pl-sm pr-sm pb-xxs brad-2 font-bold bw b-solid header-nav-button-font-size white bc-blue-bright bg-blue hover-bg-blue-bright hover-bc-blue-bright btn-blue btn-sm dib-ns va-m white"
+            href="https://subscribe.washingtonpost.com/acquisition/?promo=o2&amp;oscode=RPWH&amp;s_l=ONSITE_HEADER_HOMEPAGE&amp;p=s_v&amp;itid=top_pb_subscribe&amp;tid=nav_subscribe_logged_out&amp;itid=nav_subscribe_logged_out&amp;acqEntType=mktg_onsite_article&amp;destination=https%3A%2F%2Fwww.washingtonpost.com%2Fnews%2Fthe-intersect%2Fwp%2F2016%2F05%2F24%2Ftwitter-says-goodbye-to-all%2F&amp;arcId=M4IAOPWKF5CS3PUTQH6IOFYVD4"><span
+              class="truncate ma-0" data-sc-v="4.13.3" data-sc-c="subscribebutton">Get one year for €20</span></a></div>
+        <div class="ml-xs mw-200 dn db-ns" data-sc-v="4.13.3" data-sc-c="rendernavbutton"><button
+            data-qa="sc-account-button-not-small" class="transition-color duration-400 ease-in-out btn btn-gray btn-sm">
+            <div class="flex-ns" data-sc-v="4.13.3" data-sc-c="navbutton"><span
+                class="dn dib-ns sign-in-text truncate mr-xxs mw-144" data-sc-v="4.13.3" data-sc-c="navbutton">Sign
+                in</span><svg class="content-box fill-white profile va-m" width="16" height="16" viewBox="0 0 16 16"
+                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                <title data-sc-v="4.13.3" data-sc-c="icon">profile</title>
+                <path
+                  d="M11 5A3 3 0 1 1 5 5 3 3 0 0 1 11 5zm.167 4.649l1.22.439c.959.343 1.613 1.204 1.613 2.19V13a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-.722c0-.986.653-1.847 1.61-2.19l1.771-.636A7.787 7.787 0 0 1 8 9c.893 0 1.782.153 2.62.452l.528.19a1 1 0 0 1 .019.007z"
+                  fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+              </svg></div>
+          </button></div>
+        <div class="ml-xs mw-200 items-center pa-0 dn-ns" data-sc-v="4.13.3" data-sc-c="rendernavbutton"><button
+            data-qa="sc-account-button-small"
+            class="transition-color duration-400 ease-in-out btn btn-gray btn-sm btn-pa-0">
+            <div class="flex-ns" data-sc-v="4.13.3" data-sc-c="navbutton"><span
+                class="dn dib-ns sign-in-text truncate mr-xxs mw-144" data-sc-v="4.13.3" data-sc-c="navbutton">Sign
+                in</span><svg class="content-box fill-white profile va-m" width="24" height="24" viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                <title data-sc-v="4.13.3" data-sc-c="icon">profile</title>
+                <path
+                  d="M17 8a5 5 0 0 1-5 5 5 5 0 0 1-5-5c0-2.762 2.238-5 5-5s5 2.238 5 5zm.462 7.25l2.199.879A3.696 3.696 0 0 1 22 19.556V21a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-1.444c0-1.508.927-2.865 2.336-3.427l3.187-1.271a12.124 12.124 0 0 1 8.955 0l.958.383a1 1 0 0 1 .026.01z"
+                  fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+              </svg></div>
+          </button></div>
+      </div>
+    </nav>
+    <div class="scrollbar-width-none font-xxxs fixed top-0 right-0 bottom-0 overflow-auto" data-sc-v="4.13.3"
+      data-sc-c="drawer"
+      style="transform: translate3d(304px, 0px, 0px); transition: transform 500ms cubic-bezier(0.4, 0, 0.2, 1) 0s; width: 304px; z-index: 6;">
+      <nav class="pl-md relative side-nav pr-md border-box" aria-hidden="true" data-sc-v="4.13.3" data-sc-c="drawer">
+      </nav>
+    </div>
+    <wp-ad id="slug_banner_top" data-qa="banner-top-ad" classname="hide-for-print" aria-hidden="true"
+      data-slot="/701/wpni.technology" data-renderbehavior="lazy"
+      data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_banner_top.ref&quot;,&quot;pos&quot;:&quot;banner_top&quot;,&quot;ctr&quot;:[&quot;zeus_c_banner_top_refresh&quot;,&quot;refresh&quot;],&quot;wp_ad_refresh&quot;:&quot;1&quot;,&quot;wp_refresh&quot;:&quot;banner_top_1&quot;}}"
+      style="margin: auto; width: 1px; display: block;"></wp-ad>
+    <div class="hide-for-print
+       db dn-ns" data-qa="interstitial-ad" aria-hidden="true" style="height:1px">
+      <wp-ad id="slug_interstitial" data-slot="/701/wpni.technology" aria-hidden="true" data-renderbehavior="never"
+        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_interstitial.init&quot;,&quot;pos&quot;:&quot;interstitial&quot;,&quot;ctr&quot;:[&quot;zeus_c_interstitial&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;interstitial_0&quot;}}"
+        style="margin: auto; width: 1px; display: none;"></wp-ad>
+    </div>
+    <div class="hide-for-print
+       dn db-ns" data-qa="interstitial-ad" aria-hidden="true" style="height:1px">
+      <wp-ad id="slug_desktop_interstitial" data-slot="/701/wpni.technology" aria-hidden="true"
+        data-renderbehavior="lazy"
+        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_desktop_interstitial.ref&quot;,&quot;pos&quot;:&quot;desktop_interstitial&quot;,&quot;ctr&quot;:[&quot;zeus_c_desktop_interstitial_refresh&quot;,&quot;refresh&quot;],&quot;wp_ad_refresh&quot;:&quot;1&quot;,&quot;wp_refresh&quot;:&quot;desktop_interstitial_1&quot;}}"
+        style="margin: auto; width: 1px; display: block;"></wp-ad>
+    </div>
+    <div
+      class="dn overflow-hidden flex-ns w-100 center border-box absolute pt-sm pb-sm b-none b-ns bb items-center justify-center"
+      style="height:282px" data-qa="leaderboard" aria-hidden="true" q8lxgi42l="" u963jxnj5="">
+      <div aria-hidden="true">AD</div>
+    </div>
+    <div id="leaderboard-wrapper"
+      class="w-100 z-7 flex-ns dn border-box justify-center items-center overflow-hidden sticky"
+      style="top:60px;transition:top 300ms ease-in;height:282px" data-ad-module="" aria-hidden="true">
+      <div class=" w-100">
+        <wp-ad class="hide-for-print dn db-ns pt-sm pb-sm relative z-2 hide-for-print" id="slug_leaderboard"
+          data-slot="/701/wpni.technology" aria-hidden="true" data-renderbehavior="lazy" data-refresh="true"
+          data-json="{&quot;targeting&quot;:{&quot;pos&quot;:&quot;leaderboard&quot;,&quot;zeus_slot&quot;:&quot;slug_leaderboard.init&quot;,&quot;ctr&quot;:[&quot;zeus_c_leaderboard&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;leaderboard_0&quot;}}"
+          style="margin: auto; width: 1px; display: block;"></wp-ad>
+      </div>
+      <div id="leaderboard-overlay" class="o-15 h-100 bg-black w-100 absolute top-0 z-1 "><svg
+          class="content-box fill-white absolute right-0 mr-xs mt-xs pointer" width="16" height="16" viewBox="0 0 16 16"
+          xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+          <title data-sc-v="4.13.3" data-sc-c="icon">close</title>
+          <path
+            d="M8 6.586l4.293-4.293 1.414 1.414L9.414 8l4.293 4.293-1.414 1.414L8 9.414l-4.293 4.293-1.414-1.414L6.586 8 2.293 3.707l1.414-1.414L8 6.586z"
+            fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+        </svg></div>
+    </div>
+    <div class="relative">
+      <main class="grid mr-auto ml-auto print-mt-none">
+        <div class="z-5">
+          <div class="z-1 mt-lg left-0 top-0 absolute" data-sc-v="4.13.3" data-sc-c="utilitybar">
+            <div data-qa="utility-bar" class="bg-white dn grid-l grid-cols-1 b left-0 fixed fade-in-left o-0"
+              style="grid-auto-rows: 1fr; margin-left: -80px; top: 92px;" data-sc-v="4.13.3" data-sc-c="utilitybar">
+              <div role="button" data-qa="utility-bar-item-home" tabindex="0"
+                class="appearance-none pl-xs pr-xs pt-sm pb-sm relative flex flex-column items-center justify-center pointer bg-white center b bb last:bt  hover-bg-gray-lightest transition-colors duration-200 ease-in-out">
+                <svg class="content-box" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                  url="https://www.washingtonpost.com" data-sc-v="4.13.3" data-sc-c="icon">
+                  <title data-sc-v="4.13.3" data-sc-c="icon">home</title>
+                  <path
+                    d="M14 19h5V9.976l-7-5.688-7 5.688V19h5v-5h4v5zM3 9.5a1 1 0 0 1 .37-.776l8-6.5a1 1 0 0 1 1.26 0l8 6.5A1 1 0 0 1 21 9.5V20a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z"
+                    fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                </svg><span class="font-xxxxs font--subhead font-bold gray-darkest">Home</span></div>
+              <div role="button" data-qa="utility-bar-item-share" tabindex="0"
+                class="appearance-none pl-xs pr-xs pt-sm pb-sm relative flex flex-column items-center justify-center pointer bg-white center b bb last:bt  hover-bg-gray-lightest transition-colors duration-200 ease-in-out">
+                <svg class="content-box" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+                  url="https://www.washingtonpost.com" data-sc-v="4.13.3" data-sc-c="icon">
+                  <title data-sc-v="4.13.3" data-sc-c="icon">share</title>
+                  <path
+                    d="M18 9h-2V7h3a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1h3v2H6v10h12V9zm-5-3.287V17h-2V5.713H8.47L12 .757l3.53 4.956H13z"
+                    fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                </svg><span class="font-xxxxs font--subhead font-bold gray-darkest">Share</span>
+                <div role="button" aria-haspopup="true" aria-expanded="false" tabindex="0"
+                  class="transition-colors duration-200 ease-in-out pa-md absolute bg-white brad-4 top-0 ml-sm dn flex items-center pa-sm shadow-3 tooltip-module_tooltip__kQEvC hidden"
+                  style="left:100%" data-sc-v="4.13.3" data-sc-c="tooltip">
+                  <div class="absolute" style="background-color:transparent;left:-15px;top:0px;bottom:0;width:15px"
+                    data-sc-v="4.13.3" data-sc-c="tooltip"></div><button
+                    class="appearance-none focus:facebook flex ma-0 pa-0"><svg
+                      class="content-box facebook pointer pa-xs brad-50 b hover-fill-white mr-xs" width="24" height="24"
+                      viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                      <title data-sc-v="4.13.3" data-sc-c="icon">Share on Facebook</title>
+                      <path
+                        d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12c0-5.523-4.477-10-10-10"
+                        fill-rule="evenodd" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                    </svg></button><button id="mail"
+                    class="focus:mail appearance-none focus:facebook flex ma-0 pa-0"><svg
+                      class="content-box mail va-m pointer pa-xs brad-50 b hover-fill-white mr-xs" width="24"
+                      height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3"
+                      data-sc-c="icon">
+                      <title data-sc-v="4.13.3" data-sc-c="icon">Email this link</title>
+                      <path
+                        d="M3.313 5.273C3.493 5.103 3.734 5 4 5h16c.13 0 .253.025.366.07L11.79 12.49 3.313 5.273zM21 7.166V18a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V7.775l8.064 6.867c.376.32.945.305 1.338-.036L21 7.166z"
+                        fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                    </svg></button><button class="appearance-none focus:twitter flex ma-0 pa-0"><svg
+                      class="content-box twitter pointer pa-xs brad-50 b hover-fill-white mr-xs" width="24" height="24"
+                      viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                      <title data-sc-v="4.13.3" data-sc-c="icon">Share on Twitter</title>
+                      <path
+                        d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.35 8.35 0 0 0 22 5.92a8.189 8.189 0 0 1-2.357.646 4.117 4.117 0 0 0 1.804-2.27 8.222 8.222 0 0 1-2.605.996 4.107 4.107 0 0 0-6.993 3.743 11.65 11.65 0 0 1-8.457-4.287 4.106 4.106 0 0 0 1.27 5.477A4.073 4.073 0 0 1 2.8 9.713v.052a4.105 4.105 0 0 0 3.292 4.022 4.095 4.095 0 0 1-1.853.07 4.108 4.108 0 0 0 3.834 2.85A8.233 8.233 0 0 1 2 18.407a11.617 11.617 0 0 0 6.29 1.84"
+                        fill-rule="evenodd" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                    </svg></button><button class="appearance-none focus:pinterest flex ma-0 pa-0"><svg
+                      class="content-box pinterest pointer pa-xs brad-50 b hover-fill-white mr-xs" width="24"
+                      height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3"
+                      data-sc-c="icon">
+                      <title data-sc-v="4.13.3" data-sc-c="icon">Share on Pinterest</title>
+                      <path
+                        d="M12 2C6.477 2 2 6.477 2 12c0 4.239 2.634 7.86 6.354 9.317-.09-.79-.165-2.008.033-2.873.18-.781 1.169-4.97 1.169-4.97s-.297-.602-.297-1.482c0-1.391.807-2.428 1.811-2.428.856 0 1.267.642 1.267 1.407 0 .856-.543 2.14-.83 3.334-.24.995.501 1.81 1.48 1.81 1.778 0 3.145-1.876 3.145-4.576 0-2.395-1.72-4.066-4.181-4.066-2.848 0-4.519 2.132-4.519 4.338 0 .856.33 1.777.74 2.28.083.098.091.189.067.288-.074.312-.247.995-.28 1.135-.041.181-.148.223-.338.132-1.25-.584-2.033-2.403-2.033-3.876 0-3.153 2.289-6.05 6.61-6.05 3.465 0 6.164 2.47 6.164 5.778 0 3.449-2.173 6.222-5.185 6.222-1.012 0-1.967-.527-2.288-1.152l-.626 2.379c-.222.872-.83 1.958-1.242 2.625.938.288 1.926.444 2.963.444 5.522 0 10-4.477 10-10A9.98 9.98 0 0 0 12 2"
+                        fill-rule="evenodd" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                    </svg></button><button class="appearance-none focus:linkedin flex ma-0 pa-0"
+                    data-qa="share-sheet-button-linkedin"><svg
+                      class="content-box linkedin mr-0 pointer pa-xs brad-50 b hover-fill-white" width="24" height="24"
+                      viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                      <title data-sc-v="4.13.3" data-sc-c="icon">Share on LinkedIn</title>
+                      <path
+                        d="M4.329 3H19.67C20.405 3 21 3.595 21 4.329V19.67c0 .734-.595 1.329-1.329 1.329H4.33A1.329 1.329 0 0 1 3 19.67V4.329C3 3.595 3.595 3 4.329 3zM18.35 17.901v-5.316c0-2.626-1.632-3.522-3.142-3.522-1.396 0-2.31.904-2.572 1.433h-.035V9.305H10V17.9h2.706v-4.66c0-1.243.787-1.847 1.59-1.847.76 0 1.349.427 1.349 1.812v4.695h2.706zM7.56 8.107c.86 0 1.56-.656 1.56-1.553C9.12 5.656 8.42 5 7.56 5 6.697 5 6 5.656 6 6.554c0 .897.698 1.553 1.56 1.553zm-1.354 9.788h2.706V9.298H6.207v8.597z"
+                        fill-rule="evenodd" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                    </svg></button>
+                </div>
+              </div>
+            </div>
           </div>
-          <div>
-            <h3>We noticed you’re blocking ads!</h3>
+        </div>
+        <div class="center dn show-for-print"><svg viewBox="0 0 697.01 104.61" width="200" height="30"
+            class="db ma-auto">
+            <path
+              d="M39.2 32v36.6c4.7-2.8 7-6.8 8.7-12.1l1.2.6c-1.1 13.2-10.3 26-24.3 26S0 72.6 0 55.8C0 43 7.7 35.1 18.7 28.2a16.11 16.11 0 00-4.4-.6c-7.2 0-11.4 4.9-11.4 9.9H1.5a14.77 14.77 0 01-.1-2.1c0-9.3 5.5-19.7 16.9-19.7 7.3 0 12.9 6.7 21.4 6.7 4.3 0 6.7-1.6 8.4-5.3h1.2c-.1 6.5-2 12.8-10.1 14.9zm-19-3.3C15.1 34 10.1 39.6 10.1 50.9c0 6.2 1.9 12.4 6.6 16.4l3.1-1.7V40.3L16.6 42l-1-1.6 15-8.4c-3.8-.8-6.9-2.3-10.4-3.3zm17.1 3.7a17 17 0 01-2.3.1 17.52 17.52 0 01-4-.4v29.5l-12.8 7a15.57 15.57 0 009.9 3 22.58 22.58 0 009.2-2zm44 9.2v34.3c0 9.6-8.51 16.11-18 18l-.6-1c4.7-2.3 7.8-6.41 7.8-11.41V45.7l-4.9-4.5-2.6 2.6v27.1l3 2.8v.4l-8.1 8.61-9.3-8.51v-.4l3.6-3.8V25.8l10.6-11.3.2.1v26.6l8.7-9.2 8.7 7.9 2.7-2.6 1.31 1.3zM97.91 62v4.5l9 7.1 7-7.3 1.3 1.3L101 82.8 88.21 72.6l-2.8 2.8-1.2-1.3 3.1-3.2V45.8l18.9-13.8 10.5 16.3zm.2-22.6l-.2.1v20.1l8.7-6.4zM180 82.71l-13.9-12-10.6 12-14.4-12.41V50.7h-2.8a3.89 3.89 0 00-4.1 3.5h-1a15.87 15.87 0 01-.5-3.8c0-2.6 1.1-9.4 8.4-9.4V25.8c0-5.9-3.9-6.2-3.9-11.3 0-5.7 5.4-11 15.3-14.5l.9.8c-3.3 1.6-6 3.6-6 7.9 0 6.6 6.4 4.9 6.4 15.3v4l11.7-12.3 12.3 12.1 11.6-12.1 11.2 11v37zM165.4 32.8l-7-6.9-4.6 4.7v34.3l8.5 7.3 3.1-3.5zm22.6-1.3l-5.6-5.6-4.3 4.3v34.6l9.8 8.6.1-.1zm44.8 51.21l-9.4-8.61h-.2l-8.3 8.61-10.1-8.91-2.3 2.3-1.3-1.3 2.9-3V45.5l19-13.6 10.4 8.2 2.8-2.8 1.5 1.3-3.6 3.4v27.1l4.6 4.2 2.9-3 1.5 1.4zm-9.4-37.41l-8.3-6.5-.2.2v29.2l6.1 5.4 2.4-2.3zm40.6 4.8h9.4v21.4l-15.9 11.21a11.52 11.52 0 00-8.8-4.11c-3 0-5.4 1.4-7.8 4l-1.4-.5 13.8-19.8h-8.5V43.7L261.4 32c2 1.6 3.6 2.6 6.2 2.6a11.35 11.35 0 007.1-2.2l1 .7zm-1.4 8.8h-4.7l-11.1 15.9.1.2a12.36 12.36 0 017.6-2.5 10.4 10.4 0 018 3.8l.1-.09zm6.4-19.6a9.73 9.73 0 01-6.9 2.3 8.92 8.92 0 01-6.3-2.9l-.2.1v14.6h3.8l9.7-14zm40 2.3v34.3c0 9.6-8.51 16.11-18 18l-.6-1c4.7-2.3 7.8-6.41 7.8-11.41V45.7l-4.9-4.5-2.6 2.6v27.1l3 2.8v.4l-8.1 8.61-9.3-8.51v-.4l3.6-3.8V25.8l10.6-11.3.2.1v26.6l8.7-9.2 8.71 7.9 2.7-2.6 1.3 1.3zm19.6 41.11l-8.3-7.61-2.8 2.8-1.3-1.3 3.3-3.4V44.7l-3.6-3.3-2.7 2.6-1.3-1.3L322 32l7.6 6.9 2.7-2.8 1.4 1.4-3.4 3.4v28.6l4.2 3.9 3-3.1 1.3 1.4zm-2.9-51.61l-8.2-7.5 7.5-8 8.2 7.5zm46.1 51.61l-8.7-7.91V45.6l-4.7-4.4-3.4 3.5v26.1l3.1 2.9v.4l-8.2 8.61-9.3-8.51v-.3l3.6-3.8V44.9l-4.1-3.7-3 3-1.4-1.3L345.9 32l9.1 8.1v2l9.5-10.1 8.7 7.8 2.9-2.9 1.3 1.4-3.5 3.5v28l3.9 3.7 3.3-3.4 1.2 1.3zm43-41V75.6c0 5.2 2.9 5 2.9 8.9 0 4.51-6.5 8.71-16.5 16.21-3.3-3.6-5.6-5.1-8.7-5.1a19.85 19.85 0 00-10.7 3.6l-1-.8 13.7-16.11-9-7.09-2.9 2.89-1.3-1.3 3.4-3.5V45.5l19-13.6 10.2 8 3-2.9 1.3 1.3zm-7.7 41.71c-2.5-1.61-3.1-3.31-3.1-7.61V74.3L387.9 93l.1.1c3.2-1.9 5.6-3.1 10.3-3.1 4 0 6.9 1.7 9.5 4 1.9-1.6 3.3-3.2 3.3-5.7 0-1.99-1.5-3.3-4-4.89zM404 45.3l-8.3-6.5-.2.2v30.7l5.9 4.6 2.6-3zm31.5 37.41l-8.8-6.91-2.7 2.7-1.3-1.29 3.1-3.21V39.4H420l-.2-.2 3.5-5.2h2.5v-6.7L436.4 16l.2.2V34h8l.2.2-3.5 5.2h-4.7v30.3l4.8 3.7 3.3-3.4 1.3 1.4zm43.71-40.11v27.7l-16.9 12.5L450 73.5l-2.8 2.8-1.3-1.3 3.2-3.3v-27L466.81 32l11.4 8.9 2.9-2.9 1.3 1.4zm-10.8 3L460 39l-.09.1v29.8l8.5 6.4zm50.4 37l-8.7-7.9V45.5l-4.7-4.4-3.41 3.5v26.1l3.1 2.9v.4l-8.2 8.61-9.3-8.51v-.3l3.6-3.8V44.8l-4.1-3.7-3 3-1.4-1.3 10.2-10.9L502 40v2l9.5-10.1 8.7 7.8 2.9-2.9 1.3 1.4-3.5 3.5v28l3.9 3.7 3.3-3.4 1.2 1.3zm61.39.11a12.91 12.91 0 00-6.3-4.61v20.81l-.2.1-5.5-5.1-11.6 10.7-.2-.1V77.6a18.83 18.83 0 00-10.2 6.61l-.8-.5c.7-7.71 4.5-13.41 11-15.61V48.6h-2.1a5.25 5.25 0 00-5.3 4.2h-1.2a12.28 12.28 0 01-.7-4.6c0-4.9 3.3-8.6 8.7-8.6h.6V28.8l-3.6-3.2-2.8 2.8-1.4-1.3 11.1-11.4 9.4 8.6v9.8L572 31V19.5h1.9V29l12.5-13.3L597.7 26v43.5zM572 32.9l-2.9 3v56.31l2.9 2.7zm13.1-2.3l-5.9-5.4-5.3 5.6v36.3c4.7.6 8.2 2.2 11.1 5.3l.1-.1zm48.7 12v27.7l-16.9 12.5-12.3-9.3-2.8 2.8-1.3-1.3 3.2-3.3v-27L621.4 32l11.4 8.9 2.9-2.9 1.3 1.4zm-10.8 3l-8.4-6.6-.1.1v29.8l8.5 6.4zm35.6 4.5h9.4v21.4l-15.9 11.21a11.52 11.52 0 00-8.8-4.11c-3 0-5.4 1.4-7.8 4l-1.4-.5 13.8-19.8h-8.5V43.7L656 32c2 1.6 3.6 2.6 6.2 2.6a11.38 11.38 0 007.11-2.2l1 .7zm-1.4 8.8h-4.7l-11.1 15.9.1.2a12.36 12.36 0 017.6-2.5 10.4 10.4 0 018 3.8l.1-.09zm6.41-19.6a9.78 9.78 0 01-6.91 2.3 8.92 8.92 0 01-6.3-2.9l-.2.1v14.6h3.8l9.7-14zm22.9 43.41l-8.8-6.91-2.71 2.7-1.3-1.29 3.1-3.21V39.4H671l-.2-.2 3.5-5.2h2.5v-6.7L687.41 16l.2.2V34h8l.2.2-3.5 5.2h-4.7v30.3l4.8 3.7 3.3-3.4 1.3 1.4z"
+              data-sc-v="4.13.3" data-sc-c="_ref2"></path>
+          </svg><span class="italic gray font-xxxxs font--body">Democracy Dies in Darkness</span></div>
+        <header class="grid-item grid-item--cols-sm-12 grid-item--cols-md-12 b-l bb-l grid-item--cols-lg-12"
+          data-qa="main-full">
+          <div class="hide-for-print">
+            <nav
+              class="flex overflow-hidden overflow-xscroll ml-auto-ns mr-auto-ns h-100 b bb ml-neg-gutter mr-neg-gutter"
+              style="height:54px;max-width:100vw" aria-label="Secondary Navigation Menu" data-qa="secondary-nav"
+              data-sc-v="4.13.3" data-sc-c="secondarynav">
+              <div class="mt-0 mb-0 ma-0-ns flex flex-shrink-0 items-center pr-sm list-none ml-sm mr-sm"
+                data-sc-v="4.13.3" data-sc-c="secondarynav"><a
+                  href="https://www.washingtonpost.com/business/technology/?itid=sn_tech_title"
+                  data-qa="secondary-nav-primary-link"
+                  class="flex items-center h-100 bold gray-darkest font-xxs font-xs-ns ma-0-ns" data-sc-v="4.13.3"
+                  data-sc-c="secondarynavcontent">Tech</a>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="https://www.washingtonpost.com/consumer-tech/?itid=sn_tech_1/" data-qa="secondary-link"
+                    class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Consumer Tech </a></div>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="https://www.washingtonpost.com/future-of-transportation/?itid=sn_tech_2/"
+                    data-qa="secondary-link" class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Future of Transportation </a></div>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="/technology/innovations/" data-qa="secondary-link"
+                    class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Innovations </a></div>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="https://www.washingtonpost.com/internet-culture/?itid=sn_tech_4/" data-qa="secondary-link"
+                    class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Internet Culture </a></div>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="https://www.washingtonpost.com/space/?itid=sn_tech_5/" data-qa="secondary-link"
+                    class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Space </a></div>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="https://www.washingtonpost.com/tech-policy/?itid=sn_tech_6/" data-qa="secondary-link"
+                    class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Tech Policy </a></div>
+                <div class="flex flex-column items-center h-100 ml-md" data-sc-v="4.13.3" data-sc-c="navitem"><a
+                    href="/technology/video-gaming/" data-qa="secondary-link"
+                    class="gray-darkest flex h-100 items-center hover-blue hover-fill-blue"
+                    style="border-bottom-width: 0px;">Video Gaming </a></div>
+              </div>
+            </nav>
           </div>
-          <div> <span>Keep supporting great journalism by turning off your ad blocker. Or purchase a subscription for unlimited access to real news you can count on.</span> </div>
-          <div> <a href="https://subscribe.washingtonpost.com/acq/?promo=o12" target="_blank"> <span class="subscribe-link">Try 1 month for $1</span> </a> </div>
-          <div> <a data-link-ff="https://www.washingtonpost.com/steps-for-disabling-firefoxs-native-adblocker/2018/05/21/fb95bf4e-5d37-11e8-b2b8-08a538d9dbd6_story.html" data-link="https://www.washingtonpost.com/steps-for-disabling-adblocker/2016/09/14/a8c3d4d2-7aac-11e6-bd86-b7bbd53d2b5d_story.html" href="https://www.washingtonpost.com/steps-for-disabling-adblocker/2016/09/14/a8c3d4d2-7aac-11e6-bd86-b7bbd53d2b5d_story.html">Unblock ads</a> </div>
-          <div> <span>Questions about why you are seeing this?</span> <a href="https://helpcenter.washingtonpost.com/hc/en-us/requests/new?ticket_form_id=502668">Contact us</a> </div>
+          <div class="mt-md mt-lg-ns">
+            <div class="font--subhead hide-for-print kicker mb-xs " data-qa="kicker"><a
+                href="http://www.washingtonpost.com/news/the-intersect" class="font-bold link black hover-blue">Internet
+                Culture</a></div>
+          </div>
+          <div class="w-100">
+            <h1 class="
+        font--headline
+        gray-darkest
+        pb-sm
+        null
+      " data-qa="headline" id="main-content"><span data-qa="headline-opinion-text">Twitter says goodbye to all
+                ‘.@’</span></h1>
+          </div>
+        </header>
+        <article
+          class="grid-item grid-item--cols-sm-12 grid-item--cols-md-12 b-l br-l mb-xxl-ns mt-xxs mt-md-l grid-item--cols-lg-8 pr-lg-lg"
+          data-qa="main">
+          <div data-qa="lede-art">
+            <figure
+              class="center mb-md ml-neg-gutter mr-neg-gutter ml-auto-ns mr-auto-ns  overflow-hidden relative hide-for-print">
+              <div style="filter: blur(0px); transition: filter 0.1s ease 0s;" class="w-100 mw-100 h-auto" width="600"
+                height="395"><img
+                  style="background-size:cover;background-image:url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg'        xmlns%3Axlink='http%3A//www.w3.org/1999/xlink' viewBox='0 0 1280 853'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='.5'%3E%3C/feGaussianBlur%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1'%3E%3C/feFuncA%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Cimage filter='url(%23b)' x='0' y='0' height='100%25' width='100%25'         xlink%3Ahref='data%3Aimage/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAGCAIAAACepSOSAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAs0lEQVQI1wGoAFf/AImSoJSer5yjs52ktp2luJuluKOpuJefsoCNowB+kKaOm66grL+krsCnsMGrt8m1u8mzt8OVoLIAhJqzjZ2tnLLLnLHJp7fNmpyjqbPCqLrRjqO7AIeUn5ultaWtt56msaSnroZyY4mBgLq7wY6TmwCRfk2Pf1uzm2WulV+xmV6rmGyQfFm3nWSBcEIAfm46jX1FkH5Djn5AmodGo49MopBLlIRBfG8yj/dfjF5frTUAAAAASUVORK5CYII='%3E%3C/image%3E%3C/svg%3E')"
+                  alt="Image without a caption" class="w-100 mw-100 h-auto" width="600" height="395"
+                  srcset="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=440 400w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=540 540w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=691 691w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=767 767w,https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg&amp;w=916 916w"
+                  sizes="(max-width: 440px) 440px,(max-width: 600px) 691px,(max-width: 768px) 691px,(min-width: 769px) and (max-width: 1023px) 960px,(min-width: 1024px) and (max-width: 1299px) 530px,(min-width: 1300px) and (max-width: 1439px) 691px,(min-width: 1440px) 916px,440px"
+                  decoding="async"></div>
+              <figcaption
+                class="left ml-gutter mr-gutter mr-auto-ns ml-auto-ns gray-dark font--subhead font-xxxs mt-xs mb-sm"
+                aria-hidden="true">(Leon Neal/AFP/Getty Images) </figcaption>
+            </figure>
+          </div>
+          <div class="flex">
+            <div class="items-center">
+              <div class="byline flex mb-sm" data-qa="byline">
+                <div class="mr-sm"><a aria-label="Abby Ohlheiser"
+                    href="https://www.washingtonpost.com/people/abby-ohlheiser/">
+                    <div class="full-width center">
+                      <figure class="undefined overflow-hidden relative hide-for-print"><img width="55" height="55"
+                          src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png&amp;w=55&amp;h=55"
+                          class="author-image brad-50" alt="Image without a caption"></figure>
+                    </div>
+                  </a></div>
+                <div class="dib gray-dark font--subhead self-center author-text font-xxs">
+                  <div class="author-names"><span>By </span>
+                    <div class="relative dib">
+                      <div><span data-qa="author-name-wrapper"><a class="author-name-link link-hover-underline"
+                            href="https://www.washingtonpost.com/people/abby-ohlheiser/"><span
+                              class="author-name font-bold link blue hover-blue-hover">Abby Ohlheiser</span></a></span>
+                      </div>
+                      <div class="absolute bg-white brad-4 z-2 tooltip tooltip-bottom mt-sm dn hidden author-tooltip">
+                        <div class="absolute" style="background-color:transparent;top:-15px;left:0;right:0;height:15px">
+                        </div><svg
+                          class="content-box fill-white icon-close bg-gray dn-h pa-xxs brad-50 pointer fr absolute mr-xs right-0"
+                          width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"
+                          data-sc-v="4.13.3" data-sc-c="icon">
+                          <title data-sc-v="4.13.3" data-sc-c="icon">close</title>
+                          <path
+                            d="M8 6.586l4.293-4.293 1.414 1.414L9.414 8l4.293 4.293-1.414 1.414L8 9.414l-4.293 4.293-1.414-1.414L6.586 8 2.293 3.707l1.414-1.414L8 6.586z"
+                            fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                        </svg><a aria-label="Read more more stories from Abby Ohlheiser"
+                          href="https://www.washingtonpost.com/people/abby-ohlheiser/">
+                          <div class="full-width center">
+                            <figure class="undefined overflow-hidden relative hide-for-print"><img width="90"
+                                height="90"
+                                src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png&amp;w=90&amp;h=90"
+                                class="mb-xs brad-50" alt="Image without a caption"></figure>
+                          </div>
+                        </a>
+                        <div class="blue author-name font-bold"><a class="author-name-link link-hover-underline"
+                            href="https://www.washingtonpost.com/people/abby-ohlheiser/">Abby Ohlheiser</a></div>
+                        <div class="author-description gray mt-xxs">Reporter covering digital culture </div>
+                        <div class="b mt-sm"></div>
+                        <div class="social-links mt-sm black flex justify-between"><a
+                            href="mailto:abigail.ohlheiser@washpost.com?subject=Twitter says goodbye to all ‘.@’"
+                            class="email-link"><span
+                              class="pointer gray-darkest fill-gray-darkest hover-blue hover-fill-blue mr-sm flex items-center">Email<svg
+                                class="content-box fill-inherit ml-xxs" width="16" height="16" viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                                <title data-sc-v="4.13.3" data-sc-c="icon">Email</title>
+                                <path
+                                  d="M2.01 4.854l5.496 5.245a.51.51 0 0 0 .703-.012l5.725-5.446A.998.998 0 0 1 14 5v7a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V5c0-.05.004-.099.01-.146zm.666-.8A.999.999 0 0 1 3 4h10c.05 0 .098.004.146.01L7.88 9.02 2.676 4.054z"
+                                  fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                              </svg></span></a><a href="https://www.washingtonpost.com/people/abby-ohlheiser/"
+                            class="bio-link"><span
+                              class="pointer gray-darkest fill-gray-darkest hover-blue hover-fill-blue mr-sm flex items-center">Bio<svg
+                                class="content-box fill-inherit ml-xxs" width="16" height="16" viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                                <title data-sc-v="4.13.3" data-sc-c="icon">Bio</title>
+                                <path
+                                  d="M12.207 5.207L6.26 11.154 4.846 9.74l5.947-5.947L9 2h5v5l-1.793-1.793zM7 2v1H3v10h10V9h1v4a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1h4z"
+                                  fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                              </svg></span></a><a href="https://twitter.com/@abbyohlheiser" class="twitter-link"><span
+                              class="pointer gray-darkest fill-gray-darkest hover-blue hover-fill-blue flex items-center">Follow<svg
+                                class="content-box fill-inherit ml-xxs" width="16" height="16" viewBox="0 0 16 16"
+                                xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                                <title data-sc-v="4.13.3" data-sc-c="icon">Follow</title>
+                                <path
+                                  d="M5.403 13.671c5.283 0 8.172-4.413 8.172-8.241 0-.125 0-.25-.008-.374A5.872 5.872 0 0 0 15 3.556a5.695 5.695 0 0 1-1.65.456 2.902 2.902 0 0 0 1.263-1.602 5.727 5.727 0 0 1-1.824.703 2.858 2.858 0 0 0-4.064-.126 2.915 2.915 0 0 0-.83 2.768 8.132 8.132 0 0 1-5.92-3.027 2.913 2.913 0 0 0 .889 3.867 2.833 2.833 0 0 1-1.304-.363v.037c0 1.379.964 2.566 2.304 2.84a2.844 2.844 0 0 1-1.297.05 2.879 2.879 0 0 0 2.684 2.01A5.733 5.733 0 0 1 1 12.37a8.082 8.082 0 0 0 4.403 1.3"
+                                  fill-rule="evenodd" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                              </svg></span></a></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="pt-xxs pt-xs-ns author-role hide-for-print">Reporter</div>
+                </div>
+              </div>
+              <div class="mb-md gray-dark font--subhead font-xxs" data-qa="timestamp">
+                <div class="display-date ">May 24, 2016 at 8:20 p.m. GMT+2</div>
+              </div>
+            </div>
+          </div>
+          <div class="article-body">
+            <div class="teaser-content">
+              <section>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">Twitter announced a plan to
+                    make itself simpler Tuesday by, among other things, removing the need for a popular,
+                    improvised&nbsp;equivalent of a stage whisper. &nbsp;The&nbsp;changes are the latest iteration of
+                    the microblogging site’s attempts to make itself more appealing to new users. For instance, a few
+                    months ago, <a
+                      href="https://www.washingtonpost.com/news/the-intersect/wp/2015/11/03/twitter-just-eliminated-the-favorite-and-replaced-it-with-heart-shaped-likes/?itid=lk_inline_manual_2">it
+                      changed its “favorite” button</a>&nbsp;— a way to interact with a tweet without actually writing a
+                    reply — to the more universally understood “like” button.</p>
+                </div>
+              </section>
+            </div>
+            <div class="remainder-content">
+              <section>
+                <div>
+                  <div class="db dn-ns b bh bc-gray-lighter mb-md mr-neg-gutter ml-neg-gutter hide-for-print"
+                    data-qa="subscribe-promo"><a class="pt-sm pb-sm flex justify-center items-center bold font-xxxs"
+                      href="https://subscribe.washingtonpost.com/acquisition/?promo=o24_ma&amp;p=s_v&amp;s_l=ONSITE_ARTICLE_MODULE"
+                      target="_blank" rel="noreferrer noopener" style="border:none;color:#166dfc"><span
+                        class="mr-xs">Support our journalism. Subscribe today.</span><svg class="content-box" width="16"
+                        height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" style="fill:#166dfc"
+                        data-sc-v="4.13.3" data-sc-c="icon">
+                        <title data-sc-v="4.13.3" data-sc-c="icon">arrow-right</title>
+                        <path
+                          d="M7.664 1.25l6 6a1 1 0 010 1.414l-6 6L6.25 13.25 10.499 9H2V7h8.585L6.25 2.664 7.664 1.25z"
+                          fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+                      </svg></a></div>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">The company clearly believes
+                    that it needs to change some things to attract and keep new users, but doesn’t seem inclined to
+                    change anything so&nbsp;radically&nbsp;that it would upset loyalists enough for them to leave. That
+                    being said, pretty much any change to Twitter has the effect of upsetting its biggest fans<em> a
+                      little</em>: when “fav” became “like” last year, many hard-core users freaked out a bit, before
+                    adjusting to the fact that one of the site’s buttons had changed from a star to a heart and it was
+                    fine. A <a
+                      href="https://www.washingtonpost.com/news/the-intersect/wp/2016/01/06/twitters-rumored-character-limit-change-is-bad-news-for-artists-and-botmakers/?itid=lk_inline_manual_4">rumored
+                      plan to dramatically increase Twitter’s character limits</a>, however, crossed that line, and <a
+                      href="http://techcrunch.com/2016/03/18/jack-dorsey-140-characters/">Twitter’s chief
+                      executive&nbsp;Jack Dorsey eventually disavowed it</a>.</p>
+                </div>
+                <div>
+                  <p><span data-qa="interstitial-link-wrapper"
+                      class="font--body font-copy hide-for-print ma-0 pb-md db  italic interstitial"><a
+                        data-qa="interstitial-link"
+                        href="https://www.washingtonpost.com/news/the-switch/wp/2016/05/24/congrats-twitter-some-people-are-actually-happy-about-your-latest-changes/?itid=lk_interstitial_manual_5">Congrats,
+                        Twitter! Some people are actually happy about your latest changes.</a></span></p>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">While incremental, the newest
+                    round of changes — rolling out in the coming months, Twitter says — will eliminate some of the
+                    creative workarounds Twitter’s users have developed to get the most out of the 140-character limited
+                    platform. In other words, tweets will be longer, but not in the way that everyone feared. “You can
+                    already do a lot in a Tweet, but we want you to be able to do even more,” <a
+                      href="https://blog.twitter.com/express-even-more-in-140-characters">Twitter’s announcement
+                      reads</a>. My colleague&nbsp;Hayley Tsukayama<a
+                      href="https://www.washingtonpost.com/news/the-switch/wp/2016/05/24/congrats-twitter-some-people-are-actually-happy-about-your-latest-changes/?itid=lk_inline_manual_6">&nbsp;has
+                      a full-run down</a> of all the announced changes at The Switch.</p>
+                </div>
+                <div q8lxgi42l="" u963jxnj5="">
+                  <div class="relative cb bg-offwhite mt-xxs pt-md pb-md mb-lg ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns hide-for-print
+       dn db-ns" data-qa="article-body-ad" style="min-height:250px" q8lxgi42l="" u963jxnj5="">
+                    <div class="absolute z-0" aria-hidden="true" style="left:50%;top:50%">AD</div>
+                    <div class="z1 relative">
+                      <wp-ad id="slug_inline_bb" data-slot="/701/wpni.technology" aria-hidden="true"
+                        data-renderbehavior="lazy" data-refresh="true"
+                        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_inline_bb.init&quot;,&quot;pos&quot;:&quot;inline_bb&quot;,&quot;ctr&quot;:[&quot;zeus_c_inline_bb&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;inline_bb_0&quot;}}"
+                        style="margin: auto; width: 1px; display: block;"></wp-ad>
+                    </div>
+                  </div>
+                </div>
+                <div q8lxgi42l="" u963jxnj5="">
+                  <div class="relative cb bg-offwhite mt-xxs pt-md pb-md mb-lg ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns hide-for-print
+       db dn-ns" data-qa="article-body-ad" style="min-height:250px" q8lxgi42l="" u963jxnj5="">
+                    <div class="absolute z-0" aria-hidden="true" style="left:50%;top:50%">AD</div>
+                    <div class="z1 relative">
+                      <wp-ad id="slug_mob_bigbox" data-slot="/701/wpni.technology" aria-hidden="true"
+                        data-renderbehavior="never" data-refresh="true"
+                        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_mob_bigbox.init&quot;,&quot;pos&quot;:&quot;mob_bigbox&quot;,&quot;ctr&quot;:[&quot;zeus_c_mob_bigbox&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;mob_bigbox_0&quot;}}"
+                        style="margin: auto; width: 1px; display: none;"></wp-ad>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">A couple of tweaks to what
+                    “counts” towards Twitter’s short character&nbsp;limit will expand the length of tweets without going
+                    too crazy. Other announced changes will tweak the reach of some tweets. That includes one of the
+                    more interesting changes, which will largely eliminate the need for the “.@,” a weird, organic
+                    solution to&nbsp;one of Twitter’s quirks. Unfortunately, the change isn’t explained very
+                    clearly&nbsp;in Twitter’s announcement, so we’ve done our best to break down what will — and won’t —
+                    be changing below.</p>
+                </div>
+                <div>
+                  <div>
+                    <figure class="pt-xs mb-md ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns center hide-for-print">
+                      <div class="powa-wrapper"
+                        style="width:100%;height:0;background-size:100%;padding-bottom:56.25%;background-color:rgb(245, 245, 245);background-image:url(https://www.washingtonpost.com/player/prod/img/wp_grey.jpg)">
+                      </div>
+                      <figcaption
+                        class="mt-xs ml-gutter mr-gutter mr-auto-ns ml-auto-ns left gray-dark font--subhead font-xxxs"
+                        data-qa="video-caption">How twitter became a $25 billion start-up success story. (Erin Patrick
+                        O'Connor/The Washington Post)</figcaption>
+                    </figure>
+                  </div>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">See, Twitter doesn’t display
+                    every tweet of yours to all your followers. Anything that begins with an “@” is&nbsp;treated like a
+                    reply, and has a pretty limited reach. You’ll see @-beginning tweets only if both the person tagged
+                    and the person tweeting are people you follow. In recent years, Twitter has started to separate out
+                    “reply” tweets more and more. When several tweets written as replies to previous ones&nbsp;become a
+                    longer conversation, Twitter <a
+                      href="https://blog.twitter.com/2013/keep-up-with-conversations-on-twitter">bundles it for you</a>
+                    and shows it to you as a linked string of tweets.</p>
+                </div>
+                <div>
+                  <p><span data-qa="interstitial-link-wrapper"
+                      class="font--body font-copy hide-for-print ma-0 pb-md db  italic interstitial"><a
+                        data-qa="interstitial-link"
+                        href="https://www.washingtonpost.com/news/the-intersect/wp/2016/03/07/a-short-history-of/?tid=sm_tw&amp;itid=lk_interstitial_manual_12">The
+                        ‘@’ symbol was almost lost to history. Here’s how Ray Tomlinson saved it.</a></span></p>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">But not every tweet that
+                    begins with an “@” is actually a reply to another&nbsp;user. Sometimes the tweet is simply a
+                    sentence that begins with a reference to another user. Other times, it’s a stage whisper: The tweet
+                    is addressed to one person, but it’s meant for everyone to see. To get around the fact that Twitter
+                    automatically limits the reach of and “@”-leading tweets, even if they’re not actually meant as a
+                    reply to a previous tweet, many users put a single character, usually an “.” right at the beginning,
+                    to prevent Twitter from handling it like a reply. Celebrities do this a lot:</p>
+                </div>
+                <div q8lxgi42l="" u963jxnj5="">
+                  <div class="relative cb bg-offwhite mt-xxs pt-md pb-md mb-lg ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns hide-for-print
+       dn db-ns" data-qa="article-body-ad" style="min-height:250px" q8lxgi42l="" u963jxnj5="">
+                    <div class="absolute z-0" aria-hidden="true" style="left:50%;top:50%">AD</div>
+                    <div class="z1 relative">
+                      <wp-ad id="slug_inline_bb_2" data-slot="/701/wpni.technology" aria-hidden="true"
+                        data-renderbehavior="lazy" data-refresh="true"
+                        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_inline_bb_2.init&quot;,&quot;pos&quot;:&quot;inline_bb_2&quot;,&quot;ctr&quot;:[&quot;zeus_c_inline_bb_2&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;inline_bb_2_0&quot;}}"
+                        style="margin: auto; width: 1px; display: block;"></wp-ad>
+                    </div>
+                  </div>
+                </div>
+                <div q8lxgi42l="" u963jxnj5="">
+                  <div class="relative cb bg-offwhite mt-xxs pt-md pb-md mb-lg ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns hide-for-print
+       db dn-ns" data-qa="article-body-ad" style="min-height:250px" q8lxgi42l="" u963jxnj5="">
+                    <div class="absolute z-0" aria-hidden="true" style="left:50%;top:50%">AD</div>
+                    <div class="z1 relative">
+                      <wp-ad id="slug_mob_bigbox_2" data-slot="/701/wpni.technology" aria-hidden="true"
+                        data-renderbehavior="never" data-refresh="true"
+                        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_mob_bigbox_2.init&quot;,&quot;pos&quot;:&quot;mob_bigbox_2&quot;,&quot;ctr&quot;:[&quot;zeus_c_mob_bigbox_2&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;mob_bigbox_2_0&quot;}}"
+                        style="margin: auto; width: 1px; display: none;"></wp-ad>
+                    </div>
+                  </div>
+                </div>
+                <div></div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">But “.@” no more! Twitter will
+                    now automatically show those stage whisper tweets to all your followers — so long as it’s not
+                    tweeted in&nbsp;reply to something else. Those actual replies&nbsp;will remain limited in reach, in
+                    the same way they are now.&nbsp;But Twitter has a way to make sure you can force all your followers
+                    to see your witty comeback, should you wish to do that.</p>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">Introducing the self-retweet,
+                    or a new thing Twitter is allowing its users to do to draw attention to their own tweets and
+                    replies. Once Twitter enables the retweet function for all users to use on their own
+                    tweets,&nbsp;Twitter says, “you&nbsp;can easily Retweet or Quote Tweet yourself when you want to
+                    share a new reflection or feel like a really good one went unnoticed,” Twitter’s announcement
+                    explains.</p>
+                </div>
+                <div>
+                  <p><span data-qa="interstitial-link-wrapper"
+                      class="font--body font-copy hide-for-print ma-0 pb-md db  italic interstitial"><a
+                        data-qa="interstitial-link"
+                        href="https://www.washingtonpost.com/news/the-intersect/wp/2016/03/21/the-surprising-truth-about-how-twitter-has-changed-your-brain/?itid=lk_interstitial_manual_19">The
+                        surprising truth about how Twitter has changed your brain</a></span></p>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">Like that “.@” elimination,
+                    the self-retweet isn’t the result of a totally new invention. It’s already possible to place a link
+                    to your own tweet in a new one. Some users have taken to replying to their own tweets over the
+                    course of many days to revive the entire thread for their followers as a bundled conversation. And
+                    there’s always the manual retweet, although these days that’s considered to be <a
+                      href="https://www.buzzfeed.com/katienotopoulos/the-latest-twitter-trend-manual-retweet-shaming?utm_term=.bwLLgPqPN#.brpJYeNeA">a
+                      very bad thing to do on Twitter</a>. The self-retweet change simply makes it easier to do
+                    something its users were doing already.</p>
+                </div>
+                <div q8lxgi42l="" u963jxnj5="">
+                  <div class="relative cb bg-offwhite mt-xxs pt-md pb-md mb-lg ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns hide-for-print
+       dn db-ns" data-qa="article-body-ad" style="min-height:250px" q8lxgi42l="" u963jxnj5="">
+                    <div class="absolute z-0" aria-hidden="true" style="left:50%;top:50%">AD</div>
+                    <div class="z1 relative">
+                      <wp-ad id="slug_inline_bb_3" data-slot="/701/wpni.technology" aria-hidden="true"
+                        data-renderbehavior="lazy" data-refresh="true"
+                        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_inline_bb_3.init&quot;,&quot;pos&quot;:&quot;inline_bb_3&quot;,&quot;ctr&quot;:[&quot;zeus_c_inline_bb_3&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;inline_bb_3_0&quot;}}"
+                        style="margin: auto; width: 1px; display: block;"></wp-ad>
+                    </div>
+                  </div>
+                </div>
+                <div q8lxgi42l="" u963jxnj5="">
+                  <div class="relative cb bg-offwhite mt-xxs pt-md pb-md mb-lg ml-neg-gutter mr-neg-gutter mr-auto-ns ml-auto-ns hide-for-print
+       db dn-ns" data-qa="article-body-ad" style="min-height:250px" q8lxgi42l="" u963jxnj5="">
+                    <div class="absolute z-0" aria-hidden="true" style="left:50%;top:50%">AD</div>
+                    <div class="z1 relative">
+                      <wp-ad id="slug_mob_bigbox_3" data-slot="/701/wpni.technology" aria-hidden="true"
+                        data-renderbehavior="never" data-refresh="true"
+                        data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_mob_bigbox_3.init&quot;,&quot;pos&quot;:&quot;mob_bigbox_3&quot;,&quot;ctr&quot;:[&quot;zeus_c_mob_bigbox_3&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;mob_bigbox_3_0&quot;}}"
+                        style="margin: auto; width: 1px; display: none;"></wp-ad>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">Will hard-core users still
+                    “.@” for old time’s sake? probably, for a little bit. But longtime users are used to adapting to
+                    Twitter’s attempts to absorb the organic, creative workarounds to&nbsp;the platform’s limitations in
+                    the past. Twitter didn’t always allow users to post photos, so someone made TwitPic. Twitter then
+                    made the service irrelevant in 2011, when it <a
+                      href="https://blog.twitter.com/2011/searchphotos">announced a new capacity</a> to host photo and
+                    video itself. Twitter didn’t always automatically shorten URLs, so users used link shorteners to
+                    minimize the number of characters a link ate up. Now, Twitter <a
+                      href="https://twitter.com/twitter/status/735153337746653184">won’t count media
+                      attachments</a>&nbsp;towards the character limit.</p>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md ">Since the changes haven’t even
+                    rolled out yet, it’s&nbsp;too early to bury the “.@” next to the manual retweet in the graveyard of
+                    obsolete Twitter conventions. But it’s&nbsp;not long for this world.</p>
+                </div>
+                <div>
+                  <p data-el="text" class="font--body font-copy gray-darkest ma-0 pb-md "><strong>Liked that? try
+                      these:</strong></p>
+                </div>
+                <div>
+                  <ul class="font--body font-copy gray-darkest mt-0 mr-lg ml-lg mb-md list">
+                    <li class="pb-xs"><span><strong><a
+                            href="https://www.washingtonpost.com/news/the-intersect/wp/2016/05/03/the-pre-twitter-history-of-twitters-favorite-insult/?itid=lk_inline_manual_26">The
+                            pre-Twitter history of Twitter’s favorite insult&nbsp;</a></strong></span></li>
+                    <li class="pb-xs"><span><strong><a
+                            href="https://www.washingtonpost.com/news/the-intersect/wp/2016/02/11/the-internets-top-dog-rater-keeps-disappearing-from-twitter/?itid=lk_inline_manual_27">The
+                            Internet’s most famous dog rater keeps disappearing from Twitter</a></strong></span></li>
+                    <li class="pb-xs"><span><strong><a
+                            href="https://www.washingtonpost.com/news/the-intersect/wp/2014/05/23/what-happens-when-everyword-ends/?itid=lk_inline_manual_28">A
+                            eulogy for @everyword</a></strong></span></li>
+                  </ul>
+                </div>
+              </section>
+            </div>
+          </div>
+          <div></div>
+          <div style="min-height:595px" class="hide-for-print " data-qa="more-from-the-post">
+            <div></div>
+          </div>
+          <section class="b bt dn-ns pt-lgmod hide-for-print" subscriptions-section="content">
+            <div></div>
+          </section>
+          <div class="b bh mb-lg-mod">
+            <div class="hide-for-print relative " data-qa="newsletter" aria-hidden="false">
+              <div></div>
+              <div class="newsletter-form">
+                <h3 class="font--headline font-md pt-lgmod center left-ns">Today’s Headlines</h3>
+                <p class="gray-dark font--meta-text mt-xs mb-sm center left-ns">The most important news stories of the
+                  day, curated by Post editors and delivered every morning.</p>
+                <form><label for="signup-email" class="db mb-xxs font--subhead font-xxxs gray-dark"></label>
+                  <div class="relative flex items-center mb-xs mt-xs"><input type="text" id="signup-email"
+                      name="signup-email" aria-label="Enter your email address"
+                      class="pl-sm pr-sm font--subhead w-100 font-xxs form-input light brad-2 b form-input-valid inset-shadow bg-white gray-darkest"
+                      value="" placeholder="Enter your email address"></div><input type="submit"
+                    class="btn btn-blue db dib-ns w-100 w-auto-ns pl-lg pr-lg" value="Sign up">
+                </form>
+                <p class="gray font--meta-text font-xxxxs mt-xxs pb-lgmod">By signing up you agree to our
+                  <!-- --> <a href="https://www.washingtonpost.com/terms-of-service/2011/11/18/gIQAldiYiN_story.html"
+                    class="gray underline hover-inherit">Terms of Use</a> <!-- -->and
+                  <!-- --> <a href="https://www.washingtonpost.com/privacy-policy/2011/11/18/gIQASIiaiN_story.html"
+                    class="gray underline hover-inherit">Privacy&nbsp;Policy</a>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="outbrain-wrapper b-ns bb pb-lgmod mb-lg-mod hide-for-print" data-qa="outbrain" aria-hidden="true"
+            style="min-height: 650px;">
+            <div></div>
+          </div>
+        </article>
+        <aside
+          class="grid-item grid-item--cols-sm-12 grid-item--cols-md-12 mt-md-l grid-item--cols-lg-4 hide-for-print flex flex-column right-rail">
+          <div class="dn db-l pb-lgmod mb-lg-mod b bb" style="min-height:1050px">
+            <div class="dn db-ns sticky" style="top: 65px;">
+              <div class="">
+                <wp-ad class="hide-for-print  hide-for-print" id="slug_flex_ss_bb_hp" data-slot="/701/wpni.technology"
+                  aria-hidden="true" data-renderbehavior="lazy" data-refresh="true"
+                  data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_flex_ss_bb_hp.init&quot;,&quot;pos&quot;:&quot;flex_ss_bb_hp&quot;,&quot;ctr&quot;:[&quot;zeus_c_flex_ss_bb_hp&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;flex_ss_bb_hp_0&quot;}}"
+                  style="margin: auto; width: 1px; display: block;"></wp-ad>
+              </div>
+            </div>
+          </div>
+          <div class="dn db-ns b bb mb-lg-mod">
+            <div class="headline-list hide-for-print w-100 pb-sm">
+              <div class="font--subhead font-sm bold gray-darkest" data-qa="headline-list-title">Most Read<a
+                  class="ml-xxs blue" href="/technology/internet-culture/">Technology</a></div>
+              <ul class="list-unstyled mt-xs" data-cy="most-read-headline-list">
+                <li class="cb flex pt-sm pb-sm  flex-column"><a aria-hidden="true" data-qa="featured-link"
+                    class="relative w-100 db mb-sm" style="padding-top: 66.5217%;">
+                    <div style="position: absolute; top: 0px; left: 0px;">
+                      <div data-qa="fade-in-image"
+                        style="opacity: 1; transition: opacity 500ms ease-in-out 0s; height: auto;">
+                        <figure class=" overflow-hidden relative hide-for-print"><img width="600" height="399"
+                            src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/6EJGCQDBTUI6XILXO5S7FGUVEQ.jpg&amp;w=600&amp;h=399"
+                            class="mw-100 h-auto" alt="Image without a caption"></figure>
+                      </div>
+                    </div>
+                  </a>
+                  <div class="flex">
+                    <div data-qa="headline-number" class=" font-lg dib mr-sm b bb bc-secondary font--headline"
+                      style="max-height: 1.25em;">1</div>
+                    <div class="w-100 clearfix"><a
+                        href="https://www.washingtonpost.com/technology/2021/03/04/google-hbcu-recruiting/?itid=mr_technology_1"
+                        data-qa="headline-text">
+                        <h2 class="gray-darkest hover-blue font--headline font-sm">Google’s approach to historically
+                          Black schools helps explain why there are few Black engineers in Big Tech</h2>
+                      </a></div>
+                  </div>
+                </li>
+                <li class="cb flex pt-sm pb-sm b bt flex-column">
+                  <div class="flex">
+                    <div data-qa="headline-number" class=" gray-darkest bold font--headline font-md mr-sm">2</div>
+                    <div class="w-100 clearfix"><a
+                        href="https://www.washingtonpost.com/technology/2021/03/01/computer-chip-shortage-explainer-qa/?itid=mr_technology_2"
+                        aria-hidden="true" data-qa="nonfeatured-link" class="bg-gray-lightest dib fr ml-sm "
+                        style="width: 90px; height: 60px;">
+                        <div data-qa="fade-in-image" style="opacity: 1; transition: opacity 500ms ease-in-out 0s;">
+                          <figure class=" overflow-hidden relative hide-for-print"><img width="90" height="60"
+                              src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/GL4RI7TQPII6XBSRNUYJD2WGH4.jpg&amp;w=90&amp;h=60"
+                              class="mw-100" alt="Image without a caption"></figure>
+                        </div>
+                      </a><a
+                        href="https://www.washingtonpost.com/technology/2021/03/01/computer-chip-shortage-explainer-qa/?itid=mr_technology_2"
+                        data-qa="headline-text">
+                        <h2 class="gray-darkest hover-blue font--meta-text font-xxs light w-66">What you need to know
+                          about the global chip shortage</h2>
+                      </a></div>
+                  </div>
+                </li>
+                <li class="cb flex pt-sm pb-sm b bt flex-column">
+                  <div class="flex">
+                    <div data-qa="headline-number" class=" gray-darkest bold font--headline font-md mr-sm">3</div>
+                    <div class="w-100 clearfix"><a
+                        href="https://www.washingtonpost.com/technology/2021/03/05/screen-time-one-year-kids/?itid=mr_technology_3"
+                        aria-hidden="true" data-qa="nonfeatured-link" class="bg-gray-lightest dib fr ml-sm "
+                        style="width: 90px; height: 60px;">
+                        <div data-qa="fade-in-image" style="opacity: 1; transition: opacity 500ms ease-in-out 0s;">
+                          <figure class=" overflow-hidden relative hide-for-print"><img width="90" height="60"
+                              src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/4YQMQQT4MYI6XDC6GLSHWQVVDM.jpg&amp;w=90&amp;h=60"
+                              class="mw-100" alt="Image without a caption"></figure>
+                        </div>
+                      </a><a
+                        href="https://www.washingtonpost.com/technology/2021/03/05/screen-time-one-year-kids/?itid=mr_technology_3"
+                        data-qa="headline-text">
+                        <h2 class="gray-darkest hover-blue font--meta-text font-xxs light w-66">Growing up on screens:
+                          How a year lived online has changed our children</h2>
+                      </a></div>
+                  </div>
+                </li>
+                <li class="cb flex pt-sm pb-sm b bt flex-column">
+                  <div class="flex">
+                    <div data-qa="headline-number" class=" gray-darkest bold font--headline font-md mr-sm">4</div>
+                    <div class="w-100 clearfix"><a
+                        href="https://www.washingtonpost.com/technology/2021/03/05/fever-scanner-flaws-covid/?itid=mr_technology_4"
+                        aria-hidden="true" data-qa="nonfeatured-link" class="bg-gray-lightest dib fr ml-sm "
+                        style="width: 90px; height: 60px;">
+                        <div data-qa="fade-in-image" style="opacity: 1; transition: opacity 500ms ease-in-out 0s;">
+                          <figure class=" overflow-hidden relative hide-for-print"><img width="90" height="60"
+                              src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/JGDBUDELI4I6VAG72JFTLJLIVY.jpg&amp;w=90&amp;h=60"
+                              class="mw-100" alt="Image without a caption"></figure>
+                        </div>
+                      </a><a
+                        href="https://www.washingtonpost.com/technology/2021/03/05/fever-scanner-flaws-covid/?itid=mr_technology_4"
+                        data-qa="headline-text">
+                        <h2 class="gray-darkest hover-blue font--meta-text font-xxs light w-66">Those fever scanners
+                          that everyone is using to fight covid can be wildly inaccurate, researchers find</h2>
+                      </a></div>
+                  </div>
+                </li>
+                <li class="cb flex pt-sm pb-sm b bt flex-column">
+                  <div class="flex">
+                    <div data-qa="headline-number" class=" gray-darkest bold font--headline font-md mr-sm">5</div>
+                    <div class="w-100 clearfix"><a
+                        href="https://www.washingtonpost.com/technology/2021/03/05/fever-scanner-certify-fda/?itid=mr_technology_5"
+                        aria-hidden="true" data-qa="nonfeatured-link" class="bg-gray-lightest dib fr ml-sm "
+                        style="width: 90px; height: 60px;">
+                        <div data-qa="fade-in-image" style="opacity: 1; transition: opacity 500ms ease-in-out 0s;">
+                          <figure class=" overflow-hidden relative hide-for-print"><img width="90" height="60"
+                              src="https://www.washingtonpost.com/wp-apps/imrs.php?src=https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/73NTA3FW7YI6VGQ52PNRZPQHZY.jpg&amp;w=90&amp;h=60"
+                              class="mw-100" alt="Image without a caption"></figure>
+                        </div>
+                      </a><a
+                        href="https://www.washingtonpost.com/technology/2021/03/05/fever-scanner-certify-fda/?itid=mr_technology_5"
+                        data-qa="headline-text">
+                        <h2 class="gray-darkest hover-blue font--meta-text font-xxs light w-66">Fever-scanner company
+                          pulls device off market following FDA warning</h2>
+                      </a></div>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="dn db-l pb-lgmod mb-lg-mod b bb" style="min-height:1050px">
+            <div class="">
+              <wp-ad class="hide-for-print  hide-for-print" id="slug_flex_ss_bb_hp_2" data-slot="/701/wpni.technology"
+                aria-hidden="true" data-renderbehavior="lazy" data-refresh="true"
+                data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_flex_ss_bb_hp_2.init&quot;,&quot;pos&quot;:&quot;flex_ss_bb_hp_2&quot;,&quot;ctr&quot;:[&quot;zeus_c_flex_ss_bb_hp_2&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;flex_ss_bb_hp_2_0&quot;}}"
+                style="margin: auto; width: 1px; display: block;"></wp-ad>
+            </div>
+          </div>
+          <div class="b bb mb-lg-mod">
+            <div class="hide-for-print relative dn db-l" data-qa="newsletter" aria-hidden="true">
+              <div>
+                <h3 class="font--subhead font-sm false center left-ns">Today’s Headlines</h3>
+                <p class="gray-dark font--meta-text mt-xs mb-sm center left-ns">The most important news stories of the
+                  day, curated by Post editors and delivered every morning.</p>
+                <form><label for="signup-email-rr" class="db mb-xxs font--subhead font-xxxs gray-dark"></label>
+                  <div class="relative flex items-center mb-xs mt-xs"><input type="text" id="signup-email-rr"
+                      name="signup-email-rr" aria-label="Enter your email address"
+                      class="pl-sm pr-sm font--subhead w-100 font-xxs form-input light brad-2 b form-input-valid inset-shadow bg-white gray-darkest"
+                      value="" placeholder="Enter your email address"></div><input type="submit"
+                    class="btn btn-blue db dib-ns w-100 w-auto-ns pl-lg pr-lg" value="Sign up">
+                </form>
+                <p class="gray font--meta-text font-xxxxs mt-xxs pb-lgmod">By signing up you agree to our
+                  <!-- --> <a href="https://www.washingtonpost.com/terms-of-service/2011/11/18/gIQAldiYiN_story.html"
+                    class="gray underline hover-inherit">Terms of Use</a> <!-- -->and
+                  <!-- --> <a href="https://www.washingtonpost.com/privacy-policy/2011/11/18/gIQASIiaiN_story.html"
+                    class="gray underline hover-inherit">Privacy&nbsp;Policy</a>
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="dn db-l pb-lgmod mb-lg-mod b bb" style="min-height:1050px">
+            <div class="">
+              <wp-ad class="hide-for-print  hide-for-print" id="slug_flex_ss_bb_hp_4" data-slot="/701/wpni.technology"
+                aria-hidden="true" data-renderbehavior="lazy" data-refresh="true"
+                data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_flex_ss_bb_hp_4.init&quot;,&quot;pos&quot;:&quot;flex_ss_bb_hp_4&quot;,&quot;ctr&quot;:[&quot;zeus_c_flex_ss_bb_hp_4&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;flex_ss_bb_hp_4_0&quot;}}"
+                style="margin: auto; width: 1px; display: block;"></wp-ad>
+            </div>
+          </div>
+          <div class="podcast-promo-rr pb-lgmod b bb mb-lg-mod dn db-l font-xxs bold hide-for-print">
+            <div class="font--subhead font-xxxs flex mb-xs"><svg class="content-box fill-gray-darkest mr-xs" width="16"
+                height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" data-sc-v="4.13.3" data-sc-c="icon">
+                <title data-sc-v="4.13.3" data-sc-c="icon">headphones</title>
+                <path
+                  d="M8 2a6 6 0 0 1 6 6v4c0 1.55-1.37 2.75-3 2.75a1 1 0 0 1-1-1v-3.5a1 1 0 0 1 1.034-1l.19.008A3.14 3.14 0 0 1 13 9.949L13 8A5 5 0 0 0 3 8v1.948a3.163 3.163 0 0 1 2-.698 1 1 0 0 1 1 1v3.5a1 1 0 0 1-1.034 1l-.19-.008C3.24 14.64 2 13.472 2 12V8a6 6 0 0 1 6-6z"
+                  fill-rule="nonzero" data-sc-v="4.13.3" data-sc-c="icon"></path>
+              </svg><a class="internal gray-darkest hover-blue lh-initial"
+                href="https://www.washingtonpost.com/podcasts/?itid=aud_rr_postreportslnch">Podcast</a></div><a
+              href="https://www.washingtonpost.com/podcasts/post-reports/?itid=aud_rr_postreportslnch" class="internal">
+              <div class="font--subhead font-sm gray-darkest hover-blue">Post Reports</div>
+            </a>
+            <div class="cb overflow-hidden"><a
+                href="https://www.washingtonpost.com/podcasts/post-reports/?itid=aud_rr_postreportslnch"
+                class="ml-sm fr internal"><img
+                  src="/dr/resources/images/post-reports-circular.png?d=622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba"
+                  width="88" height="88" alt="Promo Image"></a>
+              <div class="font--meta-text light gray-dark mt-xs">The Washington Post's daily podcast: unparalleled
+                reports, expert insight, clear analysis. For your ears.</div>
+              <div class="font--subhead mt-xs gray-dark">Add to <a class="apple gray-darkest hover-blue"
+                  href="https://itunes.apple.com/us/podcast/id1444873564?mt=2&amp;at=1001lvyS&amp;ct=articlerr">Apple
+                  Podcasts</a><span class="">, </span><a class="google gray-darkest hover-blue"
+                  href="https://www.google.com/podcasts?feed=aHR0cHM6Ly9wb2RjYXN0LnBvc3R0di5jb20vaXR1bmVzL3Bvc3QtcmVwb3J0cy54bWw">Google
+                  Podcasts</a></div>
+            </div>
+          </div>
+          <div class="dn db-l pb-lgmod mb-lg-mod " style="min-height:1050px;flex:1">
+            <div class="dn db-ns sticky" style="top: 65px;">
+              <div class="">
+                <wp-ad class="hide-for-print  hide-for-print" id="slug_flex_ss_bb_hp_3" data-slot="/701/wpni.technology"
+                  aria-hidden="true" data-renderbehavior="lazy" data-refresh="true"
+                  data-json="{&quot;targeting&quot;:{&quot;zeus_slot&quot;:&quot;slug_flex_ss_bb_hp_3.init&quot;,&quot;pos&quot;:&quot;flex_ss_bb_hp_3&quot;,&quot;ctr&quot;:[&quot;zeus_c_flex_ss_bb_hp_3&quot;],&quot;wp_ad_refresh&quot;:&quot;0&quot;,&quot;wp_refresh&quot;:&quot;flex_ss_bb_hp_3_0&quot;}}"
+                  style="margin: auto; width: 1px; display: block;"></wp-ad>
+              </div>
+            </div>
+          </div>
+        </aside>
+      </main>
+      <div class="hide-for-print w-100 pb-xl">
+        <div class="dn db-ns" data-sc-v="4.13.3" data-sc-c="desktopfooter">
+          <footer class="mw-grid border-box grid w-100 pl-vw-sm pr-vw-sm gap-x-0 grid-cols-12 mr-auto ml-auto">
+            <div class="mw-100 border-box b bt col-span-12-md col-span-12-lg"></div>
+            <div class="mw-100 border-box  col-span-3-md col-span-3-lg" data-qa="footer-section">
+              <div data-qa="footer-section-title"
+                class="font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest font-bold mt-md" data-sc-v="4.13.3"
+                data-sc-c="footersection">About Us</div>
+              <ul class="list-none pa-0 ml-0 mt-0 mb-md mr-0" data-qa="footer-section-list" data-sc-v="4.13.3"
+                data-sc-c="footersection">
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/public-relations/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Public Relations</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://careers.washingtonpost.com/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Careers</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/pr/2020/07/30/washington-posts-2020-workforce-demographics-report/?arc404=true"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Diversity &amp; Inclusion</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://nie.washingtonpost.com"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Newspaper in Education</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/todays_paper/updates"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Today's Paper</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/brand-studio/archive/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">WP BrandStudio</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/washington-post-live/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Events</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/policies-and-standards/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Policies &amp; Standards</a></li>
+              </ul>
+            </div>
+            <div class="mw-100 border-box  col-span-3-md col-span-3-lg" data-qa="footer-section">
+              <div data-qa="footer-section-title"
+                class="font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest font-bold mt-md" data-sc-v="4.13.3"
+                data-sc-c="footersection">Get The Post</div>
+              <ul class="list-none pa-0 ml-0 mt-0 mb-md mr-0" data-qa="footer-section-list" data-sc-v="4.13.3"
+                data-sc-c="footersection">
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://subscribe.washingtonpost.com/acquisition/?oscode=RPW5&amp;tid=s_005&amp;itid=s_005&amp;promo=o18&amp;s_l=ONSITE_FOOTER_HOME&amp;p=s_v"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Home Delivery</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://subscribe.washingtonpost.com/acquisition/?&amp;tid=s_006&amp;itid=s_006&amp;promo=o6&amp;s_l=ONSITE_FOOTER_DIGITAL&amp;p=s_v"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Digital Subscription</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://subscribe.washingtonpost.com/gift?promo=g_d&amp;s_l=ONSITE_FOOTER_GIFT&amp;p=s_v"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Gift Subscriptions</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/mobile/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Mobile &amp; Apps</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://subscribe.washingtonpost.com/newsletters"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Newsletters &amp; Alerts</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/washington-post-live/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Washington Post Live</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/reprints-permissions/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Reprints &amp; Permissions</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://store.washingtonpost.com/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Post Store</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/photos-books/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Books &amp; eBooks</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/subscribe/signin/?case=ereplica"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">e-Replica</a></li>
+              </ul>
+            </div>
+            <div class="mw-100 border-box  col-span-3-md col-span-3-lg" data-qa="footer-section">
+              <div data-qa="footer-section-title"
+                class="font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest font-bold mt-md" data-sc-v="4.13.3"
+                data-sc-c="footersection">Help</div>
+              <ul class="list-none pa-0 ml-0 mt-0 mb-md mr-0" data-qa="footer-section-list" data-sc-v="4.13.3"
+                data-sc-c="footersection">
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://helpcenter.washingtonpost.com/hc/en-us/articles/360002940991-Leadership-of-The-Washington-Post-newsroom"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Contact the Newsroom</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://helpcenter.washingtonpost.com/hc/en-us"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Contact Customer Care</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="mailto:readers@washpost.com"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Reader Representative</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/mediakit/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Advertise</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/syndication/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Licensing &amp; Syndication</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://helpcenter.washingtonpost.com/hc/en-us/articles/115003675928-Submit-a-correction"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Request a Correction</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="https://www.washingtonpost.com/anonymous-news-tips/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Send a News Tip</a></li>
+              </ul>
+            </div>
+            <div class="mw-100 border-box  col-span-3-md col-span-3-lg" data-qa="footer-section">
+              <div data-qa="footer-section-title"
+                class="font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest font-bold mt-md" data-sc-v="4.13.3"
+                data-sc-c="footersection">Terms of Use</div>
+              <ul class="list-none pa-0 ml-0 mt-0 mb-md mr-0" data-qa="footer-section-list" data-sc-v="4.13.3"
+                data-sc-c="footersection">
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/terms-of-sale-for-digital-products/2014/05/06/b7763844-cbf9-11e3-93eb-6c0037dde2ad_story.html"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Digital Products Terms of Sale</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/terms-of-sale-for-print-products/2014/05/08/d60c4bc8-d6c0-11e3-aae8-c2d44bd79778_story.html"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Print Products Terms of Sale</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/terms-of-service/2011/11/18/gIQAldiYiN_story.html"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Terms of Service</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/privacy-policy/2011/11/18/gIQASIiaiN_story.html"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Privacy Policy</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/news/ask-the-post/discussion-and-submission-guidelines/"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Submissions &amp; Discussion Policy</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/rss-terms-of-service/2012/01/16/gIQAadFYAQ_story.html"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">RSS Terms of Service</a></li>
+                <li data-qa="footer-section-link" data-sc-v="4.13.3" data-sc-c="desktopfooterlink"><a
+                    href="/how-can-i-opt-out-of-online-advertising-cookies/2011/11/18/gIQABECbiN_story.html"
+                    class="hover-blue font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest" data-sc-v="4.13.3"
+                    data-sc-c="footerlink">Ad Choices</a></li>
+              </ul>
+            </div>
+            <div class="mw-100 border-box b bt mt-sm col-span-12-md col-span-12-lg">
+              <div
+                class="mw-100 border-box mt-sm center font--subhead lh-default font-xxxxs font-xxxs-l gray-darkest col-end-3-md col-end-3-lg"
+                data-qa="desktop-copyright"><a href="https://www.washingtonpost.com" class="hover-blue gray-darkest"
+                  data-qa="desktop-footer-site-link" data-sc-v="4.13.3" data-sc-c="footerlink">washingtonpost.com</a> ©
+                1996-2021 The Washington Post</div>
+            </div>
+          </footer>
+        </div>
+        <div class="dn-ns" data-sc-v="4.13.3" data-sc-c="footer">
+          <footer class="b bt pt-sm" data-sc-v="4.13.3" data-sc-c="mobilefooter">
+            <div class="mw-grid border-box grid w-100 pl-vw-sm pr-vw-sm gap-x-0 grid-cols-12 mr-auto ml-auto">
+              <div class="mw-100 border-box  col-span-12 col-span-12-md">
+                <ul class="list-none pa-0 ml-0 mt-md mr-0 mb-md" data-sc-v="4.13.3" data-sc-c="mobilefooter">
+                  <li data-sc-v="4.13.3" data-sc-c="_ref2"><a href="https://www.washingtonpost.com"
+                      class="hover-blue font--subhead lh-default font-xxxs gray-darkest font-bold" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">washingtonpost.com</a></li>
+                  <li data-qa="mobile-copyright" class="mb-sm font--subhead lh-default font-xxxs gray-darkest"
+                    data-sc-v="4.13.3" data-sc-c="_ref3">© 1996-2021 The Washington Post</li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="https://helpcenter.washingtonpost.com/hc/en-us/articles/360002940991-Leadership-of-The-Washington-Post-newsroom"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Contact the Newsroom</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="https://helpcenter.washingtonpost.com/hc/en-us"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Contact Customer Care</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="https://helpcenter.washingtonpost.com/hc/en-us/articles/115003675928-Submit-a-correction"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Request a Correction</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="https://www.washingtonpost.com/anonymous-news-tips/"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Send a News Tip</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a href="https://wapo.onelink.me/e76N/8081805d"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Download the Washington Post App</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a href="/policies-and-standards/"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Policies &amp; Standards</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/terms-of-service/2011/11/18/gIQAldiYiN_story.html"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Terms of Service</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/privacy-policy/2011/11/18/gIQASIiaiN_story.html"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Privacy Policy</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/terms-of-sale-for-print-products/2014/05/08/d60c4bc8-d6c0-11e3-aae8-c2d44bd79778_story.html"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Print Products Terms of Sale</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/terms-of-sale-for-digital-products/2014/05/06/b7763844-cbf9-11e3-93eb-6c0037dde2ad_story.html"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Digital Products Terms of Sale</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/news/ask-the-post/discussion-and-submission-guidelines/"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Submissions &amp; Discussion Policy</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/rss-terms-of-service/2012/01/16/gIQAadFYAQ_story.html"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">RSS Terms of Service</a></li>
+                  <li data-sc-v="4.13.3" data-sc-c="mobilefooter"><a
+                      href="/how-can-i-opt-out-of-online-advertising-cookies/2011/11/18/gIQABECbiN_story.html"
+                      class="hover-blue font--subhead font-xxxs gray-darkest" data-sc-v="4.13.3"
+                      data-sc-c="footerlink">Ad Choices</a></li>
+                </ul>
+              </div>
+            </div>
+          </footer>
         </div>
       </div>
     </div>
-    <script>
-      var a = ["We noticed you\u2019re blocking ads.", "Keep supporting great journalism by turning off your ad blocker. Or purchase a subscription for unlimited access to real news you can count on.", "unblock", "event 86", "safari", "cookie", "match", "featureConfig", "pb-core-loaded", "condition_isPM", "Chrome", "Safari", "bar.test", "testValue", "Firefox", "2x1", "https://pubads.g.doubleclick.net/gampad/adx?iu\x3d", "\x26sz\x3d", "\x26c\x3d", "\x26tile\x3d1\x26u_tz\x3d", "https://d2ty8gaf6rmowa.cloudfront.net/ad/ads.js",
-        "TWP.abchecker", "blocked", "GET", "limitContent", "article \x3e *", "...", "#nav-bar", "none", ".pb-f-article-article-body", "wp-ad", "displayOverlay", "div \x3e div div:nth-child(2) h3", "div \x3e div div:nth-child(4)", "data-link-ff", "href", "block", "#main-navigation-left.nav-item", "#main-navigation-right.nav-item", "html", "hidden", "initFeature", "pb-adblock-checked", "chrome", "firefox", "default-article", "undefined", "condition_", "init", "browsers", "isAnon", "isSubscriber", "headline", "We noticed you\u2019re browsing in private mode.",
-        "subhead", '\x3ca data-link-ff\x3d"https://helpcenter.washingtonpost.com/hc/en-us/articles/360028029392l" data-link\x3d"https://helpcenter.washingtonpost.com/hc/en-us/articles/360028029392" href\x3d"https://helpcenter.washingtonpost.com/hc/en-us/articles/360028029392"\x3eTurn off private browsing\x3c/a\x3e', "cta", '\x3ca href\x3d"https://subscribe.washingtonpost.com/acq/?promo\x3do22" target\x3d"_blank"\x3e\x3cspan class\x3d"subscribe-link"\x3eTry 1 month for $1\x3c/span\x3e\x3c/a\x3e', "ctaPromo", "o22",
-        "signinLink", '\x3ca  href\x3d"https://www.washingtonpost.com/subscribe/signin/?next_url\x3d"\x3eSubscriber sign in\x3c/a\x3e', "modalEvent", "event 100", "mobile", "isLogged"
-      ];
-      (function(c, d) {
-        var e = function(f) {
-          while (--f) c["push"](c["shift"]())
-        };
-        e(++d)
-      })(a, 269);
-      var b = function(c, d) {
-        c = c - 0;
-        var e = a[c];
-        return e
-      };
-      (function() {
-        var c = {};
-        var d = document[b("0x0")][b("0x1")](/rplsb=([1]+)/);
-        var e = document[b("0x0")][b("0x1")](/wapo_actmgmt=(\b|.*\|)(isub:1)(\b|\|)([^;]*);/);
-        var f = d || e ? !![] : ![];
-        var g = document[b("0x0")][b("0x1")](/wapo_secure_login_id=([^;]+)/);
-        var h = g ? !![] : ![];
-        var i = !h && !f;
-        var j = document["cookie"][b("0x1")](/wp_devicetype=([1]+)/) ? !![] : ![];
-        var k = {};
-        k[b("0x2")] = {};
-        k["getFeatureConfig"] = function() {
-          return new Promise(function(l) {
-            document.addEventListener(b("0x3"), function() {
-              if (TWP.Data.Tracking.pmbl) Object.assign(k.featureConfig,
-                TWP.Data.Tracking.pmbl);
-              l(!![])
-            })
-          })
-        };
-        k[b("0x4")] = function() {
-          return new Promise(function(m) {
-            var n = !![];
-            if (navigator.userAgent.indexOf(b("0x5")) > -1) return (new Promise(function(m) {
-              var p = window.RequestFileSystem || window.webkitRequestFileSystem;
-              if (p) p(window.TEMPORARY, 100, function() {
-                c.pv = ![];
-                m({
-                  type: "pv",
-                  result: c.pv,
-                  overlay: n
-                })
-              }, function() {
-                c.pv = !![];
-                m({
-                  type: "pv",
-                  result: c.pv,
-                  overlay: n
-                })
-              })
-            })).then(function(q) {
-              m(q)
-            });
-            else if (navigator.userAgent.indexOf(b("0x6")) > -1) try {
-                var r = b("0x7");
-                window.sessionStorage.setItem(r,
-                  b("0x8"));
-                window.sessionStorage.removeItem(r);
-                window.localStorage.setItem(r, b("0x8"));
-                window.localStorage.removeItem(r);
-                window.openDatabase(null, null, null, null);
-                c.pv = ![]
-              } catch (s) {
-                c.pv = !![]
-              } else if (navigator.userAgent.indexOf(b("0x9")) > -1) c.pv = !navigator.serviceWorker;
-              else if (window.PointerEvent || window.MSPointerEvent) c.pv = !window.indexedDB;
-            else c.pv = ![];
-            m({
-              type: "pv",
-              result: c.pv,
-              overlay: n
-            })
-          })
-        };
-        k["condition_isBL"] = function() {
-          var t = encodeURI("/701/ad-blk"),
-            u = encodeURI(b("0xa")),
-            v = Math.floor(Math.random() *
-              1E15),
-            w = -(new Date).getTimezoneOffset();
-          var x = b("0xb") + t + b("0xc") + u + b("0xd") + v + b("0xe") + w;
-          function y() {
-            return new Promise(function(z, A) {
-              var x = b("0xf");
-              try {
-                var C = new XMLHttpRequest;
-                C.withCredentials = !![];
-                C.open("GET", x);
-                C.timeout = 3E3;
-                C.onload = function(D) {
-                  if (D.indexOf(b("0x10")) == -1) A(b("0x11"));
-                  else z("")
-                };
-                C.onerror = function() {
-                  A("blocked")
-                };
-                C.send()
-              } catch (E) {
-                A(b("0x11"))
-              }
-            })
+  </div>
+  <script id="__NEXT_DATA__" type="application/json"
+    crossorigin="anonymous">{"props":{"pageProps":{"globalContent":{"_id":"M4IAOPWKF5CS3PUTQH6IOFYVD4","additional_properties":{"blog_name":"internet-culture"},"canonical_url":"/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/","comments":{"allow_comments":true},"content_elements":[{"_id":"G3HCEPO6HY2YTJA4TBWWWXGYPA","additional_properties":{"alignment":"center"},"credits_caption_display":"(Leon Neal/AFP/Getty Images) ","height":632,"type":"image","url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/G3HCEPO6HY2YTJA4TBWWWXGYPA.jpg","width":960,"originalIdx":0},{"_id":"ZW2RIPB3KZG2VMNGHFZK4GXXJE","content":"Twitter announced a plan to make itself simpler Tuesday by, among other things, removing the need for a popular, improvised equivalent of a stage whisper.  The changes are the latest iteration of the microblogging site’s attempts to make itself more appealing to new users. For instance, a few months ago, \u003ca href=\"https://www.washingtonpost.com/news/the-intersect/wp/2015/11/03/twitter-just-eliminated-the-favorite-and-replaced-it-with-heart-shaped-likes/\"\u003eit changed its “favorite” button\u003c/a\u003e — a way to interact with a tweet without actually writing a reply — to the more universally understood “like” button.","type":"text","originalIdx":1},{"_id":"CHRB3RFGTRHZNEIX2TEYXNOQSQ","content":"The company clearly believes that it needs to change some things to attract and keep new users, but doesn’t seem inclined to change anything so radically that it would upset loyalists enough for them to leave. That being said, pretty much any change to Twitter has the effect of upsetting its biggest fans\u003cem\u003e a little\u003c/em\u003e: when “fav” became “like” last year, many hard-core users freaked out a bit, before adjusting to the fact that one of the site’s buttons had changed from a star to a heart and it was fine. A \u003ca href=\"https://www.washingtonpost.com/news/the-intersect/wp/2016/01/06/twitters-rumored-character-limit-change-is-bad-news-for-artists-and-botmakers/\"\u003erumored plan to dramatically increase Twitter’s character limits\u003c/a\u003e, however, crossed that line, and \u003ca href=\"http://techcrunch.com/2016/03/18/jack-dorsey-140-characters/\"\u003eTwitter’s chief executive Jack Dorsey eventually disavowed it\u003c/a\u003e.","type":"text","originalIdx":2},{"_id":"ND4Q5CGYJNDIFBVL5AXLS7CAXY","content":"\n\u003ci\u003e\n    [Congrats, Twitter! Some people are actually happy about your latest changes.]\n  \u003c/i\u003e\n","type":"interstitial_link","url":"https://www.washingtonpost.com/news/the-switch/wp/2016/05/24/congrats-twitter-some-people-are-actually-happy-about-your-latest-changes/","originalIdx":3},{"_id":"PIMC2ZM47JEKPK3AZ24LGGMLOE","content":"While incremental, the newest round of changes — rolling out in the coming months, Twitter says — will eliminate some of the creative workarounds Twitter’s users have developed to get the most out of the 140-character limited platform. In other words, tweets will be longer, but not in the way that everyone feared. “You can already do a lot in a Tweet, but we want you to be able to do even more,” \u003ca href=\"https://blog.twitter.com/express-even-more-in-140-characters\"\u003eTwitter’s announcement reads\u003c/a\u003e. My colleague Hayley Tsukayama\u003ca href=\"https://www.washingtonpost.com/news/the-switch/wp/2016/05/24/congrats-twitter-some-people-are-actually-happy-about-your-latest-changes/\"\u003e has a full-run down\u003c/a\u003e of all the announced changes at The Switch.","type":"text","originalIdx":4},{"_id":"T36DZOPDNNBL7CEMVROFN4ZHFY","content":"A couple of tweaks to what “counts” towards Twitter’s short character limit will expand the length of tweets without going too crazy. Other announced changes will tweak the reach of some tweets. That includes one of the more interesting changes, which will largely eliminate the need for the “.@,” a weird, organic solution to one of Twitter’s quirks. Unfortunately, the change isn’t explained very clearly in Twitter’s announcement, so we’ve done our best to break down what will — and won’t — be changing below.","type":"text","originalIdx":5},{"_id":"a7b621ae-685a-11e5-bdb6-6861f4521205","additional_properties":{"embedContinuousPlay":true},"canonical_url":"/entertainment/the-evolution-of-twitter/2015/10/01/a7b621ae-685a-11e5-bdb6-6861f4521205_video.html","credits":{"by":[{"name":"Erin Patrick O'Connor"}]},"credits_caption_display":"How twitter became a $25 billion start-up success story. (Erin Patrick O'Connor/The Washington Post)","display_date":"2015-10-01T16:20:00Z","headlines":{"basic":"The evolution of Twitter"},"promo_image":{"url":"https://d1i4t8bqe7zgj6.cloudfront.net/thumbnails/560d6132e4b01e7190724342/2013_10_20T120036Z_01_TOR110_RTRIDSP_3_TWITTER_USERS_6335.jpg"},"related_content":{"basic":[{"canonical_url":"https://www.washingtonpost.com/news/the-intersect/wp/2015/09/30/everyone-you-know-will-be-able-to-rate-you-on-the-terrifying-yelp-for-people-whether-you-want-them-to-or-not/","headlines":{"basic":"THE INTERSECT: Everyone you know will be able to rate you on the terrifying ‘Yelp for people’ — whether you want them to or not"},"type":"story","version":"0.5.8"},{"canonical_url":"https://www.washingtonpost.com/news/the-intersect/wp/2015/09/29/dont-feel-bad-if-you-fell-for-the-facebook-copyright-hoax/","headlines":{"basic":"THE INTERSECT: Don’t feel bad if you fell for the Facebook copyright hoax"},"type":"story","version":"0.5.8"},{"canonical_url":"https://www.washingtonpost.com/news/the-intersect/wp/2016/01/06/twitters-rumored-character-limit-change-is-bad-news-for-artists-and-botmakers/","headlines":{"basic":"THE INTERSECT: Twitter’s rumored character-limit change is bad news for artists and botmakers"},"type":"story","version":"0.5.8"}],"redirect":[]},"streams":[{"height":180,"width":320},{"height":180,"width":320},{"height":1080,"width":1920},{"height":360,"width":640},{"height":1080,"width":1920},{"height":720,"width":1280},{"height":480,"width":854},{"height":360,"width":640},{"height":360,"width":640},{"height":720,"width":1280},{"height":1080,"width":1920},{"height":720,"width":1280}],"type":"video","originalIdx":6},{"_id":"GVARR5Z7CVAF5DVM7L3U7WYBOE","content":"See, Twitter doesn’t display every tweet of yours to all your followers. Anything that begins with an “@” is treated like a reply, and has a pretty limited reach. You’ll see @-beginning tweets only if both the person tagged and the person tweeting are people you follow. In recent years, Twitter has started to separate out “reply” tweets more and more. When several tweets written as replies to previous ones become a longer conversation, Twitter \u003ca href=\"https://blog.twitter.com/2013/keep-up-with-conversations-on-twitter\"\u003ebundles it for you\u003c/a\u003e and shows it to you as a linked string of tweets.","type":"text","originalIdx":7},{"_id":"K4SHSNAVIZFNZHP7UYD3YQFT54","content":"\n\u003ci\u003e\n    [The ‘@’ symbol was almost lost to history. Here’s how Ray Tomlinson saved it.]\n  \u003c/i\u003e\n","type":"interstitial_link","url":"https://www.washingtonpost.com/news/the-intersect/wp/2016/03/07/a-short-history-of/?tid=sm_tw","originalIdx":8},{"_id":"WMFMBTLBZBHP7FWDFQ336LOJFU","content":"But not every tweet that begins with an “@” is actually a reply to another user. Sometimes the tweet is simply a sentence that begins with a reference to another user. Other times, it’s a stage whisper: The tweet is addressed to one person, but it’s meant for everyone to see. To get around the fact that Twitter automatically limits the reach of and “@”-leading tweets, even if they’re not actually meant as a reply to a previous tweet, many users put a single character, usually an “.” right at the beginning, to prevent Twitter from handling it like a reply. Celebrities do this a lot:","type":"text","originalIdx":9},{"_id":"JY27GZIBONHZBOWYPZYLX7EM6U","type":"reference","originalIdx":10},{"_id":"GUI4CYYMPNGMLCK7PNMAMUSCSQ","content":"But “.@” no more! Twitter will now automatically show those stage whisper tweets to all your followers — so long as it’s not tweeted in reply to something else. Those actual replies will remain limited in reach, in the same way they are now. But Twitter has a way to make sure you can force all your followers to see your witty comeback, should you wish to do that.","type":"text","originalIdx":11},{"_id":"SK35ZUOMZNEFTP3L6DCBJX2ZQI","content":"Introducing the self-retweet, or a new thing Twitter is allowing its users to do to draw attention to their own tweets and replies. Once Twitter enables the retweet function for all users to use on their own tweets, Twitter says, “you can easily Retweet or Quote Tweet yourself when you want to share a new reflection or feel like a really good one went unnoticed,” Twitter’s announcement explains.","type":"text","originalIdx":12},{"_id":"2J3H47TEZNAVJOJI46JNA3ZR5A","content":"\n\u003ci\u003e\n    [The surprising truth about how Twitter has changed your brain]\n  \u003c/i\u003e\n","type":"interstitial_link","url":"https://www.washingtonpost.com/news/the-intersect/wp/2016/03/21/the-surprising-truth-about-how-twitter-has-changed-your-brain/","originalIdx":13},{"_id":"TG6KFAN6RJDLZHZQEQGSPVF4YM","content":"Like that “.@” elimination, the self-retweet isn’t the result of a totally new invention. It’s already possible to place a link to your own tweet in a new one. Some users have taken to replying to their own tweets over the course of many days to revive the entire thread for their followers as a bundled conversation. And there’s always the manual retweet, although these days that’s considered to be \u003ca href=\"https://www.buzzfeed.com/katienotopoulos/the-latest-twitter-trend-manual-retweet-shaming?utm_term=.bwLLgPqPN#.brpJYeNeA\"\u003ea very bad thing to do on Twitter\u003c/a\u003e. The self-retweet change simply makes it easier to do something its users were doing already.","type":"text","originalIdx":14},{"_id":"MLH235ITBZA3LOCSJFPB7CIEIA","content":"Will hard-core users still “.@” for old time’s sake? probably, for a little bit. But longtime users are used to adapting to Twitter’s attempts to absorb the organic, creative workarounds to the platform’s limitations in the past. Twitter didn’t always allow users to post photos, so someone made TwitPic. Twitter then made the service irrelevant in 2011, when it \u003ca href=\"https://blog.twitter.com/2011/searchphotos\"\u003eannounced a new capacity\u003c/a\u003e to host photo and video itself. Twitter didn’t always automatically shorten URLs, so users used link shorteners to minimize the number of characters a link ate up. Now, Twitter \u003ca href=\"https://twitter.com/twitter/status/735153337746653184\"\u003ewon’t count media attachments\u003c/a\u003e towards the character limit.","type":"text","originalIdx":15},{"_id":"D5VTSSSVYJBUFIU5IA63ROI254","content":"Since the changes haven’t even rolled out yet, it’s too early to bury the “.@” next to the manual retweet in the graveyard of obsolete Twitter conventions. But it’s not long for this world.","type":"text","originalIdx":16},{"_id":"LFXDLOH6VJBWHN5XA5BAVYGJLU","content":"\u003cstrong\u003eLiked that? try these:\u003c/strong\u003e","type":"text","originalIdx":17},{"_id":"222BOR54H5H7TJOVW67D3IBE2M","items":[{"_id":"CNSQAXKON5GK3GFKCXRACTK5TM","content":"\u003cstrong\u003e\u003ca href=\"https://www.washingtonpost.com/news/the-intersect/wp/2016/05/03/the-pre-twitter-history-of-twitters-favorite-insult/?itid=lk_inline_manual_26\"\u003eThe pre-Twitter history of Twitter’s favorite insult \u003c/a\u003e\u003c/strong\u003e","type":"text","itid":"lk_inline_manual_26"},{"_id":"PPY7T5A5IZAOPHKTYVIKKFC6GE","content":"\u003cstrong\u003e\u003ca href=\"https://www.washingtonpost.com/news/the-intersect/wp/2016/02/11/the-internets-top-dog-rater-keeps-disappearing-from-twitter/?itid=lk_inline_manual_27\"\u003eThe Internet’s most famous dog rater keeps disappearing from Twitter\u003c/a\u003e\u003c/strong\u003e","type":"text","itid":"lk_inline_manual_27"},{"_id":"RR63Y2OZURECNELABY3TLERF5Q","content":"\u003cstrong\u003e\u003ca href=\"https://www.washingtonpost.com/news/the-intersect/wp/2014/05/23/what-happens-when-everyword-ends/?itid=lk_inline_manual_28\"\u003eA eulogy for @everyword\u003c/a\u003e\u003c/strong\u003e","type":"text","itid":"lk_inline_manual_28"}],"list_type":"unordered","type":"list","originalIdx":18}],"credits":{"by":[{"_id":"ohlheiseraw","additional_properties":{"original":{"_id":"ohlheiseraw","affiliations":"","altByline":"Abigail Ohlheiser","awards":[],"bio":"Abby Ohlheiser covered digital culture for The Washington Post. She left The Post in March 2020.","bio_page":"https://www.washingtonpost.com/people/abby-ohlheiser/","books":[],"byline":"Abby Ohlheiser","custom_washpost_desk_name_1":"Features","custom_washpost_desk_name_2":"Internet Culture","desk":"Audience Development and Engagement","education":[{"name":"New York University, MA in religious studies, with a concentration in journalism"},{"name":"Hampshire College, BA in liberal arts"}],"email":"abigail.ohlheiser@washpost.com","employeeID":"000266260","expertise":"Reporter covering digital culture ","facebook":"https://www.facebook.com/aohlheiser","firstName":"Abby","gplus":"https://plus.google.com/112286462216881159798","image":"https://s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png","lastName":"Ohlheiser","last_updated":"2018-04-04T20:12:16.324Z","last_updated_date":"2020-06-24T19:56:27.952Z","location":"Washington, D.C.","longBio":"Abby Ohlheiser covered digital culture for The Washington Post. She left The Post in March 2020.","podcasts":[],"reddit":"aohlheiserWaPo","role":"Reporter","slug":"abby-ohlheiser","twitter":"@abbyohlheiser"}},"description":"Abby Ohlheiser covered digital culture for The Washington Post. She left The Post in March 2020.","image":{"url":"https://s3.amazonaws.com/arc-authors/washpost/9406288c-c780-4232-a791-1b5354b3e18d.png","version":"0.5.8"},"name":"Abby Ohlheiser","org":"Washington, D.C.","slug":"abby-ohlheiser","socialLinks":[{"deprecated":true,"deprecation_msg":"Please use social_links.","site":"email","url":"abigail.ohlheiser@washpost.com"},{"deprecated":true,"deprecation_msg":"Please use social_links.","site":"facebook","url":"https://www.facebook.com/aohlheiser"},{"deprecated":true,"deprecation_msg":"Please use social_links.","site":"twitter","url":"@abbyohlheiser"}],"social_links":[{"site":"email","url":"abigail.ohlheiser@washpost.com"},{"site":"facebook","url":"https://www.facebook.com/aohlheiser"},{"site":"twitter","url":"@abbyohlheiser"}],"type":"author","url":"https://www.washingtonpost.com/people/abby-ohlheiser/","version":"0.5.8"}]},"description":{"basic":"Twitter announced a series of changes that will make the site easier to use. "},"display_date":"2016-05-24T18:20:48Z","first_publish_date":"2016-05-24T18:20:48Z","fusion_additions":{"tracking":{"arc_id":"M4IAOPWKF5CS3PUTQH6IOFYVD4","author":"abby ohlheiser","blog_name":"internet-culture","clavis_keywords":"twitter; tweet; Twitter; reply; user; change; users; button; tweets; way; person; reach; announcement; link; plan; changes; need; character; anything; fact; bit; lot; everyone; retweet; platform","cms_system":"wordpress","commercial_node":"/technology","content_category":"Technology","content_id":"15491","content_type":"blog","headline":"Twitter says goodbye to all ‘.@’","hierarchy":"technology|story","page_name":"technology:blog:internet-culture - 15491 - 05/24/2016 - twitter-says-goodbye-to-all","section":"technology","seo_keywords":"twitter; .@ twitter; twitter replies; twitter character limit","subsection":"technology","source":"the washington post"}},"headlines":{"basic":"Twitter says goodbye to all ‘.@’"},"label":{"basic":{"text":"Internet Culture","url":"http://www.washingtonpost.com/news/the-intersect"}},"label_display":{"basic":{"text":"Internet Culture","url":"http://www.washingtonpost.com/news/the-intersect"},"transparency":{}},"language":"en","last_updated_date":"2019-04-28T17:30:14.537Z","owner":{"name":"The Washington Post"},"promo_items":{"basic":{"_id":"YU7K4QHOU45NXLUUOZBD64ZCM4","additional_properties":{"alt_text":"","galleries":[],"is_gif":false,"mime_type":"image/jpeg","originalName":"AFP_AD4OR.jpg","originalUrl":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YU7K4QHOU45NXLUUOZBD64ZCM4.jpg","published":true,"restricted":false,"roles":[],"version":12},"address":{},"caption":"","caption_display":"","created_date":"2017-08-04T05:40:59Z","credits_caption_display":"","credits_display":"","height":632,"last_updated_date":"2019-04-28T17:50:02Z","licensable":false,"owner":{"id":"washpost"},"source":{"additional_properties":{},"edit_url":"https://washpost.arcpublishing.com/photo/YU7K4QHOU45NXLUUOZBD64ZCM4","system":"Anglerfish"},"type":"image","url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YU7K4QHOU45NXLUUOZBD64ZCM4.jpg","version":"0.9.0","width":960}},"publish_date":"2016-05-24T21:40:06Z","related_content":{},"source":{"edit_url":"http://www.washingtonpost.com/news/the-intersect/wp-admin/post.php?action=edit\u0026post=15491","source_id":"news_32_15491","system":"wordpress"},"syndication":{},"taxonomy":{"auxiliaries":[{"_id":"59dd2397dc0e8200016776ef","name":"BofA Audience 101017","uid":"0GA"},{"_id":"58dd49dfcff47e00011af37a","name":"Sub: Neutral","uid":"0KS"},{"_id":"59ce13864cedfd00015293ff","name":"Siemens","uid":"q15"},{"_id":"569e60c2e4b066d59a91e421","name":"food safety neg","uid":"xyt"},{"_id":"5851a3ca52faff0001551a30","name":"jb kws","uid":"r6u"},{"_id":"2971","name":"apple kws","uid":"1nw"},{"_id":"5a1efd82cff47e000196cfe1","name":"IC-Raytheon-12.2017","uid":"6yp"},{"_id":"55c0c9d8e4b0450a60c5d1f2","name":"Sensitive 2","uid":"7aq"},{"_id":"1388","name":"Discover: Aux 2: Keywords \u0026 Topics","uid":"dya"},{"_id":"58064e5f4cedfd0001fbc11f","name":"Election 2016","uid":"WC9"},{"_id":"5a0db546cff47e0001f59d97","name":"IC-Rackspace-2017","uid":"4ld"},{"_id":"56ab864ae4b044d7ce640c28","name":"Icahn neg","uid":"7rl"},{"_id":"57cf2ae24cedfd00014d4d1c","name":"Young Professional / International Businessman","uid":"r5x"},{"_id":"1890","name":"Tech","uid":"54y"},{"_id":"56eaecf3e4b066d5d346ec88","name":"IC-JPMC-Mothers to Mentors","uid":"oq2"},{"_id":"566f38e3e4b0a5749577ff7a","name":"IC - JPMC - Detroits Comeback","uid":"vfq"},{"_id":"581cb4f846e0fb000193d792","name":"Johnnie Walker","uid":"f79"},{"_id":"3499","name":"ggl kws","uid":"muj"},{"_id":"56157725e4b048b53cb1fbed","name":"Emissions","uid":"zhn"},{"_id":"1686","name":"Discovery: Aux 8: Keywords \u0026 Topics","uid":"erz"},{"_id":"564ccc5ce4b03cecbf0354c7","name":"IC - JPMC - Houston","uid":"4em"},{"_id":"5605920ae4b0d9b4da3e8853","name":"Macys","uid":"ngs"},{"_id":"1882","name":"Business","uid":"hws"},{"_id":"58cc24674cedfd0001410ba1","name":"Space","uid":"gno"},{"_id":"5849767b46e0fb0001194c09","name":"BofA Dashboard Auxiliary","uid":"n95"},{"_id":"5858183e46e0fb0001989e7f","name":"gldmn kws","uid":"w4t"},{"_id":"1389","name":"Discover: Aux 3: Keywords \u0026 Topics","uid":"zk5"},{"_id":"55c23f2de4b0670805ece45d","name":"TV and Movies","uid":"vat"},{"_id":"5718db9de4b0470fdb83ec85","name":"IC-JPMC-Detroit","uid":"mgr"},{"_id":"56d46558e4b0d5d6e636ca2c","name":"Apple Content","uid":"wxg"},{"_id":"55b69f68e4b0ce5ef775c764","name":"Science, Health \u0026 Technology","uid":"wkq"},{"_id":"566f33dfe4b0f277140e90a8","name":"IC - JPMC - Entrepreneures","uid":"i7i"},{"_id":"5913726046e0fb0001533215","name":"Corporate Responsibility","uid":"FTM"},{"_id":"5745e444e4b0e20227a9b303","name":"emails - neg","uid":"7nc"},{"_id":"59caa7e246e0fb0001852e74","name":"bp kws","uid":"PKT"},{"_id":"5433f1a7e4b0e3961e436a7b","name":"Sensitive1","uid":"8z8"},{"_id":"56eafa14e4b044d7ce640c36","name":"IC-JPMC-Tech Savvy","uid":"0hv"},{"_id":"55c10921e4b06708aa1918b2","name":"Social Media","uid":"34n"},{"_id":"56143156e4b0d9b4054a80ad","name":"Ahld","uid":"l7l"},{"_id":"581b7d0046e0fb00017e248e","name":"IC-Allstate-MM","uid":"n0e"},{"_id":"58af16ae46e0fb0001a90e52","name":"Entrepreneurship","uid":"sqb"},{"_id":"574dd054e4b01597ba8d4aaf","name":"IC-JPMC-Detroit (2)","uid":"ft0"},{"_id":"548b3b9be4b009dcd4eea6d6","name":"China_HongKong Exclusion 12-12-14","uid":"5k4"},{"_id":"59d3a6b452faff0001c2f763","name":"New Auxiliary 460","uid":"IAJ"},{"_id":"59a5e120c9e77c00018a863c","name":"api kws","uid":"BUM"},{"_id":"55c1126de4b0b091a86d579a","name":"Companies","uid":"ieb"},{"_id":"589cd0244cedfd0001bd1adc","name":"Travel TG","uid":"97K"},{"_id":"59395dcc46e0fb0001e4ae4f","name":"Boeing Targeting 6.8.17","uid":"F85"},{"_id":"563cedc8e4b03cec236c127a","name":"IC - JPMC - Decisive Action","uid":"xzm"},{"_id":"59f3aaf0cff47e00016208cf","name":"intel kw","uid":"GQP"},{"_id":"57fbced246e0fb0001ba525a","name":"Qualcomm Smart Cities","uid":"w5n"},{"_id":"56376500e4b0cdebeb04791e","name":"Murdoch neg","uid":"zwn"},{"_id":"5679c3dae4b0cf4e62c8fc59","name":"Exn neg","uid":"9xx"},{"_id":"5a0b379dcff47e0001beeb20","name":"aig kws","uid":"IAM"},{"_id":"2708","name":"New Auxiliary 561","uid":"3uh"}],"keywords":[{"frequency":52,"keyword":"twitter","score":0.8262536462205308,"tag":"proper_noun"},{"frequency":29,"keyword":"tweet","score":0.41690226132701147,"tag":"noun"},{"frequency":26,"keyword":"Twitter","score":0.21730337651334225,"tag":"proper_noun"},{"frequency":15,"keyword":"reply","score":0.157864761813073,"tag":"noun"},{"frequency":17,"keyword":"user","score":0.14219809111509205,"tag":"noun"},{"frequency":12,"keyword":"change","score":0.0849734842704094,"tag":"noun"},{"frequency":13,"keyword":"users","score":0.08098538363131483,"tag":"noun"},{"frequency":5,"keyword":"button","score":0.07323663216809063,"tag":"noun"},{"frequency":12,"keyword":"tweets","score":0.07313599903220462,"tag":"noun"},{"frequency":8,"keyword":"way","score":0.06912455402929947,"tag":"noun"},{"frequency":6,"keyword":"person","score":0.052176545902838704,"tag":"noun"},{"frequency":8,"keyword":"reach","score":0.04162047695920773,"tag":"noun"},{"frequency":6,"keyword":"announcement","score":0.03242816051223914,"tag":"noun"},{"frequency":5,"keyword":"link","score":0.03135936720696684,"tag":"noun"},{"frequency":4,"keyword":"plan","score":0.030606353741888626,"tag":"noun"},{"frequency":6,"keyword":"changes","score":0.02934765088237372,"tag":"noun"},{"frequency":4,"keyword":"need","score":0.028420185617468008,"tag":"noun"},{"frequency":6,"keyword":"character","score":0.02583322000357028,"tag":"noun"},{"frequency":4,"keyword":"anything","score":0.023610615743742656,"tag":"noun"},{"frequency":4,"keyword":"fact","score":0.023319126660486574,"tag":"noun"},{"frequency":4,"keyword":"bit","score":0.022736148493974408,"tag":"noun"},{"frequency":4,"keyword":"lot","score":0.02186168124420616,"tag":"noun"},{"frequency":4,"keyword":"everyone","score":0.02186168124420616,"tag":"noun"},{"frequency":5,"keyword":"retweet","score":0.021715384639920437,"tag":"noun"},{"frequency":4,"keyword":"platform","score":0.021278703077694,"tag":"noun"}],"named_entities":[{"_id":"hayley-tsukayama","name":"Hayley Tsukayama","score":0.6910486007490741,"type":"person"},{"_id":"jack-dorsey","name":"Jack Dorsey","score":0.563140612756398,"type":"person"},{"_id":"twitter","name":"Twitter","score":0.4531274452812311,"type":"organization"}],"primary_site":{"_id":"/technology/internet-culture","additional_properties":{"original":{"_admin":{"alias_ids":["/technology/internet-culture","/internet-culture"],"commercial_node":"/technology/internet-culture","default_content":"prism://prism.query/site,/technology/internet-culture\u0026limit=20","tracking_node":null},"_comments_config":{"comments_config":{"includetabs":"true","markersfeatured":"featured_comment"}},"_id":"/technology/internet-culture","ancestors":["/technology"],"hss":{"active_season":null},"in_the_news":{"in_the_news_usebasepage":"/in-the-news-forsections/","in_the_news_usefeature":"sitewide","in_the_news_usesectionbar":"false"},"inactive":false,"name":"Internet Culture","navigation":{"additional_inline_information_in_navigation_mobile_only":[],"nav_title":"Internet Culture"},"node_type":"section","order":2006,"parent":"/technology","site":{"additional_info":{},"archives_url":[],"native_app_rendering":"true","pagebuilder_path_for_native_apps":"/internet-culture/","pagebuilder_path_for_native_apps_tablet":"/internet-culture/","site_about":null,"site_description":null,"site_keywords":"internet, digital culture, memes, Internet memes, Internet hoaxes, social media trends, viral memes","site_tagline":"","site_theme":null,"site_title":"Internet Culture","site_url":"https://www.washingtonpost.com/internet-culture/","site_url_section":"technology","social_share_image":null,"tracking_blog_name":null,"tracking_page_name":"front - technology - internet-culture","tracking_section":null,"tracking_section_override":"technology","tracking_site_node":"/technology/internet-culture","tracking_subsection":null,"tracking_subsection_override":"internet-culture"},"site_topper":{"custom_links":["Technology^https://www.washingtonpost.com/technology/","Consumer Tech^https://www.washingtonpost.com/consumer-tech/","Innovations^https://www.washingtonpost.com/news/innovations/","Space^https://www.washingtonpost.com/space/","Tech Policy^https://www.washingtonpost.com/tech-policy/","Video Gaming^https://www.washingtonpost.com/technology/video-gaming/"],"custom_links_highlight":"1","display_social_links":null,"newsletter_links":{},"secondary_nav_add_padding":"false","secondary_nav_alternate_section_to_use":"/technology","secondary_nav_instead_of_custom_links":"true","site_background_image":null,"site_logo_image":null,"social_link_display_order":null,"topper_for_article":"normal"},"social":{"archive_end_date":null,"archive_start_date":null,"archives":null,"facebook":null,"instagram":null,"rss":null,"twitter":"https://twitter.com/abbyohlheiser"},"story_list":{"display_social_share_buttons":null,"social_share_buttons":null,"story_list_content":{}}}},"description":null,"name":"Internet Culture","parent_id":"/technology","path":"/technology/internet-culture","type":"site","version":"0.5.8"},"seo_keywords":["twitter",".@ twitter","twitter replies","twitter character limit"],"sites":[{"_id":"/technology/internet-culture","additional_properties":{"original":{"_admin":{"alias_ids":["/technology/internet-culture","/internet-culture"],"commercial_node":"/technology/internet-culture","default_content":"prism://prism.query/site,/technology/internet-culture\u0026limit=20","tracking_node":null},"_comments_config":{"comments_config":{"includetabs":"true","markersfeatured":"featured_comment"}},"_id":"/technology/internet-culture","ancestors":["/technology"],"hss":{"active_season":null},"in_the_news":{"in_the_news_usebasepage":"/in-the-news-forsections/","in_the_news_usefeature":"sitewide","in_the_news_usesectionbar":"false"},"inactive":false,"name":"Internet Culture","navigation":{"additional_inline_information_in_navigation_mobile_only":[],"nav_title":"Internet Culture"},"node_type":"section","order":2006,"parent":"/technology","site":{"additional_info":{},"archives_url":[],"native_app_rendering":"true","pagebuilder_path_for_native_apps":"/internet-culture/","pagebuilder_path_for_native_apps_tablet":"/internet-culture/","site_about":null,"site_description":null,"site_keywords":"internet, digital culture, memes, Internet memes, Internet hoaxes, social media trends, viral memes","site_tagline":"","site_theme":null,"site_title":"Internet Culture","site_url":"https://www.washingtonpost.com/internet-culture/","site_url_section":"technology","social_share_image":null,"tracking_blog_name":null,"tracking_page_name":"front - technology - internet-culture","tracking_section":null,"tracking_section_override":"technology","tracking_site_node":"/technology/internet-culture","tracking_subsection":null,"tracking_subsection_override":"internet-culture"},"site_topper":{"custom_links":["Technology^https://www.washingtonpost.com/technology/","Consumer Tech^https://www.washingtonpost.com/consumer-tech/","Innovations^https://www.washingtonpost.com/news/innovations/","Space^https://www.washingtonpost.com/space/","Tech Policy^https://www.washingtonpost.com/tech-policy/","Video Gaming^https://www.washingtonpost.com/technology/video-gaming/"],"custom_links_highlight":"1","display_social_links":null,"newsletter_links":{},"secondary_nav_add_padding":"false","secondary_nav_alternate_section_to_use":"/technology","secondary_nav_instead_of_custom_links":"true","site_background_image":null,"site_logo_image":null,"social_link_display_order":null,"topper_for_article":"normal"},"social":{"archive_end_date":null,"archive_start_date":null,"archives":null,"facebook":null,"instagram":null,"rss":null,"twitter":"https://twitter.com/abbyohlheiser"},"story_list":{"display_social_share_buttons":null,"social_share_buttons":null,"story_list_content":{}}}},"description":null,"name":"Internet Culture","parent_id":"/technology","path":"/technology/internet-culture","type":"site","version":"0.5.8"},{"_id":"/technology","additional_properties":{"original":{"Video":{"video_ad_zone":"wpni.video.technology"},"_admin":{"alias_ids":["/business/technology","/technology","/technology/the-switch","/news/the-switch","/business/on-it"],"commercial_node":"/technology","default_content":"prism://prism.query/site-articles-only,/technology\u0026limit=20","tracking_node":""},"_comments_config":{"comments_config":{"comment_system":"coral","comment_system_date":"2016-07-20T00:00","includetabs":"true","markersfeatured":"featured_comment"}},"_id":"/technology","in_the_news":{"in_the_news_usebasepage":"/in-the-news-forsections/","in_the_news_usefeature":"sitewide","in_the_news_usesectionbar":"true"},"inactive":false,"name":"Technology","navigation":{"nav_title":"Tech"},"node_type":"section","order":1014,"parent":"/","site":{"archives_url":[],"native_app_rendering":"true","pagebuilder_path_for_native_apps":"/business/technology","pagebuilder_path_for_native_apps_tablet":"/business/technology","site_about":"","site_description":"Washington Post technology news.","site_keywords":"technology news,social media,tech gadgets,tech news,internet policy,internet privacy,social networks,internet gaming,technology policy,technology regulation,patents,intellectual property policy","site_tagline":null,"site_theme":"normal","site_title":"Technology","site_url":"https://www.washingtonpost.com/business/technology/","site_url_section":"technology","tracking_page_name":"front - business - technology","tracking_section":"technology","tracking_section_override":"","tracking_site_node":"/technology","tracking_subsection_override":""},"site_topper":{"custom_links":["Consumer Tech^https://www.washingtonpost.com/consumer-tech/","Innovations^https://www.washingtonpost.com/news/innovations/","Internet Culture^https://www.washingtonpost.com/internet-culture/","Space^https://www.washingtonpost.com/space/","Tech Policy^https://www.washingtonpost.com/tech-policy/","Video Gaming^https://www.washingtonpost.com/technology/video-gaming/"],"custom_links_highlight":null,"display_social_links":null,"secondary_nav_add_padding":"false","secondary_nav_alternate_section_to_use":"/technology","secondary_nav_instead_of_custom_links":"true","site_background_image":null,"site_logo_image":null,"social_link_display_order":null},"social":{"archives":null,"facebook":null,"rss":"http://feeds.washingtonpost.com/rss/business/technology","twitter":null},"story_list":{"display_social_share_buttons":"true","social_share_buttons":null,"story_list_content":{}}}},"description":"Washington Post technology news.","name":"Technology","parent_id":"/","path":"/technology","type":"site","version":"0.5.8"}],"tags":[{"_id":"64OK6SSH4FG5ZBDZ7NF6OI6PIA","additional_properties":{"type":"category"},"slug":"social-media","text":"Social media"},{"_id":"CIEFMWKT4NDXTD7K57FGZCNGS4","additional_properties":{"type":"tag"},"slug":"online-media","text":"online media"}],"topics":[{"_id":"53457843e4b02fdfdb579d58","name":"Social Media","score":0.9989429583801807,"uid":"us"},{"_id":"53457900e4b02fdfdb579d70","name":"Companies","score":0.7304828059203656,"uid":"jp"},{"_id":"washpost-20000048-onlinemedia-tk84p7ovdn","name":"iptc-media/arts_culture_entertainment_and_media/mass_media/online_media","score":0,"uid":"ari7w"},{"_id":"washpost-20000231-software-es3ucfmld3","name":"iptc-media/economy_business_and_finance/economic_sector/computing_and_information_technology/software","score":0,"uid":"aml15"},{"_id":"washpost-20000304-media-u1v53lmlyu","name":"iptc-media/economy_business_and_finance/economic_sector/media","score":0,"uid":"al2af"},{"_id":"washpost-20000756-technologyand-etldtixwth","name":"iptc-media/science_and_technology/technology_and_engineering","score":0,"uid":"aupih"},{"_id":"washpost-20000227-computernetwor-cdyrjmv2l0","name":"iptc-media/economy_business_and_finance/economic_sector/computing_and_information_technology/computer_networking","score":0,"uid":"a2iam"}]},"tracking":{"author_desk":"features","author_id":"ohlheiseraw","author_name":"abby ohlheiser","author_subdesk":"internet culture","author_type":"(not set)","blog_name":"internet-culture","commercial_node":"/technology","content_category":"Technology","content_topics":"Internet Culture;Technology","in_url_headline":"twitter-says-goodbye-to-all","post_id":"15491","section":"technology","site_node":"/technology/internet-culture"},"type":"story"},"outputType":"default","contentState":{"{\"source\":\"site-homepage\"}":{"site":{"additional_info":{"hp_subscribe_nav_text":"Try one month for $1","hp_subscribe_sections_text":"Try one month for $1","subscribe_nav_text":"Try one month for $1","subscribe_sections_text":"Try one month for $1","hp_gift_nav_show":"false","hp_gift_nav_show_sub":"false","hp_gift_url":"/acq","hp_gift_nav_text":"Gift subscriptions","hp_gift_nav_promo":"g_r_hp","gift_url":"/acq","gift_nav_text":"Gift subscriptions","gift_nav_show":"false","gift_nav_show_sub":"false","gift_nav_promo":"g_r_article","gift_nav_promo_sidebar":"g_r_sb","sw_gift_show":"false","sw_gift_show_sub":"false"}}},"{\"source\":\"story-feed-most-read-2\",\"query\":{\"section\":\"/technology\",\"feedSize\":15}}":{"content_elements":[{"canonical_url":"/technology/2021/03/04/google-hbcu-recruiting/","headlines":{"basic":"Google’s approach to historically Black schools helps explain why there are few Black engineers in Big Tech"},"description":{"basic":"Google for years has been celebrated for trying to fix Silicon Valley’s race gap. But while Google had a head start on building relationships with HBCUs, critics say its track record also exposes instances when Google undervalued and underinvested in Black engineering students."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/6EJGCQDBTUI6XILXO5S7FGUVEQ.jpg","type":"image"}}},{"canonical_url":"/technology/2021/03/01/computer-chip-shortage-explainer-qa/","headlines":{"basic":"What you need to know about the global chip shortage"},"description":{"basic":"A host of factors, from the trade war to the pandemic, have caused a global shortage in computer chips. It's showing just how vital the tiny circuits are to modern life."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/GL4RI7TQPII6XBSRNUYJD2WGH4.jpg","type":"image"}}},{"canonical_url":"/technology/2021/03/05/screen-time-one-year-kids/","headlines":{"basic":"Growing up on screens: How a year lived online has changed our children"},"description":{"basic":"Thriving, falling behind, bored and burned out, a year of nonstop screen time hasn’t been what families expected."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/4YQMQQT4MYI6XDC6GLSHWQVVDM.jpg","type":"image"}}},{"canonical_url":"/technology/2021/03/05/fever-scanner-flaws-covid/","headlines":{"basic":"Those fever scanners that everyone is using to fight covid can be wildly inaccurate, researchers find"},"description":{"basic":"A flood of thermal scanners hit the market last year. But researchers say many of the devices use software that can make a feverish person appear perfectly well."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/JGDBUDELI4I6VAG72JFTLJLIVY.jpg","type":"image"}}},{"canonical_url":"/technology/2021/03/05/fever-scanner-certify-fda/","headlines":{"basic":"Fever-scanner company pulls device off market following FDA warning"},"description":{"basic":"The FDA on Thursday sent a warning letter to Certify, saying it had not been authorized to sell the device for multi-person scanning."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/73NTA3FW7YI6VGQ52PNRZPQHZY.jpg","type":"image"}}},{"canonical_url":"/technology/2021/02/25/nasa-space-future-private/","headlines":{"basic":"As private companies erode government’s hold on space travel, NASA looks to open a new frontier"},"description":{"basic":"Space enthusiasts, including NASA, see enormous benefit in the shift — a new era of space exploration that will usher in a more capable and efficient space industry. But the changing dynamic also has left NASA with an uncertain role."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/4GGKKCRF64I6XHCKBXDCILCICQ.jpg","type":"image"}}},{"canonical_url":"/technology/2021/02/10/covid-vaccine-appointment-websites/","headlines":{"basic":"How to master the vaccine-appointment website: A guide for everyone"},"description":{"basic":"Five strategies to increase the chances of getting a free shot for yourself or someone you care about."},"label":{"transparency":{"text":"Perspective"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/YBMXKFTLEUI6XJTO4JYEN2PITA.jpg","type":"image"}}},{"canonical_url":"/technology/2021/03/03/spacex-starship-test-sn10/","headlines":{"basic":"Elon Musk’s SpaceX Starship rocket lands successfully but then explodes"},"description":{"basic":""},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/KZO3HLT4PMI6XDC6GLSHWQVVDM.jpg","type":"image"}}},{"canonical_url":"/technology/2021/03/01/semiconductor-shortage-halts-auto-factories/","headlines":{"basic":"Biden can’t fix the chip shortage any time soon. Here’s why."},"description":{"basic":"Chip shortages have forced General Motors and Ford to slash production in three states as well as in Canada and Mexico, threatening jobs at the auto companies and their suppliers."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/3H3M4JDXAUI6XFEJR562ZVI6OU.jpg","type":"image"}}},{"canonical_url":"/technology/2021/02/26/ice-private-utility-data/","headlines":{"basic":"ICE investigators used a private utility database covering millions to pursue immigration violations"},"description":{"basic":"ICE’s use of the vast database offers another example of how government agencies have targeted commercial sources to access information they are not authorized to compile on their own. One researcher called it “a massive betrayal of people’s trust\": “When you sign up for electricity, you don’t expect them to send immigration agents to your front door.”"},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/U4KM35V744I6VCIINCRLT2XJ4A.jpg","type":"image"}}},{"canonical_url":"/technology/2021/02/27/vaccine-selfies/","headlines":{"basic":"To selfie or not to selfie? Why the joy of getting vaccinated is drawing backlash."},"description":{"basic":"People are divided over “vaccine selfie\" etiquette, but health experts think they are a good thing."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/FW5GA4TWZAI6XFEJR562ZVI6OU.jpg","type":"image"}}},{"canonical_url":"/technology/2021/02/02/amazon-union-warehouse-workers/","headlines":{"basic":"Amazon’s anti-union blitz stalks Alabama warehouse workers everywhere, even the bathroom"},"description":{"basic":"The stakes couldn’t be higher for the e-commerce giant, which is fighting the biggest labor battle in its history on U.S. soil."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/2MSRDHDDLEI6XILXO5S7FGUVEQ.jpg","type":"image"}}},{"canonical_url":"/technology/2020/05/08/musk-grimes-baby-name/","headlines":{"basic":"Elon Musk’s baby name isn’t just weird, it may be against California regulations"},"description":{"basic":"Elon Musk and singer Grimes announced their newborn son would be named X Æ A-12 Musk — but California regulations are not on board."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/7WU6JYEQQQI6VEZCUKPHL374SM.jpg","type":"image"}}},{"canonical_url":"/technology/2021/02/16/covid-vaccine-misinformation-evangelical-mark-beast/","headlines":{"basic":"On social media, vaccine misinformation mixes with extreme faith"},"description":{"basic":"Across social media, vaccine misinformation targeted toward Christians and other religious groups is reaching sizeable audiences. This area is the hardest for tech companies to police."},"label":{"transparency":{"text":"News"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/DAPGGZGEBFAR3CUPGXAW4BTNPY.jpg","type":"image"}}},{"canonical_url":"/technology/2019/04/04/die-robocalls-die-how-to-guide-stop-spammers-exact-revenge/","headlines":{"basic":"Die, robocalls, die: A how-to guide to stop spammers and exact revenge"},"description":{"basic":"We tested six apps and services to find the best way to fight back against spam bots, telemarketers and fraud."},"label":{"transparency":{"text":"Review"}},"promo_items":{"basic":{"url":"https://arc-anglerfish-washpost-prod-washpost.s3.amazonaws.com/public/T4QRBYCWIQI6TDXT7PKBULHE2U.jpg","type":"image"}}}]},"{\"source\":\"site-menu\",\"query\":{\"hierarchy\":\"WebNav\"}}":{"children":[{"_id":"/homepage","name":"Home Page","site":{"site_url":"https://www.washingtonpost.com/"},"navigation":{"nav_title":"Home Page"},"children":[]},{"_id":"/politics","name":"Politics","site":{"site_url":"https://www.washingtonpost.com/politics/"},"navigation":{"nav_title":"Politics"},"children":[{"_id":"/politics/powerpost","name":"PowerPost","site":{"site_url":"https://www.washingtonpost.com/politics/powerpost/"},"navigation":{"nav_title":"Congress"}},{"_id":"/politics/courts-law","name":"Courts \u0026 Law","site":{"site_url":"https://www.washingtonpost.com/politics/courts-law/"},"navigation":{"nav_title":"Courts \u0026 Law"}},{"_id":"/politics/fact-checker","name":"Fact Checker","site":{"site_url":"https://www.washingtonpost.com/news/fact-checker/"},"navigation":{"nav_title":"Fact Checker"}},{"_id":"/politics/the-fix","name":"The Fix","site":{"site_url":"https://www.washingtonpost.com/the-fix/"},"navigation":{"nav_title":"The Fix"}},{"_id":"/politics/monkey-cage","name":"Monkey Cage","site":{"site_url":"https://www.washingtonpost.com/monkey-cage/"},"navigation":{"nav_title":"Monkey Cage"}},{"_id":"/politics/polling","name":"Polling","site":{"site_url":"https://www.washingtonpost.com/politics/polling/"},"navigation":{"nav_title":"Polling"}},{"_id":"/politics/white-house","name":"White House","site":{"site_url":"https://www.washingtonpost.com/politics/white-house/"},"navigation":{"nav_title":"White House"}}]},{"_id":"/opinions","name":"Opinions","site":{"site_url":"https://www.washingtonpost.com/opinions/"},"navigation":{"nav_title":"Opinions"},"children":[{"_id":"/opinions/the-opinions-essay","name":"The Opinions Essay","site":{"site_url":"https://www.washingtonpost.com/the-opinions-essay/"},"navigation":{"nav_title":"The Opinions Essay"}},{"_id":"/opinions/the-posts-view","name":"The Post's View","site":{"site_url":"https://www.washingtonpost.com/opinions/the-posts-view/"},"navigation":{"nav_title":"The Post's View"}},{"_id":"/opinions/cartoons","name":"Editorial Cartoons","site":{"site_url":"https://www.washingtonpost.com/opinions/cartoons/"},"navigation":{"nav_title":"Editorial Cartoons"}},{"_id":"/opinions/global-opinions","name":"Global Opinions","site":{"site_url":"https://www.washingtonpost.com/global-opinions/"},"navigation":{"nav_title":"Global Opinions"}},{"_id":"/opinions/local-opinions","name":"Local Opinions","site":{"site_url":"https://www.washingtonpost.com/opinions/local-opinions/"},"navigation":{"nav_title":"Local Opinions"}},{"_id":"/opinions/letters-to-the-editor","name":"Letters to the Editor","site":{"site_url":"https://www.washingtonpost.com/opinions/letters-to-the-editor/"},"navigation":{"nav_title":"Letters to the Editor"}},{"_id":"/opinions/plum-line","name":"The Plum Line","site":{"site_url":"https://www.washingtonpost.com/plum-line/"},"navigation":{"nav_title":"The Plum Line"}},{"_id":"/opinions/global-opinions/post-opinion","name":"Post Opinión","site":{"site_url":"https://www.washingtonpost.com/es/post-opinion/"},"navigation":{"nav_title":"Post Opinión"}},{"_id":"/opinions/compost","name":"Alexandra Petri","site":{"site_url":"https://www.washingtonpost.com/people/alexandra-petri/"},"navigation":{"nav_title":"Alexandra Petri"}},{"_id":"/opinions/right-turn","name":"Jennifer Rubin","site":{"site_url":"https://www.washingtonpost.com/people/jennifer-rubin/"},"navigation":{"nav_title":"Jennifer Rubin"}},{"_id":"/opinions/erik-wemple","name":"Erik Wemple","site":{"site_url":"https://www.washingtonpost.com/people/erik-wemple/"},"navigation":{"nav_title":"Erik Wemple"}}]},{"_id":"/national/investigations","name":"Investigations","site":{"site_url":"https://www.washingtonpost.com/national/investigations/"},"navigation":{"nav_title":"Investigations"},"children":[]},{"_id":"/technology","name":"Technology","site":{"site_url":"https://www.washingtonpost.com/business/technology/"},"navigation":{"nav_title":"Tech"},"children":[{"_id":"/technology/consumer-tech","name":"Consumer Tech","site":{"site_url":"https://www.washingtonpost.com/consumer-tech/"},"navigation":{"nav_title":"Consumer Tech"}},{"_id":"/technology/future-of-transportation","name":"Future of Transportation","site":{"site_url":"https://www.washingtonpost.com/future-of-transportation/"},"navigation":{"nav_title":"Future of Transportation"}},{"_id":"/technology/innovations","name":"Innovations","site":{"site_url":"https://www.washingtonpost.com/technology/innovations/"},"navigation":{"nav_title":"Innovations"}},{"_id":"/technology/internet-culture","name":"Internet Culture","site":{"site_url":"https://www.washingtonpost.com/internet-culture/"},"navigation":{"nav_title":"Internet Culture"}},{"_id":"/technology/space","name":"Space","site":{"site_url":"https://www.washingtonpost.com/space/"},"navigation":{"nav_title":"Space"}},{"_id":"/technology/tech-policy","name":"Tech Policy","site":{"site_url":"https://www.washingtonpost.com/tech-policy/"},"navigation":{"nav_title":"Tech Policy"}},{"_id":"/technology/video-gaming","name":"Video Gaming","site":{"site_url":"https://www.washingtonpost.com/technology/video-gaming/"},"navigation":{"nav_title":"Video Gaming"}}]},{"_id":"/world","name":"World","site":{"site_url":"https://www.washingtonpost.com/world/"},"navigation":{"nav_title":"World"},"children":[{"_id":"/world/africa","name":"Africa","site":{"site_url":"https://www.washingtonpost.com/world/africa/"},"navigation":{"nav_title":"Africa"}},{"_id":"/world/americas","name":"Americas","site":{"site_url":"https://www.washingtonpost.com/world/americas/"},"navigation":{"nav_title":"Americas"}},{"_id":"/world/asia-pacific","name":"Asia","site":{"site_url":"https://www.washingtonpost.com/world/asia-pacific/"},"navigation":{"nav_title":"Asia"}},{"_id":"/world/europe","name":"Europe","site":{"site_url":"https://www.washingtonpost.com/world/europe/"},"navigation":{"nav_title":"Europe"}},{"_id":"/world/middle-east","name":"Middle East","site":{"site_url":"https://www.washingtonpost.com/world/middle-east/"},"navigation":{"nav_title":"Middle East"}}]},{"_id":"/local","name":"D.C., Md. \u0026 Va.","site":{"site_url":"https://www.washingtonpost.com/local/"},"navigation":{"nav_title":"D.C., Md. \u0026 Va."},"children":[{"_id":"/local/dc","name":"The District","site":{"site_url":"http://www.washingtonpost.com/local/dc/"},"navigation":{"nav_title":"The District"}},{"_id":"/local/maryland","name":"Maryland","site":{"site_url":"https://www.washingtonpost.com/local/maryland/"},"navigation":{"nav_title":"Maryland"}},{"_id":"/local/virginia","name":"Virginia","site":{"site_url":"https://www.washingtonpost.com/local/virginia/"},"navigation":{"nav_title":"Virginia"}},{"_id":"/local/public-safety","name":"Local Crime \u0026 Public Safety","site":{"site_url":"https://www.washingtonpost.com/local/public-safety/"},"navigation":{"nav_title":"Crime \u0026 Public Safety"}},{"_id":"/local/education","name":"Local Education","site":{"site_url":"https://www.washingtonpost.com/local/education/"},"navigation":{"nav_title":"Education"}},{"_id":"/entertainment/going-out-guide","name":"Going Out Guide","site":{"site_url":"https://www.washingtonpost.com/goingoutguide/"},"navigation":{"nav_title":"Going Out Guide"}},{"_id":"/entertainment/restaurants","name":"Restaurants \u0026 Bars","site":{"site_url":"https://www.washingtonpost.com/goingoutguide/restaurants/"},"navigation":{"nav_title":"Restaurants \u0026 Bars"}},{"_id":"/local/traffic-commuting","name":"Local Transportation","site":{"site_url":"http://www.washingtonpost.com/local/traffic-commuting/"},"navigation":{"nav_title":"Transportation"}}]},{"_id":"/sports","name":"Sports","site":{"site_url":"https://www.washingtonpost.com/sports/"},"navigation":{"nav_title":"Sports"},"children":[{"_id":"/sports/nfl","name":"NFL","site":{"site_url":"https://www.washingtonpost.com/sports/nfl/"},"navigation":{"nav_title":"NFL"}},{"_id":"/sports/mlb","name":"MLB","site":{"site_url":"https://www.washingtonpost.com/sports/mlb/"},"navigation":{"nav_title":"MLB"}},{"_id":"/sports/nba","name":"NBA","site":{"site_url":"https://www.washingtonpost.com/sports/nba/"},"navigation":{"nav_title":"NBA"}},{"_id":"/sports/nhl","name":"NHL","site":{"site_url":"https://www.washingtonpost.com/sports/nhl/"},"navigation":{"nav_title":"NHL"}},{"_id":"/sports/boxing-mma","name":"Boxing \u0026 MMA","site":{"site_url":"https://www.washingtonpost.com/sports/boxing-mma/"},"navigation":{"nav_title":"Boxing \u0026 MMA"}},{"_id":"/sports/colleges","name":"College Sports","site":{"site_url":"https://www.washingtonpost.com/sports/colleges/"},"navigation":{"nav_title":"College Sports"}},{"_id":"/sports/dc-sports-bog","name":"D.C. Sports Bog","site":{"site_url":"https://www.washingtonpost.com/dc-sports-bog/"},"navigation":{"nav_title":"D.C. Sports Bog"}},{"_id":"/sports/golf","name":"Golf","site":{"site_url":"https://www.washingtonpost.com/sports/golf/"},"navigation":{"nav_title":"Golf"}},{"_id":"/sports/highschools","name":"High School Sports","site":{"site_url":"https://www.washingtonpost.com/allmetsports/"},"navigation":{"nav_title":"High School Sports"}},{"_id":"/sports/olympics","name":"Olympics","site":{"site_url":"https://www.washingtonpost.com/sports/olympics/"},"navigation":{"nav_title":"Olympics"}},{"_id":"/sports/soccer","name":"Soccer","site":{"site_url":"https://www.washingtonpost.com/sports/soccer/"},"navigation":{"nav_title":"Soccer"}},{"_id":"/sports/tennis","name":"Tennis","site":{"site_url":"https://www.washingtonpost.com/sports/tennis/"},"navigation":{"nav_title":"Tennis"}},{"_id":"/sports/wnba","name":"WNBA","site":{"site_url":"https://www.washingtonpost.com/sports/wnba/"},"navigation":{"nav_title":"WNBA"}}]},{"_id":"/topics/floyd-protests","name":"Race and Reckoning","site":{"site_url":"https://www.washingtonpost.com/race-america/"},"navigation":{"nav_title":"Race \u0026 Reckoning"},"children":[]},{"_id":"/entertainment","name":"Arts \u0026 Entertainment","site":{"site_url":"https://www.washingtonpost.com/entertainment/"},"navigation":{"nav_title":"Arts \u0026 Entertainment"},"children":[{"_id":"/entertainment/books","name":"Books","site":{"site_url":"https://www.washingtonpost.com/entertainment/books/"},"navigation":{"nav_title":"Books"}},{"_id":"/entertainment/movies","name":"Movies","site":{"site_url":"https://www.washingtonpost.com/goingoutguide/movies/"},"navigation":{"nav_title":"Movies"}},{"_id":"/entertainment/museums","name":"Museums","site":{"site_url":"https://www.washingtonpost.com/goingoutguide/museums/"},"navigation":{"nav_title":"Museums"}},{"_id":"/entertainment/music","name":"Music","site":{"site_url":"https://www.washingtonpost.com/goingoutguide/music/"},"navigation":{"nav_title":"Music"}},{"_id":"/entertainment/pop-culture","name":"Pop Culture","site":{"site_url":"https://www.washingtonpost.com/pop-culture/"},"navigation":{"nav_title":"Pop Culture"}},{"_id":"/entertainment/theater-dance","name":"Theater \u0026 Dance","site":{"site_url":"https://www.washingtonpost.com/goingoutguide/theater-dance/"},"navigation":{"nav_title":"Theater \u0026 Dance"}},{"_id":"/entertainment/tv","name":"TV","site":{"site_url":"https://www.washingtonpost.com/entertainment/tv/"},"navigation":{"nav_title":"TV"}}]},{"_id":"/business","name":"Business","site":{"site_url":"https://www.washingtonpost.com/business/"},"navigation":{"nav_title":"Business"},"children":[{"_id":"/us-policy/economic-policy","name":"Economic Policy","site":{"site_url":"https://www.washingtonpost.com/economic-policy/"},"navigation":{"nav_title":"Economic Policy"}},{"_id":"/business/economy","name":"Economy","site":{"site_url":"https://www.washingtonpost.com/economy/"},"navigation":{"nav_title":"Economy"}},{"_id":"/business/energy","name":"Energy","site":{"site_url":"https://www.washingtonpost.com/energy/"},"navigation":{"nav_title":"Energy"}},{"_id":"/business/health-care","name":"Health Care","site":{"site_url":"https://www.washingtonpost.com/health-care/"},"navigation":{"nav_title":"Health Care"}},{"_id":"/business/markets","name":"Markets","site":{"site_url":"https://www.washingtonpost.com/markets/"},"navigation":{"nav_title":"Markets"}},{"_id":"/business/personal-finance","name":"Personal Finance","site":{"site_url":"https://www.washingtonpost.com/personal-finance/"},"navigation":{"nav_title":"Personal Finance"}},{"_id":"/realestate","name":"Real Estate","site":{"site_url":"https://www.washingtonpost.com/realestate/"},"navigation":{"nav_title":"Real Estate"}},{"_id":"/business/on-small-business","name":"Small Business","site":{"site_url":"https://www.washingtonpost.com/business/on-small-business/"},"navigation":{"nav_title":"Small Business"}}]},{"_id":"/climate-environment","name":"Climate \u0026 Environment","site":{"site_url":"https://www.washingtonpost.com/climate-environment/"},"navigation":{"nav_title":"Climate \u0026 Environment"},"children":[]},{"_id":"/climate-environment/climate-solutions","name":"Climate Solutions","site":{"site_url":"https://www.washingtonpost.com/climate-solutions/"},"navigation":{"nav_title":"Climate Solutions"},"children":[]},{"_id":"/topics/coronavirus","name":"Coronavirus","site":{"site_url":"https://www.washingtonpost.com/coronavirus/"},"navigation":{"nav_title":"Coronavirus"},"children":[{"_id":"/topics/coronavirus/living","name":"Coronavirus Living","site":{"site_url":"https://www.washingtonpost.com/coronavirus/living/"},"navigation":{"nav_title":"Life at Home"}}]},{"_id":"/education","name":"Education","site":{"site_url":"https://www.washingtonpost.com/education/"},"navigation":{"nav_title":"Education"},"children":[{"_id":"/education/higher-education","name":"Higher Education","site":{"site_url":"https://www.washingtonpost.com/higher-education/"},"navigation":{"nav_title":"Higher Education"}}]},{"_id":"/lifestyle/food","name":"Food","site":{"site_url":"https://www.washingtonpost.com/food/"},"navigation":{"nav_title":"Food"},"children":[{"_id":"/lifestyle/food/voraciously","name":"Voraciously","site":{"site_url":"https://www.washingtonpost.com/news/voraciously/"},"navigation":{"nav_title":"Voraciously"}}]},{"_id":"/health","name":"Health","site":{"site_url":"https://www.washingtonpost.com/health/"},"navigation":{"nav_title":"Health"},"children":[{"_id":"/health/medical-mysteries","name":"Medical Mysteries","site":{"site_url":"https://www.washingtonpost.com/health/medical-mysteries/"},"navigation":{"nav_title":"Medical Mysteries"}},{"_id":"/lifestyle/wellness","name":"Wellness","site":{"site_url":"https://www.washingtonpost.com/lifestyle/wellness/"},"navigation":{"nav_title":"Wellness"}}]},{"_id":"/history","name":"History","site":{"site_url":"https://www.washingtonpost.com/history/"},"navigation":{"nav_title":"History"},"children":[{"_id":"/opinions/made-by-history","name":"Made by History","site":{"site_url":"https://www.washingtonpost.com/made-by-history/"},"navigation":{"nav_title":"Made by History"}},{"_id":"/local/retropolis","name":"Retropolis","site":{"site_url":"https://www.washingtonpost.com/retropolis/"},"navigation":{"nav_title":"Retropolis"}}]},{"_id":"/immigration","name":"Immigration","site":{"site_url":"https://www.washingtonpost.com/immigration/"},"navigation":{"nav_title":"Immigration"},"children":[]},{"_id":"/lifestyle","name":"Lifestyle","site":{"site_url":"https://www.washingtonpost.com/lifestyle/"},"navigation":{"nav_title":"Lifestyle"},"children":[{"_id":"/lifestyle/advice","name":"Advice","site":{"site_url":"https://www.washingtonpost.com/lifestyle/advice/"},"navigation":{"nav_title":"Advice"}},{"_id":"/lifestyle/fashion","name":"Fashion","site":{"site_url":"https://www.washingtonpost.com/lifestyle/fashion/"},"navigation":{"nav_title":"Fashion"}},{"_id":"/lifestyle/home-garden","name":"Home \u0026 Garden","site":{"site_url":"https://www.washingtonpost.com/lifestyle/home-garden/"},"navigation":{"nav_title":"Home \u0026 Garden"}},{"_id":"/lifestyle/inspired-life","name":"Inspired Life","site":{"site_url":"https://www.washingtonpost.com/inspired-life/"},"navigation":{"nav_title":"Inspired Life"}},{"_id":"/lifestyle/kidspost","name":"KidsPost","site":{"site_url":"https://www.washingtonpost.com/lifestyle/kidspost/"},"navigation":{"nav_title":"KidsPost"}},{"_id":"/lifestyle/on-parenting","name":"Parenting","site":{"site_url":"https://www.washingtonpost.com/lifestyle/on-parenting/"},"navigation":{"nav_title":"Parenting"}},{"_id":"/lifestyle/relationships","name":"Relationships","site":{"site_url":"https://www.washingtonpost.com/relationships/"},"navigation":{"nav_title":"Relationships"}},{"_id":"/lifestyle/travel","name":"Travel","site":{"site_url":"https://www.washingtonpost.com/lifestyle/travel/"},"navigation":{"nav_title":"Travel"}}]},{"_id":"/lifestyle/magazine","name":"The Washington Post Magazine","site":{"site_url":"https://www.washingtonpost.com/lifestyle/magazine/"},"navigation":{"nav_title":"Magazine"},"children":[]},{"_id":"/lifestyle/media","name":"Media","site":{"site_url":"https://www.washingtonpost.com/media/"},"navigation":{"nav_title":"Media"},"children":[]},{"_id":"/national","name":"National","site":{"site_url":"https://www.washingtonpost.com/national/"},"navigation":{"nav_title":"National"},"children":[]},{"_id":"/national-security","name":"National Security","site":{"site_url":"https://www.washingtonpost.com/national-security/"},"navigation":{"nav_title":"National Security"},"children":[{"_id":"/national-security/foreign-policy","name":"Foreign Policy","site":{"site_url":"https://www.washingtonpost.com/foreign-policy/"},"navigation":{"nav_title":"Foreign Policy"}},{"_id":"/national-security/justice","name":"Justice","site":{"site_url":"https://www.washingtonpost.com/justice/"},"navigation":{"nav_title":"Justice"}},{"_id":"/national-security/military","name":"Military","site":{"site_url":"https://www.washingtonpost.com/military/"},"navigation":{"nav_title":"Military"}}]},{"_id":"/local/obituaries","name":"Obituaries","site":{"site_url":"https://www.washingtonpost.com/local/obituaries/"},"navigation":{"nav_title":"Obituaries"},"children":[]},{"_id":"/opinions/outlook","name":"Outlook","site":{"site_url":"https://www.washingtonpost.com/outlook/"},"navigation":{"nav_title":"Outlook"},"children":[{"_id":"/opinions/book-party","name":"Book Party","site":{"site_url":"https://www.washingtonpost.com/book-party/"},"navigation":{"nav_title":"Book Party"}},{"_id":"/opinions/five-myths","name":"Five Myths","site":{"site_url":"https://www.washingtonpost.com/outlook/five-myths/"},"navigation":{"nav_title":"Five Myths"}},{"_id":"/opinions/posteverything","name":"PostEverything","site":{"site_url":"https://www.washingtonpost.com/news/posteverything/"},"navigation":{"nav_title":"PostEverything"}}]},{"_id":"/religion","name":"Religion","site":{"site_url":"https://www.washingtonpost.com/religion/"},"navigation":{"nav_title":"Religion"},"children":[]},{"_id":"/science","name":"Science","site":{"site_url":"https://www.washingtonpost.com/science/"},"navigation":{"nav_title":"Science"},"children":[{"_id":"/science/animals","name":"Animals","site":{"site_url":"https://www.washingtonpost.com/animals/"},"navigation":{"nav_title":"Animals"}}]},{"_id":"/topics/biden-transfer","name":"First 100 Days","site":{"site_url":"https://www.washingtonpost.com/politics/joe-biden-46th-president/"},"navigation":{"nav_title":"First 100 Days"},"children":[]},{"_id":"/transportation","name":"Transportation","site":{"site_url":"https://www.washingtonpost.com/transportation/"},"navigation":{"nav_title":"Transportation"},"children":[]},{"_id":"/local/weather","name":"Weather","site":{"site_url":"https://www.washingtonpost.com/local/weather/"},"navigation":{"nav_title":"Weather"},"children":[]},{"_id":"/travel","name":"By The Way - Travel","site":{"site_url":"https://www.washingtonpost.com/travel/"},"navigation":{"nav_title":"By The Way"},"children":[]},{"_id":"/lifestyle/carolyn-hax","name":"Carolyn Hax","site":{"site_url":"https://www.washingtonpost.com/people/carolyn-hax/"},"navigation":{"nav_title":"Carolyn Hax"},"children":[]},{"_id":"/columns/about-us","name":"About US","site":{"site_url":"https://www.washingtonpost.com/about-us/"},"navigation":{"nav_title":"About US"},"children":[]},{"_id":"/sports/launcher","name":"Video Games","site":{"site_url":"https://www.washingtonpost.com/video-games/"},"navigation":{"nav_title":"Launcher"},"children":[]},{"_id":"/the-lily","name":"The Lily","site":{"site_url":"https://www.thelily.com/"},"navigation":{"nav_title":"The Lily"},"children":[]},{"_id":"/national/morning-mix","name":"Morning Mix","site":{"site_url":"https://www.washingtonpost.com/morning-mix/"},"navigation":{"nav_title":"Morning Mix"},"children":[]},{"_id":"/photography","name":"Photography","site":{"site_url":"https://www.washingtonpost.com/photography/"},"navigation":{"nav_title":"Photography"},"children":[{"_id":"/photography/in-sight","name":"In Sight","site":{"site_url":"http://www.washingtonpost.com/photography/in-sight/"},"navigation":{"nav_title":"In Sight"}}]},{"_id":"/podcasts","name":"Podcasts","site":{"site_url":"https://www.washingtonpost.com/podcasts/"},"navigation":{"nav_title":"Podcasts"},"children":[]},{"_id":"/video","name":"Video","site":{"site_url":"https://www.washingtonpost.com/video/"},"navigation":{"nav_title":"Video"},"children":[{"_id":"/video/top-news","name":"Top News Video","site":{"site_url":"https://www.washingtonpost.com/posttv/c/video/topic/topnews"},"navigation":{"nav_title":"Top News"}},{"_id":"/video/business","name":"Business Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/business"},"navigation":{"nav_title":"Business"}},{"_id":"/video/entertainment","name":"Entertainment Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/entertainment"},"navigation":{"nav_title":"Entertainment"}},{"_id":"/video/local","name":"Local Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/local"},"navigation":{"nav_title":"Local"}},{"_id":"/video/national","name":"National Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/national"},"navigation":{"nav_title":"National"}},{"_id":"/video/opinions","name":"Opinions Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/opinions"},"navigation":{"nav_title":"Opinions"}},{"_id":"/video/politics","name":"Politics Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/politics"},"navigation":{"nav_title":"Politics"}},{"_id":"/video/sports","name":"Sports Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/sports"},"navigation":{"nav_title":"Sports"}},{"_id":"/video/style","name":"Style Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/style"},"navigation":{"nav_title":"Style"}},{"_id":"/video/technology","name":"Technology Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/tech"},"navigation":{"nav_title":"Technology"}},{"_id":"/video/world","name":"World Video","site":{"site_url":"https://www.washingtonpost.com/video/topic/world"},"navigation":{"nav_title":"World"}}]},{"_id":"/crosswords","name":"Crosswords","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/"},"navigation":{"nav_title":"Crosswords"},"children":[{"_id":"/crosswords/daily","name":"Daily Crossword","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/daily/"},"navigation":{"nav_title":"Daily"}},{"_id":"/crosswords/mini-meta","name":"Daily Mini Meta Crossword","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/mini-meta/"},"navigation":{"nav_title":"Daily Mini (+Weekly Meta)"}},{"_id":"/crosswords/sunday","name":"Sunday Crossword","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/sunday-evan-birnholz/"},"navigation":{"nav_title":"Sunday Crossword"}},{"_id":"/crosswords/merl-reagle","name":"Classic Crosswords","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/merl-reagle/"},"navigation":{"nav_title":"Classic"}},{"_id":"/crosswords/monthly-music-meta","name":"Monthly Music Meta","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/monthly-music-meta/"},"navigation":{"nav_title":"Monthly Meta"}}]},{"_id":"/live-chats","name":"Live Chats","site":{"site_url":"https://washingtonpost.com/live-chats/"},"navigation":{"nav_title":"Live Chats"},"children":[]},{"_id":"/newsletters-alerts","name":"Newsletters \u0026 Alerts","site":{"site_url":"https://washingtonpost.com/newsletters/"},"navigation":{"nav_title":"Newsletters \u0026 Alerts"},"children":[]},{"_id":"/entertainment/puzzles-and-games","name":"Puzzles \u0026 Games","site":{"site_url":"https://games.washingtonpost.com/"},"navigation":{"nav_title":"Puzzles \u0026 Games"},"children":[{"_id":"/entertainment/comics","name":"Comics","site":{"site_url":"https://www.washingtonpost.com/entertainment/comics/"},"navigation":{"nav_title":"Comics"}},{"_id":"/entertainment/horoscopes","name":"Horoscopes","site":{"site_url":"https://www.washingtonpost.com/entertainment/horoscopes/"},"navigation":{"nav_title":"Horoscopes"}}]},{"_id":"/washington-post-live","name":"Washington Post Live","site":{"site_url":"https://www.washingtonpost.com/washington-post-live/"},"navigation":{"nav_title":"Washington Post Live"},"children":[]},{"_id":"/jobs","name":"Jobs","site":{"site_url":"https://jobs.washingtonpost.com/"},"navigation":{"nav_title":"Jobs"},"children":[]},{"_id":"/classifieds","name":"Classifieds","site":{"site_url":"https://www.washingtonpost.com/classifieds/"},"navigation":{"nav_title":"Classifieds"},"children":[]},{"_id":"/brandconnect","name":"WP BrandStudio","site":{"site_url":"https://www.washingtonpost.com/brand-studio/archive/"},"navigation":{"nav_title":"WP BrandStudio"},"children":[]}]},"{\"source\":\"site-account-sidebar\"}":{"children":[{"_id":"/account-sidebar/my-post","name":"My Post","site":{"site_url":"https://www.washingtonpost.com/my-post?tid=nav_acctmgnt_menu","additional_info":{"authenticatedOnly":"true","subscriberOnly":"false"}}},{"_id":"/account-sidebar/my-reading-list","name":"My Reading List","site":{"site_url":"https://www.washingtonpost.com/my-post/#/my-reading-list?tid=nav_acctmgnt_menu","additional_info":{"authenticatedOnly":"true","subscriberOnly":"true"}}},{"_id":"/account-sidebar/account-settings","name":"Account Settings","site":{"site_url":"https://subscribe.washingtonpost.com/profile/#/?destination=https://www.washingtonpost.com/?refresh=true\u0026tid=nav_acctmgnt_menu","additional_info":{"authenticatedOnly":"true","subscriberOnly":"false"}}},{"_id":"/account-sidebar/newsletters-and-alerts","name":"Newsletters \u0026 Alerts","site":{"site_url":"https://subscribe.washingtonpost.com/newsletters?tid=nav_acctmgnt_menu"}},{"_id":"/account-sidebar/gift-subscriptions","name":"Gift subscriptions","site":{"site_url":"https://subscribe.washingtonpost.com/gift?promo=g_d\u0026tid=nav_acctmgnt_menu"}},{"_id":"/account-sidebar/contact-us","name":"Contact us","site":{"site_url":"https://helpcenter.washingtonpost.com/hc/en-us"}},{"_id":"/account-sidebar/help-desk","name":"Help desk","site":{"site_url":"https://helpcenter.washingtonpost.com/hc/en-us"}}]},"{\"source\":\"site-menu\",\"query\":{\"hierarchy\":\"secondary-nav\"}}":{"children":[{"_id":"/politics","name":"Politics","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/politics/"},"navigation":{"nav_title":"Politics"},"children":[{"_id":"link-6ZGW30B05T5QTC3WTTD5PEDHFM","url":"https://www.washingtonpost.com/politics/2021/03/08/joe-biden-live-updates/","display_name":"Live updates","node_type":"link","children":[]},{"_id":"/politics/powerpost","name":"PowerPost","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/politics/powerpost/"},"navigation":{"nav_title":"Congress"},"children":[]},{"_id":"/politics/courts-law","name":"Courts \u0026 Law","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/politics/courts-law/"},"navigation":{"nav_title":"Courts \u0026 Law"},"children":[]},{"_id":"/politics/fact-checker","name":"Fact Checker","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/news/fact-checker/"},"navigation":{"nav_title":"Fact Checker"},"children":[]},{"_id":"link-DDKPRFCMZX5Y9DZZHEGKEAUGV0","url":"https://www.washingtonpost.com/the-fix/","display_name":"The Fix","node_type":"link","children":[]},{"_id":"link-HFGMKPE0A536TBBW75XMBZMKPG","url":"https://www.washingtonpost.com/monkey-cage/","display_name":"Monkey Cage","node_type":"link","children":[]},{"_id":"/politics/polling","name":"Polling","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/politics/polling/"},"navigation":{"nav_title":"Polling"},"children":[]},{"_id":"link-JKGUW47YWX7X7FDW85ZZGENMAM","url":"https://www.washingtonpost.com/politics/joe-biden-46th-president/","display_name":"White House","node_type":"link","children":[]}]},{"_id":"/entertainment","name":"Arts \u0026 Entertainment","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/entertainment/"},"navigation":{"nav_title":"Arts \u0026 Entertainment"},"children":[{"_id":"/entertainment/books","name":"Books","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/entertainment/books/"},"navigation":{"nav_title":"Books"},"children":[]},{"_id":"link-EN0UXCF7NX5N3458ZP2Q547MBM","url":"https://www.washingtonpost.com/goingoutguide/movies/","display_name":"Movies","node_type":"link","children":[]},{"_id":"link-1A7CP1YGKX39X3TCXXGZK3K9ZC","url":"https://www.washingtonpost.com/goingoutguide/music/","display_name":"Music","node_type":"link","children":[]},{"_id":"link-PDNHNPY73900FF7G71PB6DZM1G","url":"https://www.washingtonpost.com/goingoutguide/museums/","display_name":"Museums","node_type":"link","children":[]},{"_id":"link-20NG7E7R7X0DF1ZJR8H0ZD0724","url":"https://www.washingtonpost.com/goingoutguide/theater-dance/","display_name":"Theater \u0026 Dance","node_type":"link","children":[]},{"_id":"/entertainment/tv","name":"TV","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/entertainment/tv/"},"navigation":{"nav_title":"TV"},"children":[]},{"_id":"/entertainment/comics","name":"Comics","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/entertainment/comics/"},"navigation":{"nav_title":"Comics"},"children":[]},{"_id":"link-XZBCGV7AVX6U13Y5CAUKFJ4618","url":"https://www.washingtonpost.com/goingoutguide/","display_name":"Going Out Guide","node_type":"link","children":[]},{"_id":"link-86B2VQNZY53YDFR78G9DTYB8D4","url":"https://www.washingtonpost.com/crossword-puzzles/","display_name":"Crosswords","node_type":"link","children":[]}]},{"_id":"/technology","name":"Technology","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/business/technology/"},"navigation":{"nav_title":"Tech"},"children":[{"_id":"link-EQV4T77A6X2RV3UCCC1J0YEW0M","url":"https://www.washingtonpost.com/consumer-tech/","display_name":"Consumer Tech","node_type":"link","children":[]},{"_id":"link-NEUE9V8R0X7C3FUW2M1EWM4BXM","url":"https://www.washingtonpost.com/future-of-transportation/","display_name":"Future of Transportation","node_type":"link","children":[]},{"_id":"/technology/innovations","name":"Innovations","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/technology/innovations/"},"navigation":{"nav_title":"Innovations"},"children":[]},{"_id":"link-KJAT70VQYD45HBFG52CFNRYDDW","url":"https://www.washingtonpost.com/internet-culture/","display_name":"Internet Culture","node_type":"link","children":[]},{"_id":"link-UD33NEMB4N045APNW2J0N92VCG","url":"https://www.washingtonpost.com/space/","display_name":"Space","node_type":"link","children":[]},{"_id":"link-450B8JKAJT05376677KEG9VUD0","url":"https://www.washingtonpost.com/tech-policy/","display_name":"Tech Policy","node_type":"link","children":[]},{"_id":"/technology/video-gaming","name":"Video Gaming","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/technology/video-gaming/"},"navigation":{"nav_title":"Video Gaming"},"children":[]}]},{"_id":"/opinions","name":"Opinions","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/opinions/"},"navigation":{"nav_title":"Opinions"},"children":[{"_id":"link-NA2UNH9J8H5578D50C1HY1R3J4","url":"https://www.washingtonpost.com/opinions/the-posts-view/","display_name":"Editorial Board","node_type":"link","children":[]},{"_id":"link-G0QA21B2WN0WQDPJ5V0EFKFW30","url":"https://www.washingtonpost.com/the-opinions-essay/","display_name":"The Opinions Essay","node_type":"link","children":[]},{"_id":"link-T5QN4AF0KD0G15671ZTKHNX8DG","url":"https://www.washingtonpost.com/global-opinions/","display_name":"Global Opinions","node_type":"link","children":[]},{"_id":"link-EX19HC7U590857FRQ16EFJ6AAM","url":"https://www.washingtonpost.com/opinions/biden-administration/","display_name":"First 100 Days","node_type":"link","children":[]},{"_id":"link-CER8JVU4DT1V39MR5VQ6486P64","url":"https://www.washingtonpost.com/opinions/local-opinions/","display_name":"D.C., Md. \u0026 Va.","node_type":"link","children":[]},{"_id":"link-E37NA2WR4N2GH4C5E3MRTYUXCM","url":"https://www.washingtonpost.com/opinions/cartoons/","display_name":"Cartoons","node_type":"link","children":[]},{"_id":"link-5Y98PFVNF939X76WYYWRX5E338","url":"https://www.washingtonpost.com/podcasts/cape-up/","display_name":"Cape Up","node_type":"link","children":[]},{"_id":"link-AM5BN25REX25V3UXMPYW91JAE0","url":"https://www.washingtonpost.com/es/post-opinion/","display_name":"Post Opinión","node_type":"link","children":[]},{"_id":"link-EKEZEUF6HX3TQ7WAGVQKGG957W","url":"https://www.washingtonpost.com/posttv/c/video/topic/opinions","display_name":"Video","node_type":"link","children":[]},{"_id":"link-TMG3008VA91V72NREY794NEDF0","url":"https://www.washingtonpost.com/opinions/letters-to-the-editor/","display_name":"Letters","node_type":"link","children":[]}]},{"_id":"/opinions/global-opinions","name":"Global Opinions","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/global-opinions/"},"navigation":{"nav_title":"Global Opinions"},"children":[{"_id":"link-920QWR0Y4924T72J4RNVW47TVM","url":"https://www.washingtonpost.com/opinions/","display_name":"Opinions","node_type":"link","children":[]},{"_id":"link-G2MKHX0C1D5HK0RVCJRTCDFWDC","url":"https://www.washingtonpost.com/es/post-opinion/","display_name":"Post Opinión","node_type":"link","children":[]},{"_id":"link-46GTZ5EXJH5J995HHTKNFCZ9G8","url":"https://www.washingtonpost.com/post-opinions-arabic/","display_name":"Post Opinions Arabic","node_type":"link","children":[]},{"_id":"link-JJK18QKKYX4B1DZYXRH6PKKCUM","url":"https://www.washingtonpost.com/opinions/the-posts-view/","display_name":"Editorial Board","node_type":"link","children":[]},{"_id":"link-0HP3KM7N211AVC0RKFCUE7FZYM","url":"https://www.washingtonpost.com/the-opinions-essay/","display_name":"The Opinions Essay","node_type":"link","children":[]}]},{"_id":"/sports/capitals","name":"Washington Capitals","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/capitals/"},"navigation":{"nav_title":"Capitals"},"children":[{"_id":"link-QV8GR3FZPD60KEUXP6KCDTGAZW","url":"http://stats.washingtonpost.com/nhl/teamstats.asp?teamno=23\u0026type=schedule","display_name":"Schedule","node_type":"link","children":[]},{"_id":"link-V19XN409Z129KD87PUJ61ZGZ98","url":"http://stats.washingtonpost.com/nhl/standings_conference.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-1PJ7H310G54H123W5E7PBYG7KC","url":"http://stats.washingtonpost.com/nhl/teamstats.asp?teamno=23\u0026type=stats","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-4PGR3NZ1WN6XB175H9BDMEHMVG","url":"http://stats.washingtonpost.com/nhl/teamstats.asp?teamno=23\u0026type=injuries","display_name":"Injuries","node_type":"link","children":[]},{"_id":"link-WVBMMJH9QX5A578KQ31ZKQ73V4","url":"http://stats.washingtonpost.com/nhl/teamstats.asp?teamno=23\u0026type=transactions","display_name":"Transactions","node_type":"link","children":[]},{"_id":"link-U7G2Y49CZ909K6ZD2QT4A904VR","url":"https://www.washingtonpost.com/sports/nhl/","display_name":"NHL","node_type":"link","children":[]}]},{"_id":"/sports/nationals","name":"Washington Nationals","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/nationals/"},"navigation":{"nav_title":"Nationals"},"children":[{"_id":"link-FUUZW06KQN39Q39HUR97C5BRMM","url":"http://stats.washingtonpost.com/mlb/scoreboard.asp","display_name":"Schedule","node_type":"link","children":[]},{"_id":"link-H1P41PRPVN1T37XHD7WGK58JM4","url":"http://stats.washingtonpost.com/mlb/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-KHZEFZKMNT5M5CUGUW2P9HHKC0","url":"http://stats.washingtonpost.com/mlb/scoreboard.asp","display_name":"Scoreboard","node_type":"link","children":[]},{"_id":"link-M8NT0TMT5D0UXDG1DTVED84GXM","url":"http://stats.washingtonpost.com/mlb/teamstats.asp?team=20\u0026type=stats","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-PXH3ZEZGQD2D906XZX6KJUM7JC","url":"https://www.washingtonpost.com/sports/mlb/","display_name":"MLB","node_type":"link","children":[]},{"_id":"link-6BJ18QQPX91HTCAM3CY8B7280M","url":"http://stats.washingtonpost.com/mlb/teamstats.asp?team=20\u0026type=injuries","display_name":"Injuries","node_type":"link","children":[]},{"_id":"link-UA9AKVEA4N1ZT3KDPGNH7C0GUR","url":"http://stats.washingtonpost.com/mlb/teamstats.asp?team=20\u0026type=depth","display_name":"Depth Chart","node_type":"link","children":[]},{"_id":"link-2FF8G8R6950X1CZZ2EFQNWX0QM","url":"http://stats.washingtonpost.com/mlb/teamstats.asp?team=20\u0026type=trans","display_name":"Transactions","node_type":"link","children":[]}]},{"_id":"/sports/wizards","name":"Washington Wizards","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/wizards/"},"navigation":{"nav_title":"Wizards"},"children":[{"_id":"link-ER87A480V174DDMWXVPNYGC81W","url":"http://stats.washingtonpost.com/nba/teamstats.asp?type=schedule\u0026teamno=27","display_name":"Schedule","node_type":"link","children":[]},{"_id":"link-AXG5PZ5Q1H24N6M86EUNDXTC8R","url":"http://stats.washingtonpost.com/nba/teamstats.asp?teamno=27\u0026type=stats","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-JH03X7KB8X65N9U2Q4U9NR58M4","url":"http://stats.washingtonpost.com/nba/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-YFZUR28K390QH7DH1C6A00D57C","url":"https://www.washingtonpost.com/sports/nba/","display_name":"NBA","node_type":"link","children":[]}]},{"_id":"/sports/redskins","name":"Washington Football Team","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/washington-football/"},"navigation":{"nav_title":"Washington Football"},"children":[{"_id":"link-UTP9BBHZZH36TF2X7C4G1RR8FW","url":"https://www.washingtonpost.com/sports/nfl/","display_name":"NFL news","node_type":"link","children":[]},{"_id":"link-C4YWB68XBT4154RCATHX4W6QXC","url":"http://stats.washingtonpost.com/fb/scoreboard.asp","display_name":"Scoreboard","node_type":"link","children":[]},{"_id":"link-BCXHR9VGG564T45JG0Y9HXKKZG","url":"http://stats.washingtonpost.com/fb/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-E1MYPQQG794WQ9PH54ZP1DUC9C","url":"http://stats.washingtonpost.com/fb/teamstats.asp?teamno=28\u0026type=stats","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-K6EX81DU993KZ3VPVH5RHJ4008","url":"http://stats.washingtonpost.com/fb/teamstats.asp?tm=28\u0026type=roster","display_name":"Roster","node_type":"link","children":[]},{"_id":"link-5X516AN37X38VDRMCDXRER0D5C","url":"http://stats.washingtonpost.com/fb/teamstats.asp?tm=28\u0026type=injuries","display_name":"Injuries","node_type":"link","children":[]},{"_id":"link-7CB2A105AX0BBECTC3XKFGXGDW","url":"http://stats.washingtonpost.com/fb/teamstats.asp?teamno=28\u0026type=transactions","display_name":"Transactions","node_type":"link","children":[]}]},{"_id":"/sports/nhl","name":"NHL","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/nhl/"},"navigation":{"nav_title":"NHL"},"children":[{"_id":"link-JZZD17TPTT67D60H353YUQVVK0","url":"http://stats.washingtonpost.com/nhl/scoreboard.asp","display_name":"Scoreboard","node_type":"link","children":[]},{"_id":"link-VV04T3QKXD541A23TGGV1803GG","url":"http://stats.washingtonpost.com/nhl/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-V85X2594BD61T8BNGJ6EXUENTR","url":"http://stats.washingtonpost.com/nhl/index.asp?season=reg","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-Y36KKHDJVT3VH8GHM25NB57B3C","url":"http://stats.washingtonpost.com/nhl/teams.asp","display_name":"Teams","node_type":"link","children":[]},{"_id":"link-10W9X84BED0HK1EX1ZAKPR8ACR","url":"https://www.washingtonpost.com/sports/capitals/","display_name":"Washington Capitals","node_type":"link","children":[]}]},{"_id":"/sports/mlb","name":"MLB","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/mlb/"},"navigation":{"nav_title":"MLB"},"children":[{"_id":"link-4Q0ANVFKC92V3DU8PFHCQF7RG8","url":"http://stats.washingtonpost.com/mlb/scoreboard.asp","display_name":"Scoreboard","node_type":"link","children":[]},{"_id":"link-V1BT10J8E53K33744NC9XT1GR8","url":"http://stats.washingtonpost.com/mlb/index.asp","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-6Q8YQ4UGC55378TWEC5HRCM7WM","url":"http://stats.washingtonpost.com/mlb/recentinj.asp","display_name":"Injuries","node_type":"link","children":[]},{"_id":"link-RGBR986HRD4GT1PE06PBV3F120","url":"http://stats.washingtonpost.com/mlb/recenttrans.asp","display_name":"Transactions","node_type":"link","children":[]},{"_id":"link-273R41VVC57EB5GEE0P7P4QK74","url":"https://www.washingtonpost.com/sports/nationals/","display_name":"Washington Nationals","node_type":"link","children":[]}]},{"_id":"/sports/nfl","name":"NFL","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/nfl/"},"navigation":{"nav_title":"NFL"},"children":[{"_id":"link-N6CB4VBDK57TTE31EF6DWA6R6C","url":"http://stats.washingtonpost.com/fb/scoreboard.asp","display_name":"Scoreboard","node_type":"link","children":[]},{"_id":"link-2XZPPZ0EAN6DH8G280HG15TX0W","url":"http://stats.washingtonpost.com/fb/index.asp","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-Z8FC81489162DCVW58NFYKDDG8","url":"http://stats.washingtonpost.com/fb/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-CE5BRCQ0M149Z9UD10RRBHW42G","url":"http://stats.washingtonpost.com/fb/teams.asp","display_name":"Teams","node_type":"link","children":[]},{"_id":"link-AMJJWDX2M16Z19U83WD0Y8HY7R","url":"http://stats.washingtonpost.com/fb/recenttrans.asp","display_name":"Transactions","node_type":"link","children":[]},{"_id":"link-9NBP77JM8N1C3DFFQX1MR09AY8","url":"https://www.washingtonpost.com/sports/washington-football/","display_name":"Washington Football","node_type":"link","children":[]}]},{"_id":"/sports/nba","name":"NBA","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/nba/"},"navigation":{"nav_title":"NBA"},"children":[{"_id":"link-YK9HH60F150DT190JP0DBU837M","url":"https://www.washingtonpost.com/graphics/2020/sports/nba-top-players-2020-2021/","display_name":"Top 100 Players","node_type":"link","children":[]},{"_id":"link-FRX5VTX4C17DB0Z59Q0EN4P77G","url":"http://stats.washingtonpost.com/nba/scoreboard.asp","display_name":"Scoreboard","node_type":"link","children":[]},{"_id":"link-D6FQFZWHAH5GTF8570CUQZ91AG","url":"http://stats.washingtonpost.com/nba/index.asp","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-MDR8MURK9103N5XM74YN6G7KNC","url":"http://stats.washingtonpost.com/nba/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-32AC46QR293HF8XJ25UDJ1VDDR","url":"http://stats.washingtonpost.com/nba/recentinj.asp","display_name":"Injuries","node_type":"link","children":[]},{"_id":"link-CTR2WDWKCH22H46DQAC4FHDU20","url":"http://stats.washingtonpost.com/nba/recenttrans.asp","display_name":"Transactions","node_type":"link","children":[]},{"_id":"link-63D1N6UB1D3F9DBXDKFTHKJ0C8","url":"https://www.washingtonpost.com/sports/wizards/","display_name":"Washington Wizards","node_type":"link","children":[]}]},{"_id":"/sports/soccer","name":"Soccer","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/soccer/"},"navigation":{"nav_title":"Soccer"},"children":[{"_id":"link-RPBK2UX6YX34K0475MA19WU9YW","url":"http://stats.washingtonpost.com/mls/schedules.asp?team=5","display_name":"D.C. United schedule","node_type":"link","children":[]},{"_id":"link-2FZPF4AQ4N53T91CRGFG6M85A4","url":"http://stats.washingtonpost.com/mls/scoreboard_daily.asp","display_name":"MLS scoreboard","node_type":"link","children":[]},{"_id":"link-H3EH68NAYD0ZD9165AFJQHBTJG","url":"http://stats.washingtonpost.com/epl/scoreboard_daily.asp","display_name":"Premier League","node_type":"link","children":[]},{"_id":"link-7A23DJ4BGT3G332XJJ5GBB7BAR","url":"http://stats.washingtonpost.com/bund/scoreboard_daily.asp","display_name":"Bundesliga","node_type":"link","children":[]},{"_id":"link-X4BKF5R2M56CN3ZAF4NF7NXUYC","url":"http://stats.washingtonpost.com/liga/scoreboard_daily.asp","display_name":"La Liga","node_type":"link","children":[]},{"_id":"link-FEM4D51NTT3CT0KG6XG8C2HM04","url":"http://stats.washingtonpost.com/seri/scoreboard_daily.asp","display_name":"Serie A","node_type":"link","children":[]},{"_id":"link-837N191KT92GKFCXF7WRAPRDER","url":"http://stats.washingtonpost.com/chlg/scoreboard_daily.asp","display_name":"UEFA Champions League","node_type":"link","children":[]}]},{"_id":"/sports/colleges","name":"College Sports","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/sports/colleges/"},"navigation":{"nav_title":"College Sports"},"children":[{"_id":"link-W0FF5ZBQGN087EZ40EMF2832QG","url":"https://www.washingtonpost.com/sports/2021/02/17/when-is-march-madness/","display_name":"March Madness","node_type":"link","children":[]},{"_id":"link-VKT8F0K8ZD5YV6EF2FF2CMY1Z0","url":"http://stats.washingtonpost.com/cbk/scoreboard.asp","display_name":"NCAA scoreboard","node_type":"link","children":[]},{"_id":"link-UWVXWXFQJ16MK9FM3839D3DFNW","url":"http://stats.washingtonpost.com/cbk/leaders.asp","display_name":"Stats","node_type":"link","children":[]},{"_id":"link-P0D7TXDM717Z1BARB7ZGQ8XNRG","url":"http://stats.washingtonpost.com/cbk/standings.asp","display_name":"Standings","node_type":"link","children":[]},{"_id":"link-GCMUDRPCJ95079KAHNYRJD392M","url":"http://stats.washingtonpost.com/cbk/polls.asp","display_name":"Polls","node_type":"link","children":[]},{"_id":"link-720CV5FG8H5WK9P8ZTEX9RAAPC","url":"http://stats.washingtonpost.com/wcbk/scoreboard.asp","display_name":"Women's scoreboard","node_type":"link","children":[]}]},{"_id":"/lifestyle/food","name":"Food","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/food/"},"navigation":{"nav_title":"Food"},"children":[{"_id":"link-9ZRXZGQ3KH6W34V9DZCG6PKE70","url":"https://www.washingtonpost.com/news/voraciously/","display_name":"Voraciously","node_type":"link","children":[]},{"_id":"link-4C7FGVNK612B95C9V504YD4H3M","url":"https://www.washingtonpost.com/recipes/","display_name":"Recipe Finder","node_type":"link","children":[]},{"_id":"link-65NMQZVD7X1KB7JFPMWMWX2VE4","url":"https://www.washingtonpost.com/goingoutguide/","display_name":"Going Out Guide","node_type":"link","children":[]},{"_id":"link-Q3B7BABADN47KE6W70CFAWPGNR","url":"https://www.washingtonpost.com/people/tom-sietsema/","display_name":"Tom Sietsema","node_type":"link","children":[]},{"_id":"link-AP1Z2TPEV12B9E6J6ZJKBEK1HG","url":"https://www.washingtonpost.com/people/tim-carman/","display_name":"Tim Carman","node_type":"link","children":[]},{"_id":"link-XV5R416PB94XQ5EMF8YQ5MBP74","url":"https://www.washingtonpost.com/people/ellie-krieger/","display_name":"Nourish","node_type":"link","children":[]},{"_id":"link-ZUUNBPP0DD61X1NCW794AEBYBC","url":"https://www.washingtonpost.com/recipes/search/?column=Dinner%20in%20Minutes","display_name":"Dinner in Minutes","node_type":"link","children":[]},{"_id":"link-2PWMEJZ7MT1MQ42R7Q5Q071QUM","url":"https://www.washingtonpost.com/people/dave-mcintyre/","display_name":"Wine","node_type":"link","children":[]},{"_id":"link-9FK4664Z9520Q47KBQ0N371FVM","url":"https://www.washingtonpost.com/people/m-carrie-allan/","display_name":"Spirits","node_type":"link","children":[]}]},{"_id":"/lifestyle","name":"Lifestyle","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/"},"navigation":{"nav_title":"Lifestyle"},"children":[{"_id":"/lifestyle/advice","name":"Advice","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/advice/"},"navigation":{"nav_title":"Advice"},"children":[]},{"_id":"link-EA900ZC66N1X12C4N1X0FAB05M","url":"https://www.washingtonpost.com/food/","display_name":"Food","node_type":"link","children":[]},{"_id":"/lifestyle/home-garden","name":"Home \u0026 Garden","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/home-garden/"},"navigation":{"nav_title":"Home \u0026 Garden"},"children":[]},{"_id":"link-ARZ9AXA2QD4KKC6Z4BCD7BZ6P0","url":"https://www.washingtonpost.com/lifestyle/kidspost/","display_name":"KidsPost","node_type":"link","children":[]},{"_id":"/lifestyle/magazine","name":"The Washington Post Magazine","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/magazine/"},"navigation":{"nav_title":"Magazine"},"children":[]},{"_id":"/lifestyle/on-parenting","name":"Parenting","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/on-parenting/"},"navigation":{"nav_title":"Parenting"},"children":[]},{"_id":"/lifestyle/travel","name":"Travel","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/travel/"},"navigation":{"nav_title":"Travel"},"children":[]},{"_id":"/lifestyle/wellness","name":"Wellness","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/wellness/"},"navigation":{"nav_title":"Wellness"},"children":[]}]},{"_id":"/lifestyle/kidspost","name":"KidsPost","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/lifestyle/kidspost/"},"navigation":{"nav_title":"KidsPost"},"children":[{"_id":"link-Y12UCPJN2T413B5XXBUVYGPR0R","url":"https://www.washingtonpost.com/lifestyle/kidspost/make-it/","display_name":"Crafts and Recipes","node_type":"link","children":[]},{"_id":"link-KJQ55W29U11WD7XBAN15CWV3UM","url":"https://www.washingtonpost.com/people/fred-bowen/","display_name":"Fred Bowen on Sports","node_type":"link","children":[]},{"_id":"link-4B3VXFN1M91MBD0UJ2VPBNREV0","url":"https://www.washingtonpost.com/lifestyle/kidspost/readers-corner/","display_name":"Readers' Corner","node_type":"link","children":[]},{"_id":"link-T2Y1KMFJJ50QN17TCYJCC815FG","url":"https://www.washingtonpost.com/lifestyle/kidspost/ever-wondered/","display_name":"Ever Wondered?","node_type":"link","children":[]}]},{"_id":"/national-security","name":"National Security","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/national-security/"},"navigation":{"nav_title":"National Security"},"children":[{"_id":"link-4NGF798K2N4RFDZF9JTVKV1VNR","url":"https://www.washingtonpost.com/foreign-policy/","display_name":"Foreign Policy","node_type":"link","children":[]},{"_id":"link-4HNVQY6A0H3D7FATZ4ZC13F334","url":"https://www.washingtonpost.com/justice/","display_name":"Justice","node_type":"link","children":[]},{"_id":"link-2FR5FYECEN5WDFFGM73TWRPN1R","url":"https://www.washingtonpost.com/military/","display_name":"Military","node_type":"link","children":[]}]},{"_id":"/elections","name":"Elections","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/elections/"},"navigation":{"nav_title":"Election 2020"},"children":[{"_id":"link-AGPA374MF11GXBKPZCGC3FHJGR","url":"https://www.washingtonpost.com/politics/2021/01/06/georgia-senate-election-results-live-updates/","display_name":"Live updates","node_type":"link","children":[]},{"_id":"link-AB7KVCHVFT4WNBKN2ZC7V89GZR","url":"https://www.washingtonpost.com/elections/election-results/georgia-senate-runoffs-2021/","display_name":"Georgia results","node_type":"link","children":[]},{"_id":"link-HNFGKN9TFH02K471F4F8VRN5PG","url":"https://www.washingtonpost.com/politics/joe-biden-46th-president/","display_name":"Transfer of Power","node_type":"link","children":[]},{"_id":"link-4ZWF7GT4Q12JQFNFRK0CQE2TRG","url":"https://www.washingtonpost.com/elections/interactive/2020/election-integrity/","display_name":"Facts on election integrity","node_type":"link","children":[]},{"_id":"link-8BWBPBEPA103Q7D41A18UQVN88","url":"https://www.washingtonpost.com/graphics/politics/biden-cabinet/","display_name":"Biden Cabinet","node_type":"link","children":[]},{"_id":"link-WTV42ZDTTX7DF2QZN14E69J6YW","url":"https://www.washingtonpost.com/elections/opinions/","display_name":"Opinions","node_type":"link","children":[]}]},{"_id":"/topics/biden-transfer","name":"First 100 Days","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/politics/joe-biden-46th-president/"},"navigation":{"nav_title":"First 100 Days"},"children":[{"_id":"link-TTG2U3RDAN5FF0XZ44HT3WKB60","url":"https://www.washingtonpost.com/politics/2021/03/08/joe-biden-live-updates/","display_name":"Live updates","node_type":"link","children":[]},{"_id":"/topics/biden-transfer/agenda","name":"The Biden Agenda","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/politics/joe-biden-46th-president/"},"navigation":{"nav_title":"The Biden Agenda"},"children":[{"_id":"link-E77BU55DQN7AQ851WN2CN7VWGM","url":"https://www.washingtonpost.com/graphics/2020/politics/biden-climate-environment/","display_name":"Climate change","node_type":"link"},{"_id":"link-MN8NKTZGJX08ZD3WXQTPVG7JY8","url":"http://washingtonpost.com/politics/2021/01/14/biden-economy/","display_name":"Economic policy","node_type":"link"},{"_id":"link-5DGB06FD512A37B6N41DU797ZG","url":"https://www.washingtonpost.com/graphics/2020/politics/biden-foreign-policy/","display_name":"Foreign policy","node_type":"link"},{"_id":"link-KMQX6M84RN3DQD4W4TJ1MA4QGC","url":"https://www.washingtonpost.com/graphics/2020/politics/biden-health-care/","display_name":"Health care","node_type":"link"},{"_id":"link-4JZW02V1TN1D71NEZTZW65D5RR","url":"https://www.washingtonpost.com/graphics/2020/politics/biden-immigration/","display_name":"Immigration policies","node_type":"link"},{"_id":"link-Y4BBW96FAH4WT8V29ZVYB41ZGM","url":"http://washingtonpost.com/politics/2021/01/11/bidens-policies-social-criminal-justice/","display_name":"Social and criminal justice","node_type":"link"},{"_id":"link-VG12WGECD91HFCDHX43PTQHTXR","url":"http://washingtonpost.com/politics/2021/01/18/biden-technology/","display_name":"Tech policy","node_type":"link"}]},{"_id":"link-PAGR0FKVU97WN6VYYBMKFNM1PG","url":"https://www.washingtonpost.com/politics/interactive/2020/biden-appointee-tracker/","display_name":"Biden Appointees","node_type":"link","children":[]},{"_id":"link-J2Y0U18BU10D515XMRGWF9KMUC","url":"https://www.washingtonpost.com/opinions/biden-administration/","display_name":"Opinions","node_type":"link","children":[]}]},{"_id":"/world","name":"World","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/world/"},"navigation":{"nav_title":"World"},"children":[{"_id":"/world/africa","name":"Africa","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/world/africa/"},"navigation":{"nav_title":"Africa"},"children":[]},{"_id":"/world/americas","name":"Americas","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/world/americas/"},"navigation":{"nav_title":"Americas"},"children":[]},{"_id":"/world/asia-pacific","name":"Asia","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/world/asia-pacific/"},"navigation":{"nav_title":"Asia"},"children":[]},{"_id":"/world/europe","name":"Europe","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/world/europe/"},"navigation":{"nav_title":"Europe"},"children":[]},{"_id":"/world/middle-east","name":"Middle East","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/world/middle-east/"},"navigation":{"nav_title":"Middle East"},"children":[]},{"_id":"link-5XFWQFMBMN3WH1Q62BKWNEHFAC","url":"https://www.washingtonpost.com/graphics/world/washington-post-foreign-correspondents/","display_name":"Foreign Correspondents","node_type":"link","children":[]}]},{"_id":"/topics/coronavirus","name":"Coronavirus","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/coronavirus/"},"navigation":{"nav_title":"Coronavirus"},"children":[{"_id":"link-58J46J4QF532H0UAP1N4YZCCDM","url":"https://www.washingtonpost.com/graphics/2020/national/coronavirus-us-cases-deaths/","display_name":"U.S. map","node_type":"link","children":[]},{"_id":"link-GMRF3ZBN895QH434N6X62Y3W74","url":"https://www.washingtonpost.com/graphics/2020/world/mapping-spread-new-coronavirus/","display_name":"World map","node_type":"link","children":[]},{"_id":"link-MFW8KTH96T5P9DAD5Z498WNA9M","url":"https://www.washingtonpost.com/graphics/2020/health/covid-vaccine-states-distribution-doses/","display_name":"Vaccine tracker","node_type":"link","children":[]},{"_id":"link-B47EJVYJ390E9FHPJ6UN17H2DR","url":"https://www.washingtonpost.com/health/2020/11/17/covid-vaccines-what-you-need-to-know/","display_name":"Vaccine FAQ","node_type":"link","children":[]},{"_id":"link-J3FB7CE4XH26QDBHVFYHMF3QWG","url":"https://www.washingtonpost.com/health/interactive/2021/01/25/covid-variants/","display_name":"Variants FAQ","node_type":"link","children":[]},{"_id":"link-6AV5G6CCN160XBEA3PC3CR90NM","url":"https://www.washingtonpost.com/health/interactive/2021/coronavirus-anniversary/","display_name":"A pandemic year","node_type":"link","children":[]},{"_id":"link-UAD2XYRV3D6B553VRX5ABQV4K8","url":"https://www.washingtonpost.com/coronavirus/living/","display_name":"Coronavirus Living","node_type":"link","children":[]}]},{"_id":"/public-relations/pr","name":"Washington Post PR Blog","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/pr/"},"navigation":{"nav_title":"Washington Post PR Blog"},"children":[{"_id":"/public-relations","name":"Public Relations","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/"},"navigation":{"nav_title":"Public Relations"},"children":[]},{"_id":"/public-relations/press-releases","name":"Press Releases","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/press-releases/"},"navigation":{"nav_title":null},"children":[]},{"_id":"/public-relations/audience-traffic","name":"Audience \u0026 Traffic","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/audience-traffic/"},"navigation":{"nav_title":null},"children":[]},{"_id":"/public-relations/awards","name":"Awards","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/awards/"},"navigation":{"nav_title":null},"children":[]},{"_id":"/public-relations/events","name":"Events","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/events/"},"navigation":{"nav_title":null},"children":[]},{"_id":"/public-relations/staff-news","name":"Staff News","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/staff-news/"},"navigation":{"nav_title":null},"children":[]},{"_id":"/public-relations/in-the-news","name":"In the News","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/in-the-news/"},"navigation":{"nav_title":null},"children":[]},{"_id":"link-B6KJJN76RT03VBXJHEQMWFBPT0","url":"https://www.washingtonpost.com/public-relations/arc-publishing/","display_name":"Arc","node_type":"link","children":[]},{"_id":"/public-relations/zeus","name":"Zeus","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/public-relations/zeus/"},"navigation":{"nav_title":"Zeus"},"children":[]}]},{"_id":"/opinions/letters-to-the-editor","name":"Letters to the Editor","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/opinions/letters-to-the-editor/"},"navigation":{"nav_title":"Letters to the Editor"},"children":[{"_id":"link-HMWNEYV8D93F7BEAP99JNX1KAR","url":"https://www.washingtonpost.com/opinions/","display_name":"Opinions","node_type":"link","children":[]},{"_id":"link-D83JKVE5UN511EY7U5A61526QG","url":"https://www.washingtonpost.com/global-opinions/","display_name":"Global Opinions","node_type":"link","children":[]},{"_id":"link-0U03BTKA51557383G7V274C9Z0","url":"https://www.washingtonpost.com/opinions/local-opinions/","display_name":"D.C., Md. \u0026 Va. Opinions","node_type":"link","children":[]},{"_id":"link-869KC6GZW93JH0GMM8R7YB9W9W","url":"https://www.washingtonpost.com/opinions/letter-to-the-editor/","display_name":"Submit a letter","node_type":"link","children":[]},{"_id":"link-UDAJGZ5XFT5TVB6Z9K7KXV62W0","url":"https://www.washingtonpost.com/opinions/submit-an-op-ed/","display_name":"Submit an op-ed","node_type":"link","children":[]}]},{"_id":"/washington-post-live","name":"Washington Post Live","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/washington-post-live/"},"navigation":{"nav_title":"Washington Post Live"},"children":[{"_id":"link-ZTWT8X1PYX4HV9RR1CFAJ12PD8","url":"https://www.washingtonpost.com/post-live-Daily-About-Page/","display_name":"About","node_type":"link","children":[]},{"_id":"link-98MFD3P5JX4WF30YM1PCEMBY80","url":"https://www.washingtonpost.com/washington-post-live/2020/01/01/washington-post-live-past-events/","display_name":"Past Events","node_type":"link","children":[]},{"_id":"link-91FW8R132X21T4CUADUN90Q09R","url":"https://www.washingtonpost.com/podcasts/post-live/","display_name":"Podcast","node_type":"link","children":[]}]},{"_id":"/local/virginia/vapolitics","name":"Virginia Politics","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/virginia/politics/"},"navigation":{"nav_title":"Virginia Politics"},"children":[{"_id":"link-0H9AHTT1XT463EMYHB0FHFT67C","url":"https://www.washingtonpost.com/local/","display_name":"Local news","node_type":"link","children":[]},{"_id":"link-HGUN3FM03T1D18XZHVFPR2Y68W","url":"https://www.washingtonpost.com/local/dc/politics/","display_name":"D.C. politics","node_type":"link","children":[]},{"_id":"link-EWF2F1DNC50878UW2MFE3NC78C","url":"https://www.washingtonpost.com/local/maryland/politics/","display_name":"Md. politics","node_type":"link","children":[]}]},{"_id":"/local/maryland/md-politics","name":"Maryland Politics","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/maryland/politics/"},"navigation":{"nav_title":"Maryland Politics"},"children":[{"_id":"link-YYR14M31KH0WBCWUWA1M1UU7M4","url":"https://www.washingtonpost.com/local/","display_name":"Local news","node_type":"link","children":[]},{"_id":"link-2JDP4CKND55994J7FVPY5HJVDC","url":"https://www.washingtonpost.com/local/dc/politics/","display_name":"D.C. politics","node_type":"link","children":[]},{"_id":"link-D18PN75C6H50K84EA9B2NNK2U4","url":"https://www.washingtonpost.com/local/virginia/politics/","display_name":"Va. politics","node_type":"link","children":[]}]},{"_id":"/local/dc/dc-politics","name":"D.C. Politics","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/dc/politics/"},"navigation":{"nav_title":"D.C. Politics"},"children":[{"_id":"link-E5MMHGF5P95HH4CJF830VBNN5W","url":"https://www.washingtonpost.com/local/","display_name":"Local news","node_type":"link","children":[]},{"_id":"link-XPJREE8BFT7JHFY7JMP7659W0M","url":"https://www.washingtonpost.com/local/maryland/politics/","display_name":"Maryland politics","node_type":"link","children":[]},{"_id":"link-VM3CURR28N11NEUYQWJ9DKRTHW","url":"https://www.washingtonpost.com/local/virginia/politics/","display_name":"Virginia politics","node_type":"link","children":[]}]},{"_id":"/local","name":"D.C., Md. \u0026 Va.","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/"},"navigation":{"nav_title":"D.C., Md. \u0026 Va."},"children":[{"_id":"/local/dc","name":"The District","node_type":"section","site":{"site_url":"http://www.washingtonpost.com/local/dc/"},"navigation":{"nav_title":"The District"},"children":[]},{"_id":"/local/maryland","name":"Maryland","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/maryland/"},"navigation":{"nav_title":"Maryland"},"children":[]},{"_id":"/local/virginia","name":"Virginia","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/virginia/"},"navigation":{"nav_title":"Virginia"},"children":[]},{"_id":"/local/public-safety","name":"Local Crime \u0026 Public Safety","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/public-safety/"},"navigation":{"nav_title":"Crime \u0026 Public Safety"},"children":[]},{"_id":"/local/education","name":"Local Education","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/education/"},"navigation":{"nav_title":"Education"},"children":[]},{"_id":"/local/obituaries","name":"Obituaries","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/obituaries/"},"navigation":{"nav_title":"Obituaries"},"children":[]},{"_id":"/local/traffic-commuting","name":"Local Transportation","node_type":"section","site":{"site_url":"http://www.washingtonpost.com/local/traffic-commuting/"},"navigation":{"nav_title":"Transportation"},"children":[]},{"_id":"/local/weather","name":"Weather","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/local/weather/"},"navigation":{"nav_title":"Weather"},"children":[]}]},{"_id":"/crosswords","name":"Crosswords","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/"},"navigation":{"nav_title":"Crosswords"},"children":[{"_id":"/crosswords/daily","name":"Daily Crossword","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/daily/"},"navigation":{"nav_title":"Daily"},"children":[]},{"_id":"/crosswords/mini-meta","name":"Daily Mini Meta Crossword","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/mini-meta/"},"navigation":{"nav_title":"Daily Mini (+Weekly Meta)"},"children":[]},{"_id":"/crosswords/sunday","name":"Sunday Crossword","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/sunday-evan-birnholz/"},"navigation":{"nav_title":"Sunday Crossword"},"children":[]},{"_id":"/crosswords/merl-reagle","name":"Classic Crosswords","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/merl-reagle/"},"navigation":{"nav_title":"Classic"},"children":[]},{"_id":"/crosswords/monthly-music-meta","name":"Monthly Music Meta","node_type":"section","site":{"site_url":"https://www.washingtonpost.com/crossword-puzzles/monthly-music-meta/"},"navigation":{"nav_title":"Monthly Meta"},"children":[]},{"_id":"link-20CWYVZQEH08V8KXTBDRBHK9JC","url":"https://www.washingtonpost.com/crossword-puzzles/","display_name":"All Crosswords","node_type":"link","children":[]},{"_id":"link-UB7QKDFZ7928H9EJEUVVBMKXK8","url":"https://games.washingtonpost.com/","display_name":"More Games","node_type":"link","children":[]}]}]},"{\"source\":\"powa-manifest\"}":{"PTVENV":"v/3.3.13-wapo.11","VAENV":"v/1.14.5","powaDrive":false}},"requestUri":"/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/"}},"page":"/[...all]","query":{"all":["news","the-intersect","wp","2016","05","24","twitter-says-goodbye-to-all"]},"buildId":"622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba","runtimeConfig":{"CLIENT_SIDE_API_DOMAIN":"https://www.washingtonpost.com/prism","SERVER_SIDE_API_DOMAIN":"https://prism-proxy.wpit.nile.works","CONTENT_SOURCE":"prism-content-api","environment":"prod","isCypress":false,"buildId":"622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba","DEBUG_DATADOG":false},"isFallback":false,"dynamicIds":["16Al","17x9","JhMR","KqkS","WbBG","i8i4","q1tI","viRO","yl30","/GRZ","0TfD","1V4k","3ppj","5XH/","5zgZ","6GKZ","6iqY","7XQX","8T0T","9/5/","9izM","C+bE","Cule","EjV/","F0vc","Fbky","GlrJ","HJqa","HzQL","I79i","IIS0","ISpO","InM0","J6gt","J983","JJBo","JK4X","KIFj","KgHr","Kj45","LIY2","MUC3","OUbi","Pfy6","Qetd","RzSr","SSMQ","T+cC","TU4j","Twuh","Tzx1","U3xo","VNu+","VzBp","WF+G","X8P9","XbjY","YFvv","atHZ","b1GP","cj+i","evQH","gdjR","hKI/","i2R6","l77S","liT6","mQ/1","mbbJ","nUda","oiqD","ojxP","qhzo","qzg6","rVFW","rbcV","rvXq","snFH","tztA","vuIU","wPDr","wx14","yGA9","+16+","+crz","/+cc","/bc4","/haT","0fTL","1/IK","11Dh","13rC","2DQC","2bWf","2mSc","3TB8","4wWB","6Itj","775v","7XDw","7YNk","7kPY","8Kx6","8mJX","9EhL","9msO","AeTi","B+nL","B3Gz","BP2f","Crnf","EDGv","EbsX","FVZ7","FzwB","HNss","HhOs","HnGL","Iwx7","JpeY","KWpo","KxqD","L7kK","LgNh","LzCK","O4t5","O8ln","PAr6","PBW6","PITc","Rpj0","SpMp","T/ac","WQC2","Xc4q","YYJz","Yso1","aB0n","asZd","bAcS","bRWJ","cCv3","cb+M","dAl+","gDwN","geOz","hs8z","iuhU","j/y5","ja3c","kmP+","lmPv","mUIY","o1A5","orCB","pHfW","pQ6l","pWWL","q0Y5","qM1X","rDi/","rE4D","rYgr","sSc4","uZIS","vkRV","wXxt","z4vS","zOWX","zktT","Q1qA"]}</script>
+  <script crossorigin="anonymous"
+    nomodule="">!function () { var e = document, t = e.createElement("script"); if (!("noModule" in t) && "onbeforeload" in t) { var n = !1; e.addEventListener("beforeload", function (e) { if (e.target === t) n = !0; else if (!e.target.hasAttribute("nomodule") || !n) return; e.preventDefault() }, !0), t.type = "module", t.src = ".", e.head.appendChild(t), t.remove() } }();</script>
+  <script crossorigin="anonymous" nomodule="" src="/_next/static/runtime/polyfills-ace4ae69055fc3bfbb9a.js"></script>
+  <script async="" data-next-page="/[...all]"
+    src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/pages/%5B...all%5D.js" crossorigin="anonymous"
+    nomodule=""></script>
+  <script async="" data-next-page="/[...all]"
+    src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/pages/%5B...all%5D.module.js"
+    crossorigin="anonymous" type="module"></script>
+  <script async="" data-next-page="/_app"
+    src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/pages/_app.js" crossorigin="anonymous"
+    nomodule=""></script>
+  <script async="" data-next-page="/_app"
+    src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/pages/_app.module.js" crossorigin="anonymous"
+    type="module"></script>
+  <script async="" src="/_next/static/chunks/30cd56ec8b4292fd1d19f6bfd4b67b1689d06305.6e76385a4d9f539919c8.js"
+    crossorigin="anonymous" nomodule=""></script>
+  <script async="" src="/_next/static/chunks/30cd56ec8b4292fd1d19f6bfd4b67b1689d06305.fbe3db9814b1fd316b2f.module.js"
+    crossorigin="anonymous" type="module"></script>
+  <script async="" src="/_next/static/chunks/22.ae27e6fc7e0529cfc3ae.js" crossorigin="anonymous" nomodule=""></script>
+  <script src="/_next/static/runtime/webpack-5f12dd2a797543b3e813.js" async="" crossorigin="anonymous"
+    nomodule=""></script>
+  <script src="/_next/static/runtime/webpack-503a898abacb4f6ee260.module.js" async="" crossorigin="anonymous"
+    type="module"></script>
+  <script src="/_next/static/chunks/framework.4370e18122abbe0cbfe9.js" async="" crossorigin="anonymous"
+    nomodule=""></script>
+  <script src="/_next/static/chunks/framework.4370e18122abbe0cbfe9.module.js" async="" crossorigin="anonymous"
+    type="module"></script>
+  <script src="/_next/static/chunks/commons.11e09a580d37990d267b.js" async="" crossorigin="anonymous"
+    nomodule=""></script>
+  <script src="/_next/static/chunks/commons.bbf28d5ca380de8c8a53.module.js" async="" crossorigin="anonymous"
+    type="module"></script>
+  <script src="/_next/static/chunks/ea3f3c9376134bde2ad6392f973353ef8165b1fa.7495ff6aa0f59d87caa1.js" async=""
+    crossorigin="anonymous" nomodule=""></script>
+  <script src="/_next/static/chunks/ea3f3c9376134bde2ad6392f973353ef8165b1fa.ae13968471fc68c12bdd.module.js" async=""
+    crossorigin="anonymous" type="module"></script>
+  <script src="/_next/static/runtime/main-a6228a303da5c639c17f.js" async="" crossorigin="anonymous"
+    nomodule=""></script>
+  <script src="/_next/static/runtime/main-58c9c6a0aea42808e6d2.module.js" async="" crossorigin="anonymous"
+    type="module"></script>
+  <script src="/_next/static/chunks/f17dffc46075aac6ebb2b8b9ff0ad166c18d91ba.a602addbb65503b56613.js" async=""
+    crossorigin="anonymous" nomodule=""></script>
+  <script src="/_next/static/chunks/f17dffc46075aac6ebb2b8b9ff0ad166c18d91ba.15be5738a8c07c994443.module.js" async=""
+    crossorigin="anonymous" type="module"></script>
+  <script src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/_buildManifest.js" async=""
+    crossorigin="anonymous" nomodule=""></script>
+  <script src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/_buildManifest.module.js" async=""
+    crossorigin="anonymous" type="module"></script>
+  <script src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/_ssgManifest.js" async=""
+    crossorigin="anonymous" nomodule=""></script>
+  <script src="/_next/static/622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba/_ssgManifest.module.js" async=""
+    crossorigin="anonymous" type="module"></script>
+  <script>window.renderingEnv = "next"</script>
+  <script src="https://js.sentry-cdn.com/bc323af135a34282a26884f37ff2e3af.min.js" crossorigin="anonymous"></script>
+  <script>
+    var deployment = window.Fusion && window.Fusion.deployment || "no release";
+    window.Sentry.forceLoad();
+    window.Sentry.onLoad(function sentryInit() {
+      window.Sentry.init({
+        release: deployment,
+        environment: "prod",
+        sampleRate: 0.20,
+        whitelistUrls: [
+          "washingtonpost.com",
+          "wapodev.com",
+          "wapostage.com",
+          "washpost.arcpublishing.com"
+        ],
+        blacklistUrls: [
+          "washingtonpost.com/wp-stat/",
+          "washingtonpost.com/scripts/",
+          "*/src/",
+          "*/verify.js",
+          "*/score.min.js",
+          "localhost"
+        ],
+        beforeSend: function (event, hint) {
+          var error = hint && hint.originalException;
+          if (error && error.message && error.message.match(/WPFusionReactError/)) {
+            return event;
           }
-          function F() {
-            return new Promise(function(G, H) {
-              try {
-                var I = new XMLHttpRequest;
-                I.withCredentials = !![];
-                I.open(b("0x12"), x);
-                I.timeout =
-                  3E3;
-                I.onload = function() {
-                  G("")
-                };
-                I.onerror = function() {
-                  H(b("0x11"))
-                };
-                I.send()
-              } catch (J) {
-                H(b("0x11"))
-              }
-            })
-          }
-          return new Promise(function(K) {
-            var L = !![];
-            c.ad = ![];
-            function M(N) {
-              if (N == b("0x11")) {
-                TWP.Data.Tracking.adblocked = !![];
-                c.ad = !![]
-              }
-              K({
-                type: "ad",
-                result: c.ad,
-                overlay: L
-              })
-            }
-            F().then(M, function() {
-              if (navigator.userAgent.indexOf("Firefox") > -1) F().then(M, M);
-              else y().then(M, M)
-            })
-          })
-        };
-        k[b("0x13")] = function() {
-          var O = document.querySelectorAll(b("0x14"));
-          try {
-            var P = 0;
-            O.forEach(function(Q) {
-              if (Q.tagName == "P") {
-                var R = 50 - P;
-                var S =
-                  Q.innerHTML.split(" ");
-                P += S.length;
-                if (P > 50) {
-                  Q.innerHTML = S.slice(0, R).join(" ") + b("0x15");
-                  while (Q.nextSibling != null) Q.nextSibling.parentNode.removeChild(Q.nextSibling);
-                  return
-                }
-              }
-            })
-          } catch (T) {
-            O.slice(2).remove()
-          }
-          document.querySelector(b("0x16")).style.transform = b("0x17");
-          var U = document.querySelector(b("0x18"));
-          while (U.nextSibling != null) U.nextSibling.parentNode.removeChild(U.nextSibling);
-          U = document.querySelectorAll(b("0x19"));
-          for (var V = 0; V < U.length; V++) U[V].parentNode.removeChild(U[V])
-        };
-        k[b("0x1a")] = function(W,
-          X) {
-          function Y(W) {
-            try {
-              if (typeof s !== "undefined") {
-                var a0 = {};
-                switch (W) {
-                  case "pv":
-                    a0.pageName = s.pageName;
-                    a0.eVar1 = s.eVar1;
-                    a0.prop43 = a0.eVar43 = wp_pb.canonical_url;
-                    a0.prop59 = a0.eVar59 = g;
-                    a0.prop64 = a0.eVar32 = k.featureConfig[W].ctaPromo;
-                    break;
-                  case "ad":
-                    break
-                }
-                s.sendDataToOmniture("blocker modal", k.featureConfig[W].modalEvent, a0)
-              }
-            } catch (a1) {}
-          }
-          document.removeEventListener("pb-adblocked", k.displayOverlay);
-          W = !W ? "ad" : W;
-          var a2 = document.querySelector(X);
-          var a3 = a2.querySelector(".link");
-          var a4 = a2.querySelector(b("0x1b"));
-          var a5 = a2.querySelector("div \x3e div div:nth-child(3) span");
-          var a6 = a2.querySelector("div \x3e div div:nth-child(5)");
-          var a7 = a2.querySelector(b("0x1c"));
-          if (k.featureConfig[W].headline) a4.innerHTML = k.featureConfig[W].headline;
-          if (k.featureConfig[W].subhead) a5.innerHTML = k.featureConfig[W].subhead;
-          if (k.featureConfig[W].unblock) a6.innerHTML = k.featureConfig[W].unblock;
-          if (k.featureConfig[W].cta) a7.innerHTML = k.featureConfig[W].cta;
-          if (k.featureConfig[W].signinLink) a3.innerHTML = k.featureConfig[W].signinLink;
-          var a8 = a3.querySelector("a");
-          var a9 = a8.href;
-          a8.href = a9 + window.location.href;
-          if (navigator.userAgent.indexOf("Firefox") > -1) {
-            var aa = a6.querySelector("a").getAttribute(b("0x1d"));
-            a6.querySelector("a").setAttribute(b("0x1e"), aa)
-          }
-          a2.style.display = b("0x1f");
-          k.limitContent();
-          if (j) {
-            document.querySelector(b("0x20")).style.display = b("0x17");
-            document.querySelector(b("0x21")).style.display = b("0x17")
-          }
-          var ab = document.querySelector(b("0x22"));
-          ab.style.overflow = b("0x23");
-          try {
-            var ac = window.TWP || {};
-            ac.Features = ac.Features || {};
-            ac.Features.ol = ac.Features.ol = !![]
-          } catch (ad) {}
-          setTimeout(function() {
-            Y(W)
-          }, 1E3)
-        };
-        k[b("0x24")] = function(ae) {
-          function af(ag) {
-            var ah = window.TWP || {};
-            ah.Data = ah.Data || {};
-            ah.Data.Tracking = ah.Data.Tracking || {};
-            ah.Data.Tracking.blockers = c;
-            document.dispatchEvent(new CustomEvent(b("0x25")));
-            var ai = document.querySelector("html"),
-              aj;
-            if (navigator.userAgent.indexOf(b("0x5")) > -1) aj = b("0x26");
-            else if (navigator.userAgent.indexOf(b("0x6")) > -1) aj = "safari";
-            else if (navigator.userAgent.indexOf("Firefox") > -1) aj = b("0x27");
-            else aj = "na";
-            if (ai.className.indexOf(b("0x28")) > -1 && typeof ae != b("0x29"))
-              for (var ak = 0; ak < ag.length; ak++) {
-                var al = ag[ak].type;
-                var am = ag[ak].result;
-                var an = typeof ag[ak].overlay == b("0x29") ? !![] : ag[ak].overlay;
-                var ao = k.featureConfig[al].browsers[aj];
-                var ap = k.featureConfig[al].browsers.mobile && j || !j;
-                var aq = k.featureConfig[al].isAnon && i;
-                var ar = k.featureConfig[al].isLogged && h && !f;
-                var as = k.featureConfig[al].isSubscriber && h && f;
-                var at = ao && ap && (aq || ar || as);
-                if (am && an && at) {
-                  k.displayOverlay(al, ae);
-                  break
-                }
-              }
-          }
-          k.getFeatureConfig().then(function() {
-            var au = [];
-            for (var av in k)
-              if (av.indexOf(b("0x2a")) != -1) au.push(k[av]);
-            var aw = au.map(function(ax) {
-              return ax.call()
-            });
-            Promise.all(aw).then(af, af)
-          })
-        };
-        k[b("0x2b")] = function(ay) {
-          k.initFeature(ay)
-        };
-        k[b("0x2")]["ad"] = {};
-        k[b("0x2")]["pv"] = {};
-        k[b("0x2")]["pv"][b("0x2c")] = {};
-        k[b("0x2")]["pv"][b("0x2d")] = !![];
-        k[b("0x2")]["pv"]["isLogged"] = ![];
-        k[b("0x2")]["pv"][b("0x2e")] = ![];
-        k[b("0x2")]["pv"][b("0x2f")] = b("0x30");
-        k[b("0x2")]["pv"][b("0x31")] = "Private browsing is permitted exclusively for our subscribers. Turn off private browsing to keep reading this story, or subscribe to use this feature, plus get unlimited digital access.";
-        k[b("0x2")]["pv"]["unblock"] = b("0x32");
-        k[b("0x2")]["pv"][b("0x33")] = b("0x34");
-        k[b("0x2")]["pv"][b("0x35")] = b("0x36");
-        k[b("0x2")]["pv"][b("0x37")] = b("0x38");
-        k[b("0x2")]["pv"][b("0x39")] = b("0x3a");
-        k[b("0x2")]["pv"][b("0x2c")]["safari"] = !![];
-        k[b("0x2")]["pv"][b("0x2c")][b("0x27")] = !![];
-        k[b("0x2")]["pv"][b("0x2c")]["chrome"] = !![];
-        k[b("0x2")]["pv"][b("0x2c")]["ie"] = ![];
-        k[b("0x2")]["pv"][b("0x2c")][b("0x3b")] = ![];
-        k[b("0x2")]["ad"][b("0x2c")] = {};
-        k[b("0x2")]["ad"][b("0x2d")] = !![];
-        k[b("0x2")]["ad"][b("0x3c")] = ![];
-        k[b("0x2")]["ad"][b("0x2e")] = ![];
-        k[b("0x2")]["ad"]["headline"] = b("0x3d");
-        k[b("0x2")]["ad"][b("0x31")] = b("0x3e");
-        k[b("0x2")]["ad"][b("0x3f")] = '\x3ca data-link-ff\x3d"https://www.washingtonpost.com/steps-for-disabling-firefoxs-native-adblocker/2018/05/21/fb95bf4e-5d37-11e8-b2b8-08a538d9dbd6_story.html" data-link\x3d"https://www.washingtonpost.com/steps-for-disabling-adblocker/2016/09/14/a8c3d4d2-7aac-11e6-bd86-b7bbd53d2b5d_story.html" href\x3d"https://www.washingtonpost.com/steps-for-disabling-adblocker/2016/09/14/a8c3d4d2-7aac-11e6-bd86-b7bbd53d2b5d_story.html"\x3eUnblock ads\x3c/a\x3e';
-        k[b("0x2")]["ad"][b("0x33")] = '\x3ca href\x3d"https://subscribe.washingtonpost.com/acq/?promo\x3do12" target\x3d"_blank"\x3e\x3cspan class\x3d"subscribe-link"\x3eTry 1 month for $1\x3c/span\x3e\x3c/a\x3e';
-        k[b("0x2")]["ad"]["ctaPromo"] = "o12";
-        k[b("0x2")]["ad"]["signinLink"] = b("0x38");
-        k[b("0x2")]["ad"]["modalEvent"] = b("0x40");
-        k[b("0x2")]["ad"][b("0x2c")][b("0x41")] = !![];
-        k[b("0x2")]["ad"][b("0x2c")]["firefox"] = !![];
-        k[b("0x2")]["ad"][b("0x2c")][b("0x26")] = !![];
-        k[b("0x2")]["ad"][b("0x2c")]["ie"] = ![];
-        k[b("0x2")]["ad"][b("0x2c")]["mobile"] = ![];
-        k[b("0x2b")](".o_rpoawabc")
-      })();
-    </script>
-    <script>
-      try {
-        String.prototype.endsWith || Object.defineProperty(String.prototype, "endsWith", {
-          value: function(t, e) {
-            var n = this.toString();
-            (void 0 === e || e > n.length) && (e = n.length), e -= t.length;
-            var r = n.indexOf(t, e);
-            return -1 !== r && r === e
-          },
-          configurable: true
-        });
-        window.pageBuilder = window.pageBuilder || {};
-        window.pageBuilder.loadAsync = function() {};
-        window.pageBuilder.loadAsyncOverride = function() {
-          window.pageBuilder.loadAsyncFeatures();
-          window.pageBuilder.loadAsyncChains && window.pageBuilder.loadAsyncChains()
-        };
-        document.addEventListener("pb-defer-js-loaded",
-          function() {
-            window.pageBuilder.loadAsyncOverride();
-            window.wp_pb = window.wp_pb || {};
-            wp_pb.loaderState = wp_pb.loaderState || {};
-            wp_pb.loaderState.asyncLoaded = true;
-            document.dispatchEvent(new CustomEvent("pb-async-loaded"))
-          })
-      } catch (err) {}
-      document.addEventListener("pb-core-loaded", function() {
-        pbDeferredScripts.push("/pb/gr/ro/default-article/r08eSKG9hDierr/headjs/8bb9d8351d.js?_\x3d69d73");
-        pbDeferredScripts.push("/pb/gr/c/default-article/r08eSKG9hDierr/load_async_loader/bf6f3693c3.js?_\x3dad9e0");
-        pbDeferredScripts.push("/pb/gr/ro/default-article/r08eSKG9hDierr/hi-pri-js/e7f066f51e.js?_\x3dcd70e");
-        pbDeferredScripts.push("/pb/gr/p/default-article/r08eSKG9hDierr/hi-pri-render.js?_\x3daddb1");
-        pbDeferredScripts.push("/pb/gr/ro/default-article/r08eSKG9hDierr/js/23cef797d0.js?_\x3da0cb9");
-        pbDeferredScripts.push("/pb/gr/p/default-article/r08eSKG9hDierr/render.js?_\x3daddb1");
-        pbDeferredScripts.push("/pb/gr/p/default-article/r08eSKG9hDierr/instance.js?_\x3daddb1");
-        pbDeferredScripts.push("/pb/gr/ro/default-article/r08eSKG9hDierr/after_features/82e93e7bf2.js?_\x3d895cc");
-        wp_import.valor(true);
-        wp_import(pbDeferredScripts).always(function() {
-          window.wp_pb = window.wp_pb || {};
-          wp_pb.loaderState = wp_pb.loaderState || {};
-          wp_pb.loaderState.deferLoaded = true;
-          document.dispatchEvent(new CustomEvent("pb-defer-js-loaded"))
-        })
-      });
-    </script>
-    <script>
-      document.addEventListener("async-features-loaded", function() {});
-    </script>
-    <script>
-      (function() {
-        if ("__twpCookieMonster__" in document) document.__twpCookieMonster__.ommNom()
-      })();
-    </script>
-    <script>
-      window.NREUM || (NREUM = {}), __nr_require = function(e, n, t) {
-        function r(t) {
-          if (!n[t]) {
-            var o = n[t] = {
-              exports: {}
-            };
-            e[t][0].call(o.exports, function(n) {
-              var o = e[t][1][n];
-              return r(o || n)
-            }, o, o.exports)
-          }
-          return n[t].exports
-        }
-        if ("function" == typeof __nr_require) return __nr_require;
-        for (var o = 0; o < t.length; o++) r(t[o]);
-        return r
-      }({
-        1: [function(e, n, t) {
-          function r() {}
-          function o(e, n, t) {
-            return function() {
-              return i(e, [c.now()].concat(u(arguments)), n ? null : this, t), n ? void 0 : this
-            }
-          }
-          var i = e("handle"),
-            a = e(3),
-            u = e(4),
-            f = e("ee").get("tracer"),
-            c = e("loader"),
-            s = NREUM;
-          "undefined" == typeof window.newrelic && (newrelic = s);
-          var p = ["setPageViewName", "setCustomAttribute", "setErrorHandler", "finished", "addToTrace", "inlineHit", "addRelease"],
-            d = "api-",
-            l = d + "ixn-";
-          a(p, function(e, n) {
-            s[n] = o(d + n, !0, "api")
-          }), s.addPageAction = o(d + "addPageAction", !0), s.setCurrentRouteName = o(d + "routeName", !0), n.exports = newrelic, s.interaction = function() {
-            return (new r).get()
-          };
-          var m = r.prototype = {
-            createTracer: function(e, n) {
-              var t = {},
-                r = this,
-                o = "function" == typeof n;
-              return i(l + "tracer", [c.now(),
-                  e, t
-                ], r),
-                function() {
-                  if (f.emit((o ? "" : "no-") + "fn-start", [c.now(), r, o], t), o) try {
-                    return n.apply(this, arguments)
-                  } catch (e) {
-                    throw f.emit("fn-err", [arguments, this, e], t), e;
-                  } finally {
-                    f.emit("fn-end", [c.now()], t)
-                  }
-                }
-            }
-          };
-          a("actionText,setName,setAttribute,save,ignore,onEnd,getContext,end,get".split(","), function(e, n) {
-            m[n] = o(l + n)
-          }), newrelic.noticeError = function(e, n) {
-            "string" == typeof e && (e = new Error(e)), i("err", [e, c.now(), !1, n])
-          }
-        }, {}],
-        2: [function(e, n, t) {
-          function r(e, n) {
-            if (!o) return !1;
-            if (e !== o) return !1;
-            if (!n) return !0;
-            if (!i) return !1;
-            for (var t = i.split("."), r = n.split("."), a = 0; a < r.length; a++)
-              if (r[a] !== t[a]) return !1;
-            return !0
-          }
-          var o = null,
-            i = null,
-            a = /Version\/(\S+)\s+Safari/;
-          if (navigator.userAgent) {
-            var u = navigator.userAgent,
-              f = u.match(a);
-            f && u.indexOf("Chrome") === -1 && u.indexOf("Chromium") === -1 && (o = "Safari", i = f[1])
-          }
-          n.exports = {
-            agent: o,
-            version: i,
-            match: r
-          }
-        }, {}],
-        3: [function(e, n, t) {
-          function r(e, n) {
-            var t = [],
-              r = "",
-              i = 0;
-            for (r in e) o.call(e, r) && (t[i] = n(r, e[r]), i += 1);
-            return t
-          }
-          var o = Object.prototype.hasOwnProperty;
-          n.exports = r
-        }, {}],
-        4: [function(e,
-          n, t) {
-          function r(e, n, t) {
-            n || (n = 0), "undefined" == typeof t && (t = e ? e.length : 0);
-            for (var r = -1, o = t - n || 0, i = Array(o < 0 ? 0 : o); ++r < o;) i[r] = e[n + r];
-            return i
-          }
-          n.exports = r
-        }, {}],
-        5: [function(e, n, t) {
-          n.exports = {
-            exists: "undefined" != typeof window.performance && window.performance.timing && "undefined" != typeof window.performance.timing.navigationStart
-          }
-        }, {}],
-        ee: [function(e, n, t) {
-          function r() {}
-          function o(e) {
-            function n(e) {
-              return e && e instanceof r ? e : e ? f(e, u, i) : i()
-            }
-            function t(t, r, o, i) {
-              if (!d.aborted || i) {
-                e && e(t, r, o);
-                for (var a = n(o), u = v(t),
-                    f = u.length, c = 0; c < f; c++) u[c].apply(a, r);
-                var p = s[y[t]];
-                return p && p.push([b, t, r, a]), a
-              }
-            }
-            function l(e, n) {
-              h[e] = v(e).concat(n)
-            }
-            function m(e, n) {
-              var t = h[e];
-              if (t)
-                for (var r = 0; r < t.length; r++) t[r] === n && t.splice(r, 1)
-            }
-            function v(e) {
-              return h[e] || []
-            }
-            function g(e) {
-              return p[e] = p[e] || o(t)
-            }
-            function w(e, n) {
-              c(e, function(e, t) {
-                n = n || "feature", y[t] = n, n in s || (s[n] = [])
-              })
-            }
-            var h = {},
-              y = {},
-              b = {
-                on: l,
-                addEventListener: l,
-                removeEventListener: m,
-                emit: t,
-                get: g,
-                listeners: v,
-                context: n,
-                buffer: w,
-                abort: a,
-                aborted: !1
-              };
-            return b
-          }
-          function i() {
-            return new r
-          }
-          function a() {
-            (s.api || s.feature) && (d.aborted = !0, s = d.backlog = {})
-          }
-          var u = "nr@context",
-            f = e("gos"),
-            c = e(3),
-            s = {},
-            p = {},
-            d = n.exports = o();
-          d.backlog = s
-        }, {}],
-        gos: [function(e, n, t) {
-          function r(e, n, t) {
-            if (o.call(e, n)) return e[n];
-            var r = t();
-            if (Object.defineProperty && Object.keys) try {
-              return Object.defineProperty(e, n, {
-                value: r,
-                writable: !0,
-                enumerable: !1
-              }), r
-            } catch (i) {}
-            return e[n] = r, r
-          }
-          var o = Object.prototype.hasOwnProperty;
-          n.exports = r
-        }, {}],
-        handle: [function(e, n, t) {
-          function r(e, n, t, r) {
-            o.buffer([e], r), o.emit(e, n, t)
-          }
-          var o = e("ee").get("handle");
-          n.exports = r, r.ee = o
-        }, {}],
-        id: [function(e, n, t) {
-          function r(e) {
-            var n = typeof e;
-            return !e || "object" !== n && "function" !== n ? -1 : e === window ? 0 : a(e, i, function() {
-              return o++
-            })
-          }
-          var o = 1,
-            i = "nr@id",
-            a = e("gos");
-          n.exports = r
-        }, {}],
-        loader: [function(e, n, t) {
-          function r() {
-            if (!E++) {
-              var e = x.info = NREUM.info,
-                n = l.getElementsByTagName("script")[0];
-              if (setTimeout(s.abort, 3E4), !(e && e.licenseKey && e.applicationID && n)) return s.abort();
-              c(y, function(n, t) {
-                e[n] || (e[n] = t)
-              }), f("mark", ["onload", a() + x.offset], null, "api");
-              var t = l.createElement("script");
-              t.src = "https://" + e.agent, n.parentNode.insertBefore(t, n)
-            }
-          }
-          function o() {
-            "complete" === l.readyState && i()
-          }
-          function i() {
-            f("mark", ["domContent", a() + x.offset], null, "api")
-          }
-          function a() {
-            return O.exists && performance.now ? Math.round(performance.now()) : (u = Math.max((new Date).getTime(), u)) - x.offset
-          }
-          var u = (new Date).getTime(),
-            f = e("handle"),
-            c = e(3),
-            s = e("ee"),
-            p = e(2),
-            d = window,
-            l = d.document,
-            m = "addEventListener",
-            v = "attachEvent",
-            g = d.XMLHttpRequest,
-            w = g && g.prototype;
-          NREUM.o = {
-            ST: setTimeout,
-            SI: d.setImmediate,
-            CT: clearTimeout,
-            XHR: g,
-            REQ: d.Request,
-            EV: d.Event,
-            PR: d.Promise,
-            MO: d.MutationObserver
-          };
-          var h = "" + location,
-            y = {
-              beacon: "bam.nr-data.net",
-              errorBeacon: "bam.nr-data.net",
-              agent: "js-agent.newrelic.com/nr-1118.min.js"
-            },
-            b = g && w && w[m] && !/CriOS/.test(navigator.userAgent),
-            x = n.exports = {
-              offset: u,
-              now: a,
-              origin: h,
-              features: {},
-              xhrWrappable: b,
-              userAgent: p
-            };
-          e(1), l[m] ? (l[m]("DOMContentLoaded", i, !1), d[m]("load", r, !1)) : (l[v]("onreadystatechange", o), d[v]("onload", r)), f("mark", ["firstbyte", u], null, "api");
-          var E = 0,
-            O = e(5)
-        }, {}]
-      }, {}, ["loader"]);
-      NREUM.info = {
-        beacon: "bam.nr-data.net",
-        errorBeacon: "bam.nr-data.net",
-        licenseKey: "ce992986c8",
-        applicationID: "91618238",
-        sa: 1
-      };
-    </script>
-    <script>
-      if (typeof newrelic == "object") {
-        newrelic.setCustomAttribute("site", "www.washingtonpost.com");
-        newrelic.setCustomAttribute("rawUserAgent", navigator.userAgent);
-        if (window.wp_pb && wp_pb.pageName) newrelic.setCustomAttribute("pbPageName", wp_pb.pageName)
-      };
-    </script>
-    <script>
-      window.pbThirdPartyScripts = window.pbThirdPartyScripts || new Array;
-    </script>
-    <script>
-      dataLayer = [];
-      function init(w, d, s, l, i) {
-        w[l] = w[l] || [];
-        w[l].push({
-          "gtm.start": (new Date).getTime(),
-          event: "gtm.js"
-        });
-        var f = d.getElementsByTagName(s)[0],
-          j = d.createElement(s),
-          dl = l != "dataLayer" ? "\x26l\x3d" + l : "";
-        j.async = true;
-        j.src = "https://www.googletagmanager.com/gtm.js?id\x3d" + i + dl;
-        f.parentNode.insertBefore(j, f)
-      }
-      init(window, document, "script", "dataLayer", "GTM-N78DPKH");
-      var thirdPartyFunctions = [];
-      window.addEventListener("DOMContentLoaded", function() {});
-      window.addEventListener("load", function() {
-        var isEUUser = wp_pb.StaticMethods.isEUUser() || false;
-        var isAdfreeUser = wp_pb.StaticMethods.isAdfree() || false;
-        wp_import(pbThirdPartyScripts).always(function() {
-          document.dispatchEvent(new CustomEvent("pb-r-third-party-js"))
-        });
-        var subButtonArray = document.querySelectorAll(".homepage-footer-button.subscribe, .subscribe.button");
-        subButtonArray.forEach(function(subButtonItem) {
-          subButtonItem.addEventListener("click", function() {
-            document.dispatchEvent(new CustomEvent("twp_tracking", {
-              detail: "subscribe_btn"
-            }))
-          }, true)
-        });
-        window.thirdPartyFunctions = window.thirdPartyFunctions || [];
-        thirdPartyFunctions.push(function() {
-          function applyTwitter() {
-            try {
-              var $tweetAuthors = $(".tweet-authors");
-              var $tweetTimelines = $(".twitter-timeline");
-              var $tweets = $(".twitter-tweet");
-              if (($tweetAuthors.length || $tweetTimelines.length || $tweets.length) && (!window.twttr || !twttr.widgets)) $.ajax({
-                dataType: "script",
-                cache: true,
-                url: "//platform.twitter.com/widgets.js",
-                success: function(data) {
-                  if (!!$tweetAuthors.length) $tweetAuthors.find(".pb-twitter-follow.unprocessed").removeClass("unprocessed")
-                }
-              })
-            } catch (e) {}
-          }
-          if (wp_pb.StaticMethods.isPageHydrated()) applyTwitter();
-          __e = window.__e || [];
-          __e.push(["shamble:end", function() {
-            applyTwitter()
-          }])
-        });
-        $(window).on("scroll.thirdparty", wp_pb.StaticMethods.debounce(function() {
-          $(window).off("scroll.thirdparty");
-          dataLayer.push({
-            "event": "scroll_thirdparty"
-          });
-          thirdPartyFunctions.forEach(function(callback) {
-            try {
-              callback.call()
-            } catch (err) {}
-          })
-        }, 200))
-      });
-    </script> <noscript><img src="https://sb.scorecardresearch.com/p?c1=2&c2=3005617&cv=2.0&cj=1" /></noscript> <noscript><img src="//me.effectivemeasure.net/em_image" alt="" style="position:absolute; left:-5px;" /></noscript>
-    <script>
-      window.pbExternalResourcesLoaded = window.pbExternalResourcesLoaded || new Array;
-      window.pbFootResourceGroups = window.pbFootResourceGroups || new Array;
-      pbFootResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "load_async_loader",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/js/loadAsync.js?_\x3dad9e0");
-      pbFootResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "hi-pri-js",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/js/default-hi-pri.js?_\x3dcd70e");
-      pbFootResourceGroups.push({
-        "resourceType": "pageResources",
-        "name": "hi-pri-render.js",
-        "fileType": "js"
-      });
-      pbFootResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "js",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/js/iabc/iabc-cookie.js?_\x3dd47ff");
-      pbExternalResourcesLoaded.push("/pb/resources/js/service-worker-registration.js?_\x3d8fdcf");
-      pbExternalResourcesLoaded.push("/pb/resources/js/condition-manager.min.js?_\x3db59fb");
-      pbExternalResourcesLoaded.push("/pb/resources/js/conditions.js?_\x3d12207");
-      pbExternalResourcesLoaded.push("/pb/resources/js/moment.min.js?_\x3db8874");
-      pbExternalResourcesLoaded.push("/pb/resources/js/inline-content.js?_\x3da388a");
-      pbFootResourceGroups.push({
-        "resourceType": "pageResources",
-        "name": "render.js",
-        "fileType": "js"
-      });
-      pbFootResourceGroups.push({
-        "resourceType": "pageResources",
-        "name": "instance.js",
-        "fileType": "js"
-      });
-      pbFootResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "after_features",
-        "fileType": "js"
-      });
-      pbExternalResourcesLoaded.push("/pb/resources/js/default-after-features.js?_\x3d3c3ce");
-      pbExternalResourcesLoaded.push("/pb/resources/js/article-layout-after-features.js?_\x3db126f");
-      pbExternalResourcesLoaded.push("/pb/resources/js/abtests/segments.js?_\x3d9d2a3");
-      pbFootResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "content_type_story",
-        "fileType": "js"
-      });
-      pbFootResourceGroups.push({
-        "resourceType": "externalResources",
-        "name": "third_party",
-        "fileType": "js"
-      });
-    </script>
-    <script>
-      var _uri = "/news/the-intersect/wp/2016/05/24/twitter-says-goodbye-to-all/"
-      var _context = "/pb"
-      var _outputType = "default-article"
-      var _rid = "r08eSKG9hDierr"
-      //polyfill
-      String.prototype.endsWith || Object.defineProperty(String.prototype, "endsWith", {
-        value: function(t, e) {
-          var n = this.toString();
-          (void 0 === e || e > n.length) && (e = n.length), e -= t.length;
-          var r = n.indexOf(t, e);
-          return -1 !== r && r === e
+          return null;
         }
       });
-      /* Async loader code here */
-      window.pageBuilder = window.pageBuilder || {};
-      window.pageBuilder.featureLoaded = window.pageBuilder.featureLoaded || function() {};
-      window.pageBuilder.chainLoaded = window.pageBuilder.chainLoaded || function(chain, apiResponse) {
-        var d = window.document;
-        for (var i = 0; i < apiResponse.featureIds.length; i++) {
-          var f = d.getElementById(apiResponse.featureIds[i]);
-          window.pageBuilder.featureLoaded(f);
-        }
-      };
-      window.pageBuilder._isNestedFeature = window.pageBuilder._isNestedFeature || function(element) {
-        if (!element.parentElement) return false;
-        var parent = element.parentElement;
-        if (parent.className && parent.className.split(' ').indexOf("pb-feature") >= 0) return true;
-        return window.pageBuilder._isNestedFeature(parent);
-      };
-      window.pageBuilder._executeAsyncFeatureScripts = window.pageBuilder._executeAsyncFeatureScripts || function(s) {
-        eval(s)
-      };
-      window.pageBuilder._getJson = window.pageBuilder._getJson || function(url, success, failure) {
-        var xmlhttp;
-        failure = failure || function() {};
-        if (window.XMLHttpRequest) {
-          xmlhttp = new XMLHttpRequest();
-        } else {
-          xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
-        }
-        xmlhttp.onreadystatechange = function() {
-          if (xmlhttp.readyState == 4) {
-            if (xmlhttp.status == 200) {
-              try {
-                success.call(null, JSON.parse(xmlhttp.responseText));
-              } catch (e) {
-                failure.call(null, xmlhttp, e)
-              }
-            } else {
-              failure.call(null, xmlhttp);
-            }
-          }
-        };
-        xmlhttp.open("GET", url, true);
-        xmlhttp.send();
-      };
-      window.pageBuilder.loadAsyncFeature = window.pageBuilder.loadAsyncFeature || function(id) {
-        var d = window.document;
-        function injectFeatureDom(id, featureRendering) {
-          var element = d.getElementById(id);
-          var resources = featureRendering.pageResources || {};
-          element.outerHTML = featureRendering.rendering;
-          element = d.getElementById(id); //update the element
-          var scripts = Array.prototype.slice.call(element.getElementsByTagName("script"));
-          for (var i = 0; i < scripts.length; i++) {
-            if (scripts[i].src != "") {
-              var s = d.createElement("script");
-              s.setAttribute("src", scripts[i].src);
-              d.body.appendChild(s);
-            } else {
-              window.pageBuilder._executeAsyncFeatureScripts(scripts[i].innerHTML); //eval isn't evil always.
-            }
-          }
-          for (var file in resources) {
-            if (resources.hasOwnProperty(file) && file.endsWith(".js")) {
-              var s1 = d.createElement("script");
-              s1.setAttribute("src", resources[file]);
-              d.body.appendChild(s1);
-            }
-          }
-          window.pageBuilder.featureLoaded(element);
-        }
-        var url = _context + "/api/v2/render/feature/" + id + "?rid=" + _rid + "&contentUri=" + _uri;
-        window.pageBuilder._getJson(url, function(obj) {
-          injectFeatureDom(id, obj);
-        });
-      };
-      window.pageBuilder.loadAsyncChain = window.pageBuilder.loadAsyncChain || function(id) {
-        var d = window.document;
-        function injectChainDom(id, apiResponse) {
-          var element = d.getElementById(id);
-          var resources = apiResponse.pageResources || {};
-          element.outerHTML = apiResponse.rendering;
-          element = d.getElementById(id); //update the element
-          var scripts = Array.prototype.slice.call(element.getElementsByTagName("script"));
-          for (var i = 0; i < scripts.length; i++) {
-            if (scripts[i].src != "") {
-              var s = d.createElement("script");
-              s.setAttribute("src", scripts[i].src);
-              d.body.appendChild(s);
-            } else {
-              window.pageBuilder._executeAsyncFeatureScripts(scripts[i].innerHTML); //eval isn't evil always.
-            }
-          }
-          for (var file in resources) {
-            if (resources.hasOwnProperty(file) && file.endsWith(".js")) {
-              var s1 = d.createElement("script");
-              s1.setAttribute("src", resources[file]);
-              d.body.appendChild(s1);
-            }
-          }
-          window.pageBuilder.chainLoaded(element, apiResponse);
-        }
-        var url = _context + "/api/v2/render/chain/" + id + "?rid=" + _rid + "&contentUri=" + _uri;
-        window.pageBuilder._getJson(url, function(obj) {
-          injectChainDom(id, obj);
-        });
-      };
-      window.pageBuilder.loadAsyncFeatures = window.pageBuilder.loadAsyncFeatures || function() {
-        var d = window.document;
-        var scriptsToAdd = [];
-        var featuresLoaded = [];
-        function injectAsyncFeatures(apiResp) {
-          for (var fid in apiResp) {
-            if (!apiResp.hasOwnProperty(fid)) continue;
-            var element = d.getElementById(fid);
-            var resources = apiResp[fid].pageResources || {};
-            element.outerHTML = apiResp[fid].rendering;
-            element = d.getElementById(fid); //update the element
-            var scripts = Array.prototype.slice.call(element.getElementsByTagName("script"));
-            for (var i = 0; i < scripts.length; i++) {
-              if (scripts[i].src != "") {
-                var s = d.createElement("script");
-                s.setAttribute("src", scripts[i].src);
-                d.body.appendChild(s);
-              } else {
-                window.pageBuilder._executeAsyncFeatureScripts(scripts[i].innerHTML); //eval isn't evil always.
-              }
-            }
-            for (var file in resources) {
-              if (resources.hasOwnProperty(file) && file.endsWith(".js")) {
-                resources[file].forEach(function(src) {
-                  if (scriptsToAdd.indexOf(src) === -1) {
-                    scriptsToAdd.push(src)
-                  }
-                });
-              }
-            }
-            featuresLoaded.push(element);
-          }
-          scriptsToAdd.forEach(function(src) {
-            var s = d.createElement("script");
-            s.setAttribute("src", src);
-            d.body.appendChild(s);
-          });
-          featuresLoaded.forEach(function(element) {
-            window.pageBuilder.featureLoaded(element);
-          });
-        }
-        var url = _context + "/api/v2/async/features?rid=" + _rid + "&contentUri=" + _uri;
-        window.pageBuilder._getJson(url, function(resp) {
-          injectAsyncFeatures(resp)
-        });
-      };
-      window.pageBuilder.loadAsyncChains = window.pageBuilder.loadAsyncChains || function() {
-        var d = window.document;
-        var chains = d.getElementsByClassName("pb-async pb-chain");
-        var ids = [].slice.call(chains).map(function(node) {
-          return node.id;
-        });
-        ids.forEach(function(id) {
-          window.pageBuilder.loadAsyncChain(id);
-        });
-      };
-      window.pageBuilder.loadAsync = window.pageBuilder.loadAsync || function() {
-        window.pageBuilder.loadAsyncFeatures();
-        window.pageBuilder.loadAsyncChains();
-      };
-      window.pageBuilder.loadAsync();
-    </script>
-  </body>
+    });
+  </script>
+  <link rel="icon" type="image/x-icon"
+    href="/dr/resources/images/favicon.ico?d=622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba">
+  <link rel="apple-touch-icon"
+    href="/dr/resources/images/touch-icon-iphone.png?d=622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba">
+  <link rel="apple-touch-icon" sizes="152x152"
+    href="/dr/resources/images/touch-icon-ipad.png?d=622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba">
+  <link rel="apple-touch-icon" sizes="167x167"
+    href="/dr/resources/images/touch-icon-ipad-retina.png?d=622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba">
+  <link rel="apple-touch-icon" sizes="180x180"
+    href="/dr/resources/images/touch-icon-iphone-retina.png?d=622454693@436a987123d5ee2a664f6aba0dcd56b1947cd1ba">
+  <noscript>
+    <!-- Google Tag Manager (noscript) -->
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WHNNX8B" height="0" width="0"
+      style="display:none;visibility:hidden"></iframe>
+    <!-- End Google Tag Manager (noscript) -->
+  </noscript>
+</body>
 </html>


### PR DESCRIPTION
I re-download the HTML markup related to the integration tests.

some interesting thing:


- just the verge still has wrong markup ([tweet](https://twitter.com/Kikobeats/status/1368961061274214400)).
- the washington post doesn't have markup ([tweet](https://twitter.com/Kikobeats/status/1368964702366269448)).
