### PR TITLE
fix(favicon): pass default function

### DIFF
--- a/packages/metascraper-logo-favicon/index.js
+++ b/packages/metascraper-logo-favicon/index.js
@@ -87,7 +87,7 @@ module.exports = ({ gotOpts, pickFn = pickBiggerSize } = {}) => {
     logo: [
       toUrl($ => {
         const sizes = getSizes($, sizeSelectors)
-        const size = pickFn(sizes)
+        const size = pickFn(sizes, pickBiggerSize)
         return get(size, 'url')
       }),
       ({ url }) => getLogo(url)


### PR DESCRIPTION
This pull request fixes a `TypeError: pickDefault is not a function` error when using the [example usage](https://github.com/microlinkhq/metascraper/blob/master/packages/metascraper-logo-favicon/README.md) favicon code. It looks as if the `pickBuggerSize` argument was removed perhaps by accident in https://github.com/microlinkhq/metascraper/pull/326/files#diff-74e05d3ffe4f477374555aa80848c0c82ca02139bf21197c13f8d81c4e0f9772R90.