### PR TITLE
fix(helpers): JSON+LD detects number pproperly

### DIFF
--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -300,7 +300,7 @@ const $jsonld = propName => $ => {
 
   collection.find(item => {
     value = get(item, propName)
-    return !isEmpty(value)
+    return !isEmpty(value) || typeof value === 'number' || typeof value === 'boolean'
   })
 
   return value ? decodeHTML(value) : value

--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -10,6 +10,7 @@ const {
   isArray,
   isEmpty,
   isNumber,
+  isBoolean,
   isString,
   lte,
   replace,
@@ -300,7 +301,7 @@ const $jsonld = propName => $ => {
 
   collection.find(item => {
     value = get(item, propName)
-    return !isEmpty(value) || typeof value === 'number' || typeof value === 'boolean'
+    return !isEmpty(value) || isNumber(value) || isBoolean(value)
   })
 
   return value ? decodeHTML(value) : value


### PR DESCRIPTION
lodash isEmpty considers numbers (and booleans) an empty value (https://lodash.com/docs/4.17.10#isEmpty), so it is not possible to scape numbers properly. 

For example if you try to scrape prices with the following rules, and 'price' has a value (for example 25.5), but 'offers.price' and '0.offers.price' does not, it will loop though the remaining fields and you end up with no value. 
```
price: [
    ({htmlDom: $, url}: type) => $jsonld('price')($, url),
    ({htmlDom: $, url}: type) => $jsonld('offers.price')($, url),
    ({htmlDom: $, url}: type) => $jsonld('0.offers.price')($, url),
]
``` 

Wasn't sure if I should file an issue or a PR, or if this behavior is intended for some reason, but would love to see a fix/workaround for this 😊