### PR TITLE
Get a description from the first paragraph

### DIFF
--- a/packages/metascraper-description/index.js
+++ b/packages/metascraper-description/index.js
@@ -2,6 +2,20 @@
 
 const { $jsonld, toRule, description } = require('@metascraper/helpers')
 
+const trimString = str => {
+    const maxLength = 290
+    if (str.length > maxLength) {
+      str = str.substring(0, maxLength)
+      const lastSpace = str.lastIndexOf(' ')
+      if (lastSpace > 0) str = str.substring(0, lastSpace)
+      const lastComma = str.lastIndexOf(',')
+      if (lastComma > 0) str = str.substring(0, lastComma)
+      str = str.substring(0, str.lastIndexOf(','))
+      return str + '...'
+    }
+    return str
+}
+
 module.exports = opts => {
   const toDescription = toRule(description, opts)
 
@@ -15,7 +29,8 @@ module.exports = opts => {
       toDescription($ => $('meta[name="description"]').attr('content')),
       toDescription($ => $('meta[itemprop="description"]').attr('content')),
       toDescription($jsonld('articleBody')),
-      toDescription($jsonld('description'))
+      toDescription($jsonld('description')),
+      toDescription($ => trimString($('p').innerText))
     ]
   }
 }


### PR DESCRIPTION
If description is missing use paragraph, use `<p>`
A naive implementation of how Facebook does it.