### PR TITLE
feat: unify `gotOpts`

### DIFF
--- a/packages/metascraper-amazon/index.js
+++ b/packages/metascraper-amazon/index.js
@@ -59,5 +59,6 @@ module.exports = () => {
   }
 
   rules.test = ({ url }) => isValidUrl(url)
+
   return rules
 }

--- a/packages/metascraper-iframe/src/index.js
+++ b/packages/metascraper-iframe/src/index.js
@@ -24,4 +24,4 @@ module.exports = ({ gotOpts } = {}) => {
   return rules
 }
 
-module.exports.test = test
+module.exports.isValidUrl = isValidUrl

--- a/packages/metascraper-iframe/src/index.js
+++ b/packages/metascraper-iframe/src/index.js
@@ -14,13 +14,13 @@ const isValidUrl = memoizeOne(
   memoizeOne.EqualityUrlAndHtmlDom
 )
 
-const test = ({ url, htmlDom }) => isValidUrl(url, htmlDom)
-
 module.exports = ({ gotOpts } = {}) => {
   const rules = {
     iframe: [fromHTML(gotOpts), fromProvider(gotOpts), fromTwitter(gotOpts)]
   }
-  rules.test = test
+
+  rules.test = ({ url, htmlDom }) => isValidUrl(url, htmlDom)
+
   return rules
 }
 

--- a/packages/metascraper-iframe/test/index.js
+++ b/packages/metascraper-iframe/test/index.js
@@ -8,7 +8,7 @@ const cheerio = require('cheerio')
 const createMetascraperIframe = require('..')
 const createMetascraper = require('metascraper')
 
-const { test } = createMetascraperIframe
+const { isValidUrl } = createMetascraperIframe
 
 const { getOembedUrl } = require('../src/from-html')
 
@@ -29,8 +29,7 @@ describe('metascraper-iframe', () => {
         commonProviders.forEach(url => {
           it(url, () => {
             const htmlDom = cheerio.load('')
-            const isValid = test({ url, htmlDom })
-            should(isValid).be.true()
+            should(isValidUrl(url, htmlDom)).be.true()
           })
         })
       })
@@ -39,8 +38,7 @@ describe('metascraper-iframe', () => {
         ;['https://example.com'].forEach(url => {
           it(url, () => {
             const htmlDom = cheerio.load('')
-            const isValid = test({ url, htmlDom })
-            should(isValid).be.false()
+            should(isValidUrl(url, htmlDom)).be.false()
           })
         })
       })
@@ -49,8 +47,7 @@ describe('metascraper-iframe', () => {
       const html = await readFile(resolve(__dirname, 'fixtures/genially.html'))
       const url = 'https://view.genial.ly/5dc53cfa759d2a0f4c7db5f4'
       const htmlDom = cheerio.load(html)
-      const isValid = test({ url, htmlDom })
-      should(isValid).be.true()
+      should(isValidUrl(url, htmlDom)).be.true()
     })
   })
 

--- a/packages/metascraper-instagram/index.js
+++ b/packages/metascraper-instagram/index.js
@@ -78,6 +78,8 @@ module.exports = () => {
     description: getData({ from: 'description' }),
     publisher: () => 'Instagram'
   }
+
   rules.test = ({ url }) => isValidUrl(url)
+
   return rules
 }

--- a/packages/metascraper-media-provider/README.md
+++ b/packages/metascraper-media-provider/README.md
@@ -23,20 +23,6 @@ Type: `string`
 
 It specifies cache based on file system to be used by [youtube-dl](youtube-dl).
 
-##### onError
-
-Type: `function`
-
-A function to be called when something wrong happens.
-
-It will receive `error` and `url`.
-
-```js
-const onError = (url, error) => {
-  console.error(`${url} failed: ${error.message}`)
-}
-```
-
 ##### getProxy
 
 Type: `function`
@@ -49,6 +35,18 @@ const getProxy = ({ url, retryCount }) => {
   return 'http://user:pwd@proxy:8001'
 }
 ```
+
+##### getAgent
+
+Type: `function`
+
+It receives as input the output from `.getProxy`. The output will be passed to `.gotOpts`.
+
+##### gotOpts
+
+Type: `object`
+
+Any option provided here will passed to [got#options](https://github.com/sindresorhus/got#options).
 
 ##### retry
 
@@ -63,12 +61,6 @@ Type: `number`<br>
 Default: `30000`
 
 The maximum time allowed to wait until considering the request as timed out.
-
-##### userAgent
-
-Type: `string`
-
-It specifies a custom user agent.
 
 ## License
 

--- a/packages/metascraper-media-provider/bench/constants.js
+++ b/packages/metascraper-media-provider/bench/constants.js
@@ -1,13 +1,28 @@
+const uniqueRandomArray = require('unique-random-array')
+
+const timeout = 4000
+
 module.exports = {
-  proxies: process.env.PROXIES.split(','),
-  urls: [
+  killSignal: 'SIGKILL',
+  reject: false,
+
+  gotOpts: {
+    timeout,
+    headers: {
+      'user-agent': 'googlebot'
+    }
+  },
+
+  timeout: timeout,
+  retry: 3,
+  getUrl: uniqueRandomArray([
     'https://twitter.com/Tour_du_Rwanda/status/1111166645475700737',
     'https://twitter.com/Visit_Murcia/status/1036982439829225472',
     'https://twitter.com/NBCNews/status/1034136310854963200',
     'https://twitter.com/Sportsnet/status/1034144032530653190',
-    'https://twitter.com/NFL/status/1034557736816541696',
+    'https://twitter.com/nflnetwork/status/1506348961338064896',
     'https://twitter.com/ufc/status/1027660288743464960',
     'https://twitter.com/NBA/status/1034525644288401408',
     'https://twitter.com/WorldRugby7s/status/1023907067298541568'
-  ]
+  ])
 }

--- a/packages/metascraper-media-provider/bench/provider/twitter/guest-token.js
+++ b/packages/metascraper-media-provider/bench/provider/twitter/guest-token.js
@@ -5,11 +5,10 @@ const debug = require('debug-logfmt')(
 )
 
 const { createGuestToken } = require('../../../src/get-media/provider/twitter')
-const userAgent = require('ua-string')
 
-const { getProxy } = require('../../constants')
+const opts = require('../../constants')
 
-const getGuestToken = createGuestToken({ userAgent, getProxy })
+const getGuestToken = createGuestToken(opts)
 
 // When it reaches the max, it returns a 429 rate limit error
 const mainLoop = async () => {

--- a/packages/metascraper-media-provider/bench/provider/twitter/index.js
+++ b/packages/metascraper-media-provider/bench/provider/twitter/index.js
@@ -11,14 +11,10 @@ const {
   createGetTwitterVideo
 } = require('../../../src/get-media/provider/twitter')
 
-const uniqueRandomArray = require('unique-random-array')
-const userAgent = require('ua-string')
+const { getUrl, ...opts } = require('../../constants')
 
-const { getProxy, urls } = require('../../constants')
-
-const getUrl = uniqueRandomArray(urls)
-const getGuestToken = createGuestToken({ userAgent, getProxy })
-const twitterVideo = createGetTwitterVideo({ userAgent, getGuestToken })
+const getGuestToken = createGuestToken(opts)
+const twitterVideo = createGetTwitterVideo({ ...opts, getGuestToken })
 
 const mainLoop = async () => {
   let n = 0

--- a/packages/metascraper-media-provider/package.json
+++ b/packages/metascraper-media-provider/package.json
@@ -27,7 +27,6 @@
     "async-memoize-one": "~1.1.0",
     "debug-logfmt": "~1.0.4",
     "got": "~11.8.3",
-    "keepalive-proxy-agent": "~1.2.2",
     "lodash": "~4.17.21",
     "p-do-whilst": "~1.1.0",
     "p-reflect": "~2.1.0",
@@ -43,9 +42,8 @@
     "pretty-ms": "latest",
     "should": "latest",
     "snap-shot": "latest",
-    "time-span": "latest",
-    "ua-string": "latest",
-    "unique-random-array": "latest"
+    "time-span": "4",
+    "unique-random-array": "2"
   },
   "engines": {
     "node": ">= 12"

--- a/packages/metascraper-media-provider/src/get-media/index.js
+++ b/packages/metascraper-media-provider/src/get-media/index.js
@@ -9,6 +9,7 @@ const { isTweetUrl } = require('./util')
 module.exports = props => {
   const fromGeneric = createGenericProvider(props)
   const fromTwitter = createTwitterProvider({ ...props, fromGeneric })
+
   return asyncMemoizeOne(async url => {
     const result = await (isTweetUrl(url) ? fromTwitter(url) : fromGeneric(url))
     return result || {}

--- a/packages/metascraper-media-provider/src/get-media/provider/twitter.js
+++ b/packages/metascraper-media-provider/src/get-media/provider/twitter.js
@@ -9,7 +9,7 @@ const pReflect = require('p-reflect')
 const pRetry = require('p-retry')
 const got = require('got')
 
-const { expirableCounter, getAgent, getTweetId } = require('../util')
+const { expirableCounter, getTweetId } = require('../util')
 
 // twitter guest web token
 // https://github.com/soimort/you-get/blob/da8c982608c9308765e0960e08fc28cccb74b215/src/you_get/extractors/twitter.py#L72
@@ -23,8 +23,9 @@ const canRetry = proxy => !!proxy
 
 const createGuestToken = ({
   timeout,
+  getAgent = constant(undefined),
   getProxy = constant(false),
-  userAgent
+  gotOpts = {}
 }) => {
   const retry = expirableCounter()
 
@@ -38,16 +39,15 @@ const createGuestToken = ({
 
       try {
         const { body } = await got.post(TWITTER_API_URL, {
+          ...gotOpts,
           timeout,
-          https: {
-            rejectUnauthorized: false
-          },
+          https: { rejectUnauthorized: false },
           responseType: 'json',
           agent,
           headers: {
+            ...gotOpts.headers,
             authorization: TWITTER_BEARER_TOKEN,
-            origin: 'https://twitter.com',
-            'user-agent': userAgent
+            origin: 'https://twitter.com'
           }
         })
         token = get(body, 'guest_token')
@@ -62,17 +62,18 @@ const createGuestToken = ({
   }
 }
 
-const createGetTwitterVideo = ({ userAgent, getGuestToken }) => {
+const createGetTwitterVideo = ({ gotOpts = {}, getGuestToken }) => {
   const getData = async (apiUrl, url, token) => {
     const { isFulfilled, value, reason } = await pReflect(
       got(apiUrl, {
+        ...gotOpts,
         responseType: 'json',
         headers: {
+          ...gotOpts.headers,
           referer: url,
           'x-guest-token': token,
           origin: 'https://twitter.com',
-          authorization: TWITTER_BEARER_TOKEN,
-          'user-agent': userAgent
+          authorization: TWITTER_BEARER_TOKEN
         }
       })
     )
@@ -89,9 +90,7 @@ const createGetTwitterVideo = ({ userAgent, getGuestToken }) => {
 
     const getContent = async () => {
       const token = await getGuestToken()
-      debug(
-        `getTwitterInfo apiUrl=${apiUrl} guestToken=${token} userAgent=${userAgent}`
-      )
+      debug(`getTwitterInfo apiUrl=${apiUrl} guestToken=${token}`)
 
       const payload = await getData(apiUrl, url, token)
 
@@ -116,8 +115,8 @@ const createGetTwitterVideo = ({ userAgent, getGuestToken }) => {
 
     await pRetry(getContent, {
       retries: 3,
-      onFailedAttempt: () => {
-        debug('getTwitterInfo rotating token')
+      onFailedAttempt: error => {
+        debug('getTwitterInfo rotating token', error)
       }
     })
 
@@ -125,9 +124,9 @@ const createGetTwitterVideo = ({ userAgent, getGuestToken }) => {
   }
 }
 
-module.exports = ({ fromGeneric, userAgent, getProxy }) => {
-  const getGuestToken = createGuestToken({ getProxy, userAgent })
-  const getTwitterVideo = createGetTwitterVideo({ getGuestToken, userAgent })
+module.exports = ({ fromGeneric, getProxy, gotOpts }) => {
+  const getGuestToken = createGuestToken({ getProxy, gotOpts })
+  const getTwitterVideo = createGetTwitterVideo({ getGuestToken, gotOpts })
 
   return async url => {
     const [videoInfo, twitterVideos] = await Promise.all([

--- a/packages/metascraper-media-provider/src/get-media/util.js
+++ b/packages/metascraper-media-provider/src/get-media/util.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { getDomainWithoutSuffix } = require('tldts')
-const Agent = require('keepalive-proxy-agent')
 
 const TEN_MIN_MS = 10 * 60 * 1000
 
@@ -11,17 +10,6 @@ const isTweetUrl = url =>
   isTweet(url) && getDomainWithoutSuffix(url) === 'twitter'
 
 const getTweetId = url => url.split('/').reverse()[0]
-
-const getAgent = proxy => {
-  if (!proxy) return undefined
-  return {
-    [proxy.protocol]: new Agent({
-      keepAlive: false,
-      rejectUnauthorized: false,
-      proxy
-    })
-  }
-}
 
 const expirableCounter = (value = 0, ttl = TEN_MIN_MS) => {
   let timestamp = Date.now()
@@ -45,7 +33,6 @@ const expirableCounter = (value = 0, ttl = TEN_MIN_MS) => {
 
 module.exports = {
   expirableCounter,
-  getAgent,
   getTweetId,
   isTweet,
   isTweetUrl

--- a/packages/metascraper-spotify/README.md
+++ b/packages/metascraper-spotify/README.md
@@ -11,6 +11,18 @@
 $ npm install metascraper-spotify --save
 ```
 
+## API
+
+### metascraper-spotify([options])
+
+#### options
+
+##### gotOpts
+
+Type: `object`
+
+Any option provided here will passed to [got#options](https://github.com/sindresorhus/got#options).
+
 ## License
 
 **metascraper-spotify** © [Microlink](https://microlink.io), Released under the [MIT](https://github.com/microlinkhq/metascraper/blob/master/LICENSE.md) License.<br>

--- a/packages/metascraper-spotify/package.json
+++ b/packages/metascraper-spotify/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "@metascraper/helpers": "^5.26.0",
     "async-memoize-one": "~1.1.0",
-    "spotify-url-info": "~2.2.9",
+    "got": "~11.8.3",
+    "spotify-url-info": "~3.0.0",
     "tldts": "~5.7.70"
   },
   "devDependencies": {

--- a/packages/metascraper-telegram/index.js
+++ b/packages/metascraper-telegram/index.js
@@ -57,6 +57,8 @@ module.exports = () => {
       })
     ]
   }
+
   rules.test = ({ url }) => isValidUrl(url)
+
   return rules
 }


### PR DESCRIPTION
### metascraper-spotify 

- Add `gotOpts` support.

### metascraper-media-provider

- Removed `keepalive-proxy-agent` dependency, use `getAgent` instead.