### PR TITLE
perf(logo-favicon): memoize urls resolution

### DIFF
--- a/packages/metascraper-logo-favicon/README.md
+++ b/packages/metascraper-logo-favicon/README.md
@@ -44,6 +44,12 @@ Type: `object`
 
 Any option provided here will passed to [got#options](https://github.com/sindresorhus/got#options).
 
+##### keyvOpts
+
+Type: `object`
+
+Any option provided here will passed to [@keyvhq/memoize#options](https://github.com/microlinkhq/keyv/tree/master/packages/memoize#keyvoptions).
+
 ## License
 
 **metascraper-logo-favicon** © [Microlink](https://microlink.io), Released under the [MIT](https://github.com/microlinkhq/metascraper/blob/master/LICENSE.md) License.<br>

--- a/packages/metascraper-logo-favicon/package.json
+++ b/packages/metascraper-logo-favicon/package.json
@@ -23,6 +23,7 @@
     "metascraper"
   ],
   "dependencies": {
+    "@keyvhq/memoize": "~1.6.6",
     "@metascraper/helpers": "^5.26.0",
     "lodash": "~4.17.21",
     "reachable-url": "~1.6.7"


### PR DESCRIPTION
Using a function memoizer. This is a necessary thing in this case because http agent only cache succesful/redirect responses.

In this very particular cases, the most common scenario is favicon is missing (404).

Since keyv doesn't store `undefined`, in that case we convert it to `null` and then back to `undefined`.