### PR TITLE
feat(logo-favicon): root domain resolution

### DIFF
--- a/packages/metascraper-logo-favicon/package.json
+++ b/packages/metascraper-logo-favicon/package.json
@@ -26,7 +26,8 @@
     "@keyvhq/memoize": "~1.6.6",
     "@metascraper/helpers": "^5.26.0",
     "lodash": "~4.17.21",
-    "reachable-url": "~1.6.7"
+    "reachable-url": "~1.6.7",
+    "tldts": "~5.7.70"
   },
   "devDependencies": {
     "mocha": "latest",

--- a/packages/metascraper-logo-favicon/test/index.js
+++ b/packages/metascraper-logo-favicon/test/index.js
@@ -212,4 +212,11 @@ describe('metascraper-logo-favicon', () => {
     const meta = await metascraper({ url, html })
     should(meta.logo).be.null()
   })
+
+  it('resolve domain favicon', async () => {
+    const url = 'https://cdn.teslahunt.io/foo/bar'
+    const metascraper = createMetascraper()
+    const meta = await metascraper({ url })
+    should(meta.logo).be.equal('https://teslahunt.io/favicon.ico')
+  })
 })


### PR DESCRIPTION
This new rule is oriented for resolving favicon.ico at subdomain urls.

e.g., cdn.teslahunt.io/favicon.ico will be missing, but teslahunt.io/favicon.io will be available.