### PR TITLE
metascraper-audio: better iframe detection

### DIFF
--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -237,7 +237,7 @@ const author = (value, opts) =>
   isAuthor(value) ? getAuthor(value, opts) : undefined
 
 const url = (value, { url = '' } = {}) => {
-  if (isEmpty(value)) return undefined
+  if (isEmpty(value)) return
 
   try {
     const absoluteUrl = normalizeUrl(url, value)
@@ -252,7 +252,7 @@ const getISODate = date =>
 
 const date = value => {
   if (isDate(value)) return value.toISOString()
-  if (!(isString(value) || isNumber(value))) return undefined
+  if (!(isString(value) || isNumber(value))) return
 
   // remove whitespace for easier parsing
   if (isString(value)) value = condenseWhitespace(value)
@@ -288,7 +288,7 @@ const date = value => {
 }
 
 const lang = input => {
-  if (isEmpty(input) || !isString(input)) return undefined
+  if (isEmpty(input) || !isString(input)) return
   const key = toLower(condenseWhitespace(input))
   if (input.length === 3) return iso6393[key]
   const lang = toLower(key.substring(0, 2))
@@ -429,8 +429,8 @@ const loadIframe = (url, $) =>
     const load = iframe =>
       iframe
         ? iframe.addEventListener('load', () =>
-          resolve($.load(iframe.contentDocument.documentElement.outerHTML))
-        )
+            resolve($.load(iframe.contentDocument.documentElement.outerHTML))
+          )
         : resolve($.load(''))
 
     const iframe = getIframe()

--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -407,15 +407,7 @@ const composeRule = rule => ({ from, to = from, ...opts }) => async ({
 const has = value =>
   value !== undefined && !Number.isNaN(value) && hasValues(value)
 
-const domLoaded = dom =>
-  new Promise(resolve =>
-    dom.window.document.readyState === 'interactive' ||
-    dom.window.document.readyState === 'complete'
-      ? resolve()
-      : dom.window.document.addEventListener('DOMContentLoaded', resolve)
-  )
-
-const loadIframe = (url, $) =>
+const loadIframe = (url, $, { timeout = 5000 } = {}) =>
   new Promise(resolve => {
     const dom = new JSDOM($.html(), {
       url,
@@ -424,19 +416,29 @@ const loadIframe = (url, $) =>
       resources: 'usable'
     })
 
-    const getIframe = () => dom.window.document.querySelector('iframe')
+    const done = (html = '') => resolve($.load(html))
 
-    const load = iframe =>
-      iframe
-        ? iframe.addEventListener('load', () =>
-            resolve($.load(iframe.contentDocument.documentElement.outerHTML))
-          )
-        : resolve($.load(''))
+    const listen = (element, method, fn) =>
+      element[`${method}EventListener`]('load', fn, {
+        capture: true,
+        once: true,
+        passive: true
+      })
 
-    const iframe = getIframe()
-    if (iframe) return load(iframe)
+    const iframe = dom.window.document.querySelector('iframe')
+    if (!iframe) return done()
 
-    domLoaded(dom).then(() => load(getIframe()))
+    const timer = setTimeout(() => {
+      listen(iframe, 'remove', load)
+      done()
+    }, timeout)
+
+    function load () {
+      clearTimeout(timer)
+      done(iframe.contentDocument.documentElement.outerHTML)
+    }
+
+    listen(iframe, 'add', load)
   })
 
 module.exports = {

--- a/packages/metascraper-helpers/test/load-iframe.js
+++ b/packages/metascraper-helpers/test/load-iframe.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const cheerio = require('cheerio')
+const test = require('ava')
+
+const { loadIframe } = require('..')
+
+test('timeout support', async t => {
+  const url =
+    'https://accounts.google.com/gsi/iframe/select?client_id=1005640118348-amh5tgkq641oru4fbhr3psm3gt2tcc94.apps.googleusercontent.com&ux_mode=popup&ui_mode=card&as=GAUOzT7W7w8RiyH1fhs9TQ&channel_id=c8d85ad52a58747f6547a90cd4bb19047262e93029f574d126cf2095a7a80f9b&origin=https%3A%2F%2Fwww.nytimes.com'
+  const $ = cheerio.load(`<iframe src="${url}"></iframe>`)
+
+  const $iframe = await loadIframe(url, $)
+  t.is($iframe.html(), '<html><head></head><body></body></html>')
+})
+
+test('wait `load` event', async t => {
+  const url =
+    'https://wbez-rss.streamguys1.com/player/player21011316001810372.html'
+  const $ = cheerio.load(`<iframe src="${url}"></iframe>`)
+
+  const $iframe = await loadIframe(url, $)
+  t.true($iframe.html().includes('twitter:player'))
+})

--- a/packages/metascraper-manifest/index.js
+++ b/packages/metascraper-manifest/index.js
@@ -29,7 +29,7 @@ module.exports = opts => {
 
   const toManifest = ($, url) => {
     const manifestUrl = $('link[rel="manifest"]').attr('href')
-    if (!manifestUrl) return undefined
+    if (!manifestUrl) return
     return fetchManifest(normalizeUrl(url, manifestUrl))
   }
 

--- a/packages/metascraper/test/integration/bfi/input.html
+++ b/packages/metascraper/test/integration/bfi/input.html
@@ -515,6 +515,10 @@
           <div class="grid-x grid-margin-x">
             <div class="primary-column">
               <div class="featured-media featured-media--audio">
+                <iframe></iframe>
+                <iframe src="fake"></iframe>
+                <iframe src="/fake"></iframe>
+                <iframe src="/fake"></iframe>
                 <iframe
                   src="//wbez-rss.streamguys1.com/player/player21011316001810372.html"
                   frameborder="0" scrolling="no" width="740" height="210"


### PR DESCRIPTION
The current `metascraper-audio` implementation is trying to apply audio rules over the first iframe detected on the site:

```js
const src = $filter($, iframe, el => normalizeUrl(url, el.attr('src')))
```

I noted some sites has third-party ads service that inject iframe, so the current implementation is not going to detect nothing, even the site could have other iframes with audio content.

What could be a better approach is to resolve audio rules per all iframes present. This is reasonably fast if it's done in parallel and only wait for the first audio iframe in the best case.