### PR TITLE
perf: avoid spread for initialization 

### DIFF
--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -70,17 +70,26 @@ const IMAGE = 'image'
 
 const imageExtensions = chain(require('image-extensions'))
   .concat(['avif'])
-  .reduce((acc, ext) => ({ ...acc, [ext]: IMAGE }), {})
+  .reduce((acc, ext) => {
+    acc[ext] = IMAGE
+    return acc
+  }, {})
   .value()
 
 const audioExtensions = chain(require('audio-extensions'))
   .concat(['mpga'])
   .difference(['mp4'])
-  .reduce((acc, ext) => ({ ...acc, [ext]: AUDIO }), {})
+  .reduce((acc, ext) => {
+    acc[ext] = AUDIO
+    return acc
+  }, {})
   .value()
 
 const videoExtensions = chain(require('video-extensions'))
-  .reduce((acc, ext) => ({ ...acc, [ext]: VIDEO }), {})
+  .reduce((acc, ext) => {
+    acc[ext] = VIDEO
+    return acc
+  }, {})
   .value()
 
 const EXTENSIONS = {


### PR DESCRIPTION
Normally I don't put much attention in micro benchmarking, but startup time is a thing.

<img width="753" alt="CleanShot 2022-11-03 at 17 16 08@2x" src="https://user-images.githubusercontent.com/2096101/199775232-14f5fc20-dbe9-4e00-8494-b578f455b1fb.png">

https://measurethat.net/Benchmarks/Show/3431/0/spread-vs-mutation-vs-objectassign-for-reduce-callback
