### PR TITLE
perf: unify tldts

### DIFF
--- a/packages/metascraper-amazon/index.js
+++ b/packages/metascraper-amazon/index.js
@@ -3,14 +3,13 @@
 const {
   $filter,
   author,
-  toRule,
   lang,
   memoizeOne,
+  parseUrl,
   title,
+  toRule,
   url
 } = require('@metascraper/helpers')
-
-const { getPublicSuffix } = require('tldts')
 
 const REGEX_AMAZON_URL = /https?:\/\/(.*amazon\..*\/.*|.*amzn\..*\/.*|.*a\.co\/.*)/i
 
@@ -30,7 +29,7 @@ const SUFFIX_LANGUAGES = {
   it: 'it'
 }
 
-const getDomainLanguage = url => SUFFIX_LANGUAGES[getPublicSuffix(url)]
+const getDomainLanguage = url => SUFFIX_LANGUAGES[parseUrl(url).publicSuffix]
 
 const toUrl = toRule(url)
 const toAuthor = toRule(author)

--- a/packages/metascraper-amazon/package.json
+++ b/packages/metascraper-amazon/package.json
@@ -22,8 +22,7 @@
     "metascraper"
   ],
   "dependencies": {
-    "@metascraper/helpers": "^5.31.1",
-    "tldts": "~5.7.92"
+    "@metascraper/helpers": "^5.31.1"
   },
   "devDependencies": {
     "ava": "latest"

--- a/packages/metascraper-clearbit/index.js
+++ b/packages/metascraper-clearbit/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const { composeRule } = require('@metascraper/helpers')
+const { composeRule, parseUrl } = require('@metascraper/helpers')
 const { get, isString, isObject } = require('lodash')
 const asyncMemoizeOne = require('async-memoize-one')
 const { stringify } = require('querystring')
 const memoize = require('@keyvhq/memoize')
-const { getDomain } = require('tldts')
 const got = require('got')
 
 const ENDPOINT = 'https://autocomplete.clearbit.com/v1/companies/suggest'
@@ -42,7 +41,7 @@ const createClearbit = ({ gotOpts, keyvOpts, logoOpts } = {}) => {
 
 module.exports = opts => {
   const clearbit = createClearbit(opts)
-  const getClearbit = composeRule(($, url) => clearbit(getDomain(url)))
+  const getClearbit = composeRule(($, url) => clearbit(parseUrl(url).domain))
 
   return {
     logo: getClearbit({ from: 'logo' }),

--- a/packages/metascraper-clearbit/package.json
+++ b/packages/metascraper-clearbit/package.json
@@ -28,8 +28,7 @@
     "@metascraper/helpers": "^5.31.1",
     "async-memoize-one": "~1.1.2",
     "got": "~11.8.5",
-    "lodash": "~4.17.21",
-    "tldts": "~5.7.92"
+    "lodash": "~4.17.21"
   },
   "devDependencies": {
     "ava": "latest"

--- a/packages/metascraper-helpers/index.js
+++ b/packages/metascraper-helpers/index.js
@@ -1,25 +1,5 @@
 'use strict'
 
-const {
-  chain,
-  eq,
-  flow,
-  get,
-  includes,
-  invoke,
-  isArray,
-  isBoolean,
-  isDate,
-  isEmpty,
-  isNumber,
-  isString,
-  lte,
-  replace,
-  size,
-  toLower,
-  toString
-} = require('lodash')
-
 const memoizeOne = require('memoize-one').default || require('memoize-one')
 const urlRegex = require('url-regex-safe')({ exact: true, parens: true })
 const condenseWhitespace = require('condense-whitespace')
@@ -37,8 +17,32 @@ const chrono = require('chrono-node')
 const isIso = require('isostring')
 const isUri = require('is-uri')
 const { URL } = require('url')
+const tldts = require('tldts')
+
+const {
+  chain,
+  eq,
+  flow,
+  get,
+  includes,
+  invoke,
+  isArray,
+  isBoolean,
+  isDate,
+  isEmpty,
+  isNumber,
+  isString,
+  lte,
+  memoize,
+  replace,
+  size,
+  toLower,
+  toString
+} = require('lodash')
 
 const iso6393Values = Object.values(iso6393)
+
+const parseUrl = memoize(tldts.parse)
 
 const toTitle = str =>
   capitalize(str, [
@@ -488,6 +492,7 @@ module.exports = {
   memoizeOne,
   mimeExtension,
   normalizeUrl,
+  parseUrl,
   protocol,
   publisher,
   sanetizeUrl,

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -22,8 +22,22 @@ const {
   isVideoUrl,
   lang,
   normalizeUrl,
+  parseUrl,
   url
 } = require('..')
+
+const measure = fn => {
+  const time = process.hrtime()
+  fn()
+  const diff = process.hrtime(time)
+  return (diff[0] * 1e9 + diff[1]) / 1e6
+}
+
+test('.parseUrl', t => {
+  const fn = () => parseUrl('https://example.com')
+  /* this assertion ensure parseUrl memoize the value */
+  t.true(measure(fn) > measure(fn)) // eslint-disable-line
+})
 
 test('.normalizeUrl', t => {
   t.is(normalizeUrl('https://example.com', 'javascript:false'), undefined)

--- a/packages/metascraper-instagram/index.js
+++ b/packages/metascraper-instagram/index.js
@@ -1,11 +1,12 @@
 'use strict'
 
-const { memoizeOne, composeRule } = require('@metascraper/helpers')
-const { getDomainWithoutSuffix } = require('tldts')
+const { composeRule, memoizeOne, parseUrl } = require('@metascraper/helpers')
 const { JSDOM, VirtualConsole } = require('jsdom')
 const { keys, first, get } = require('lodash')
 
-const test = memoizeOne(url => getDomainWithoutSuffix(url) === 'instagram')
+const test = memoizeOne(
+  url => parseUrl(url).domainWithoutSuffix === 'instagram'
+)
 
 const getPage = sharedData => first(keys(get(sharedData, 'entry_data')))
 
@@ -64,6 +65,7 @@ const extractData = memoizeOne((url, $) => {
     }
   }
 })
+
 const getData = composeRule(($, url) => extractData(url, $))
 
 module.exports = () => {

--- a/packages/metascraper-instagram/package.json
+++ b/packages/metascraper-instagram/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@metascraper/helpers": "^5.31.1",
     "jsdom": "~20.0.0",
-    "lodash": "~4.17.21",
-    "tldts": "~5.7.92"
+    "lodash": "~4.17.21"
   },
   "devDependencies": {
     "ava": "latest"

--- a/packages/metascraper-logo-favicon/index.js
+++ b/packages/metascraper-logo-favicon/index.js
@@ -3,10 +3,10 @@
 const { isEmpty, first, toNumber, chain, get, orderBy } = require('lodash')
 const reachableUrl = require('reachable-url')
 const memoize = require('@keyvhq/memoize')
-const { getDomain } = require('tldts')
 
 const {
   logo,
+  parseUrl,
   memoizeOne,
   normalizeUrl,
   toRule,
@@ -138,7 +138,7 @@ module.exports = ({ gotOpts, keyvOpts, pickFn = pickBiggerSize } = {}) => {
       async ({ url }) => castNull(await getLogo(normalizeUrl(url))),
       async ({ url }) => {
         const urlObj = new URL(url)
-        urlObj.hostname = getDomain(url)
+        urlObj.hostname = parseUrl(url).domain
         const result = await getLogo(normalizeUrl(urlObj))
         return castNull(result)
       }

--- a/packages/metascraper-logo-favicon/package.json
+++ b/packages/metascraper-logo-favicon/package.json
@@ -26,8 +26,7 @@
     "@keyvhq/memoize": "~1.6.14",
     "@metascraper/helpers": "^5.31.1",
     "lodash": "~4.17.21",
-    "reachable-url": "~1.7.0",
-    "tldts": "~5.7.92"
+    "reachable-url": "~1.7.0"
   },
   "devDependencies": {
     "ava": "latest"

--- a/packages/metascraper-media-provider/package.json
+++ b/packages/metascraper-media-provider/package.json
@@ -32,7 +32,6 @@
     "p-reflect": "~2.1.0",
     "p-retry": "~4.6.1",
     "p-timeout": "~4.1.0",
-    "tldts": "~5.7.92",
     "youtube-dl-exec": "~2.1.5"
   },
   "devDependencies": {

--- a/packages/metascraper-media-provider/src/get-media/util.js
+++ b/packages/metascraper-media-provider/src/get-media/util.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getDomainWithoutSuffix } = require('tldts')
+const { parseUrl } = require('@metascraper/helpers')
 const { chain } = require('lodash')
 
 const TEN_MIN_MS = 10 * 60 * 1000
@@ -8,7 +8,7 @@ const TEN_MIN_MS = 10 * 60 * 1000
 const isTweet = url => url.includes('/status/')
 
 const isTweetUrl = url =>
-  isTweet(url) && getDomainWithoutSuffix(url) === 'twitter'
+  isTweet(url) && parseUrl(url).domainWithoutSuffix === 'twitter'
 
 const getTweetId = url =>
   chain(url)

--- a/packages/metascraper-soundcloud/index.js
+++ b/packages/metascraper-soundcloud/index.js
@@ -1,19 +1,20 @@
 'use strict'
 
-const { getDomainWithoutSuffix } = require('tldts')
-
 const {
   $filter,
   author,
   description,
-  toRule,
-  memoizeOne
+  memoizeOne,
+  parseUrl,
+  toRule
 } = require('@metascraper/helpers')
 
 const toDescription = toRule(description)
 const toAuthor = toRule(author)
 
-const test = memoizeOne(url => getDomainWithoutSuffix(url) === 'soundcloud')
+const test = memoizeOne(
+  url => parseUrl(url).domainWithoutSuffix === 'soundcloud'
+)
 
 module.exports = () => {
   const rules = {

--- a/packages/metascraper-soundcloud/package.json
+++ b/packages/metascraper-soundcloud/package.json
@@ -23,8 +23,7 @@
     "soundcloud"
   ],
   "dependencies": {
-    "@metascraper/helpers": "^5.31.1",
-    "tldts": "~5.7.92"
+    "@metascraper/helpers": "^5.31.1"
   },
   "devDependencies": {
     "ava": "latest"

--- a/packages/metascraper-spotify/index.js
+++ b/packages/metascraper-spotify/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const asyncMemoizeOne = require('async-memoize-one')
-const { getDomainWithoutSuffix } = require('tldts')
 const memoize = require('@keyvhq/memoize')
 const got = require('got')
 
@@ -12,6 +11,7 @@ const {
   description,
   memoizeOne,
   normalizeUrl,
+  parseUrl,
   sanetizeUrl,
   toRule
 } = require('@metascraper/helpers')
@@ -42,7 +42,7 @@ const createSpotify = ({ gotOpts, keyvOpts }) => {
   )
 }
 
-const test = memoizeOne(url => getDomainWithoutSuffix(url) === 'spotify')
+const test = memoizeOne(url => parseUrl(url).domainWithoutSuffix === 'spotify')
 
 module.exports = ({ gotOpts, keyvOpts } = {}) => {
   const spotify = createSpotify({ gotOpts, keyvOpts })

--- a/packages/metascraper-spotify/package.json
+++ b/packages/metascraper-spotify/package.json
@@ -27,8 +27,7 @@
     "@metascraper/helpers": "^5.31.1",
     "async-memoize-one": "~1.1.2",
     "got": "~11.8.5",
-    "spotify-url-info": "~3.1.8",
-    "tldts": "~5.7.92"
+    "spotify-url-info": "~3.1.8"
   },
   "devDependencies": {
     "ava": "latest",

--- a/packages/metascraper-telegram/index.js
+++ b/packages/metascraper-telegram/index.js
@@ -5,12 +5,12 @@ const {
   date,
   image,
   memoizeOne,
+  parseUrl,
   sanetizeUrl,
   toRule
 } = require('@metascraper/helpers')
 
 const memoize = require('@keyvhq/memoize')
-const { getDomain } = require('tldts')
 const pReflect = require('p-reflect')
 const cssUrls = require('css-urls')
 const got = require('got')
@@ -21,7 +21,7 @@ const toDate = toRule(date)
 
 const TELEGRAM_DOMAINS = ['telegram.me', 't.me']
 
-const test = memoizeOne(url => TELEGRAM_DOMAINS.includes(getDomain(url)))
+const test = memoizeOne(url => TELEGRAM_DOMAINS.includes(parseUrl(url).domain))
 
 const createGetIframe = gotOpts => async (url, $) => {
   const iframe = $('iframe')

--- a/packages/metascraper-uol/index.js
+++ b/packages/metascraper-uol/index.js
@@ -1,20 +1,19 @@
 'use strict'
 
-const { getDomain } = require('tldts')
-
 const {
-  $jsonld,
   $filter,
-  title,
+  $jsonld,
   description,
-  toRule,
-  memoizeOne
+  memoizeOne,
+  parseUrl,
+  title,
+  toRule
 } = require('@metascraper/helpers')
 
 const ROOT_DOMAINS = ['uol.com.br', 'torcedores.com']
 
 const test = memoizeOne(url =>
-  ROOT_DOMAINS.some(domain => getDomain(url) === domain)
+  ROOT_DOMAINS.some(domain => parseUrl(url).domain === domain)
 )
 
 const toTitle = toRule(title)


### PR DESCRIPTION
The goal is to avoid reparse values already computed previously.

This PR unifies `tldts` inside metascraper helper, wrapped by `lodash.memoize`.

A little benchmark performed inside tests:

- first method call: 0.30225ms
- successive calls: 0.016458ms