### PR TITLE
Remove re2 from package.json

### DIFF
--- a/packages/metascraper-helpers/package.json
+++ b/packages/metascraper-helpers/package.json
@@ -39,7 +39,6 @@
     "microsoft-capitalize": "~1.0.5",
     "mime": "~3.0.0",
     "normalize-url": "~6.1.0",
-    "re2": "~1.17.7",
     "smartquotes": "~2.3.2",
     "tldts": "~5.7.92",
     "url-regex-safe": "~3.0.0",


### PR DESCRIPTION
It doesn't appear to be used and it requires node-gyp to build which can cause all kinds of problems during installation. If it's not actually used let's get rid of it. If it is used, maybe it can be removed in favor of something simpler?