### PR TITLE
fix(metascraper-logo-favicon): types reference in package.json

### DIFF
--- a/packages/metascraper-logo-favicon/package.json
+++ b/packages/metascraper-logo-favicon/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://nicedoc.io/microlinkhq/metascraper/packages/metascraper-logo-favicon",
   "version": "5.42.2",
   "main": "src/index.js",
-  "types": "types/index.d.ts",
+  "types": "src/index.d.ts",
   "author": {
     "email": "hello@microlink.io",
     "name": "microlink.io",


### PR DESCRIPTION
Fixes `.d.ts` file export  in package.json so types can be properly discovered.

![image](https://github.com/microlinkhq/metascraper/assets/10532751/82bfdebc-93ef-47c6-9c7f-d27c21262e9d)
