### PR TITLE
fix metascraper-video missing p-reflect in package.json

### DIFF
--- a/packages/metascraper-video/package.json
+++ b/packages/metascraper-video/package.json
@@ -24,7 +24,8 @@
   ],
   "dependencies": {
     "@metascraper/helpers": "^5.45.0",
-    "lodash": "~4.17.21"
+    "lodash": "~4.17.21",
+    "p-reflect": "^2.1.0"
   },
   "devDependencies": {
     "async-listen": "latest",

--- a/packages/metascraper-video/package.json
+++ b/packages/metascraper-video/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@metascraper/helpers": "^5.45.0",
     "lodash": "~4.17.21",
-    "p-reflect": "^2.1.0"
+    "p-reflect": "~2.1.0"
   },
   "devDependencies": {
     "async-listen": "latest",


### PR DESCRIPTION
[p-reflect](https://www.npmjs.com/package/p-reflect/v/2.1.0) is not a dependency of metascraper-video but it requires it here:
https://github.com/microlinkhq/metascraper/blob/8e964f23d760062c77e7513d1d3e87416c511499/packages/metascraper-video/src/index.js#L15