### PR TITLE
fix(metascraper-logo-favicon): allow URL input and apply priority

### DIFF
--- a/packages/metascraper-logo-favicon/src/index.js
+++ b/packages/metascraper-logo-favicon/src/index.js
@@ -78,7 +78,7 @@ const getDomNodeSizes = (domNodes, attr, url) =>
         {
           ...domNode.attribs,
           url: normalizedUrl,
-          size: getSize(url, domNode.attribs.sizes)
+          size: getSize(normalizedUrl, domNode.attribs.sizes)
         }
       ]
     }, [])
@@ -163,8 +163,8 @@ const createFavicon = (
     const faviconUrl = logo(`/favicon.${ext}`, { url })
     return faviconUrl
       ? resolveFaviconUrl(faviconUrl, contentTypes, gotOpts).then(
-        response => response?.url
-      )
+          response => response?.url
+        )
       : undefined
   }
 }

--- a/packages/metascraper-logo-favicon/test/index.js
+++ b/packages/metascraper-logo-favicon/test/index.js
@@ -85,6 +85,17 @@ test('get the biggest icon possible', async t => {
   t.is(metadata.logo, 'https://cdn.microlink.io/logo/favicon-196x196.png')
 })
 
+test('prefers small png over large ico', async t => {
+  const url = 'https://github.com'
+  const metascraper = createMetascraper()
+  const html = createHtml([
+    '<link rel="icon" type="image/png" href="/fluidicon.png" sizes="96x96">',
+    '<link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="128x128">'
+  ])
+  const metadata = await metascraper({ url, html })
+  t.is(metadata.logo, 'https://github.com/fluidicon.png')
+})
+
 test('detect `rel="fluid-icon"`', async t => {
   const url = 'https://github.com'
   const metascraper = createMetascraper()


### PR DESCRIPTION
closes #724

The `priority` function has not been running properly: https://github.com/microlinkhq/metascraper/blob/cfe41bb4ef30ce7d4e6dee418270057706db937c/packages/metascraper-logo-favicon/src/index.js#L54-L61

The new test fails before my change, and passes after it