### PR TITLE
chore(readability): use worker threads

### DIFF
--- a/packages/metascraper-readability/README.md
+++ b/packages/metascraper-readability/README.md
@@ -20,13 +20,6 @@ $ npm install metascraper-readability --save
 
 #### options
 
-##### getDocument
-
-Type: `function`<br>
-Default: [source code](https://github.com/microlinkhq/metascraper/blob/master/packages/metascraper-readability/src/index.js#L14-L20)
-
-The function to be called to serialized html into a DOM document.
-
 ##### readabilityOpts
 
 Type: `object`

--- a/packages/metascraper-readability/package.json
+++ b/packages/metascraper-readability/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@metascraper/helpers": "workspace:*",
     "@mozilla/readability": "~0.5.0",
+    "async-memoize-one": "~1.1.8",
     "happy-dom": "~16.5.3"
   },
   "devDependencies": {
@@ -37,7 +38,10 @@
     "src"
   ],
   "scripts": {
-    "test": "NODE_PATH=.. TZ=UTC ava --timeout 15s"
+    "test": "NODE_PATH=.. TZ=UTC ava"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "ava": {
+    "timeout": "15s"
+  }
 }

--- a/packages/metascraper-readability/src/index.d.ts
+++ b/packages/metascraper-readability/src/index.d.ts
@@ -1,5 +1,4 @@
 type Options = {
-  getDocument: ({url: string, html: string }) => Document,
   readabilityOpts: import('readability').ReadabilityOptions,
 }
 

--- a/packages/metascraper-readability/src/worker.js
+++ b/packages/metascraper-readability/src/worker.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { workerData, parentPort } = require('node:worker_threads')
+const { Readability } = require('@mozilla/readability')
+
+const parseReader = reader => {
+  try {
+    return reader.parse()
+  } catch (_) {
+    return {}
+  }
+}
+
+const getDocument = ({ url, html }) => {
+  const { Window } = require('happy-dom')
+  const window = new Window({ url })
+  const document = window.document
+  document.documentElement.innerHTML = html
+  return document
+}
+
+const main = async ({ url, html, readabilityOpts } = {}) => {
+  const document = getDocument({ url, html })
+  const reader = new Readability(document, readabilityOpts)
+  return parseReader(reader)
+}
+
+main(workerData).then(result => parentPort.postMessage(JSON.stringify(result)))


### PR DESCRIPTION
`happy-dom` throws unhandled exceptions based on the target URL markup, so there is no way to don't pullate the main Node.js process.