### PR TITLE
fix(types): Allow test and pkgName in Rules while preserving generic metadata keys

### DIFF
--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -95,9 +95,11 @@ declare namespace createMetascraper {
     [key: string]: string | undefined;
   }
 
-  export type Rules = {
-    [C in keyof Metadata]?: Array<RulesOptions> | RulesOptions;
-  } & {
+  type NamedRules = {
+    [C in keyof Metadata as string extends C ? never : C]?: Array<RulesOptions> | RulesOptions;
+  };
+
+  export interface Rules extends NamedRules {
     /**
      * The test function to be executed for skipping rules that doesn't return `true`.
      */
@@ -106,7 +108,18 @@ declare namespace createMetascraper {
      * The package name associated with the rule, used for debugging purposes.
      */
     pkgName?: string;
-  };
+    /**
+     * allow any other string key to be
+     * a rule-function (for ad-hoc metadata),
+     * or the two special keys above.
+     **/
+    [key: string]:
+      | Array<RulesOptions>
+      | RulesOptions
+      | ((options: RulesTestOptions) => boolean)
+      | string
+      | undefined;
+  }
 
   export type RulesOptions = (
     options: RulesTestOptions


### PR DESCRIPTION
This change refactors the Rules type in index.d.ts to eliminate the conflicting index‑signature behaviour and support both:

1. Strongly‑typed named metadata keys
We introduce a NamedRules mapped type that only includes the literal keys of Metadata, so plugins get proper autocompletion and excess‑property checking on known fields.

2. test and pkgName properties
We extend NamedRules with the two special properties `test?: (opts: RulesTestOptions) => boolean` and `pkgName?: string` so they no longer clash with the generic rule‑function signature.

3. Single unified index signature
A single [key: string]: … signature now covers:

- rule‑functions (RulesOptions or RulesOptions[]),
- the test function,
- the pkgName string,
- any other ad‑hoc metadata keys.

Why is this needed?

When adding pkgName or test to a plugin’s Rules object, TypeScript was treating every string key as a RulesOptions, causing **TS2322** errors. This refactoring preserves full backward‑compatibility with existing plugins (including official metascraper plugins) while allowing authors to specify test and pkgName without type conflicts.