### PR TITLE
chore(readability): avoid errors propagation

### DIFF
--- a/packages/metascraper-readability/src/worker.js
+++ b/packages/metascraper-readability/src/worker.js
@@ -11,13 +11,14 @@ const parseReader = reader => {
   }
 }
 
+const errorCapture =
+  process.env.NODE_ENV === 'test' ? 'tryAndCatch' : 'processLevel'
+
 const getDocument = ({ url, html }) => {
   const { Window } = require('happy-dom')
   const window = new Window({
     url,
-    settings: {
-      errorCapture: 'processLevel'
-    }
+    settings: { errorCapture }
   })
   const document = window.document
   document.write(html)

--- a/packages/metascraper-readability/src/worker.js
+++ b/packages/metascraper-readability/src/worker.js
@@ -13,7 +13,12 @@ const parseReader = reader => {
 
 const getDocument = ({ url, html }) => {
   const { Window } = require('happy-dom')
-  const window = new Window({ url })
+  const window = new Window({
+    url,
+    settings: {
+      errorCapture: 'processLevel'
+    }
+  })
   const document = window.document
   document.write(html)
   return document


### PR DESCRIPTION
I noted global scope is polluted by errors propagated to Node.js process produced by happy-dom

I discovered this package https://www.npmjs.com/package/@happy-dom/uncaught-exception-observer

but it's not necessary since this is now a builtin feature and we should to start using it.