### PR TITLE
perf(media-provider): dedupe in-flight getMedia by url

### DIFF
--- a/packages/metascraper-media-provider/package.json
+++ b/packages/metascraper-media-provider/package.json
@@ -25,7 +25,6 @@
   ],
   "dependencies": {
     "@metascraper/helpers": "workspace:*",
-    "async-memoize-one": "~1.1.9",
     "debug-logfmt": "~1.4.7",
     "got": "~11.8.6",
     "lodash": "~4.17.23",

--- a/packages/metascraper-media-provider/src/create-last-and-inflight-cache.js
+++ b/packages/metascraper-media-provider/src/create-last-and-inflight-cache.js
@@ -1,0 +1,28 @@
+'use strict'
+
+module.exports = createFn => {
+  const inFlightByKey = new Map()
+  let lastResult
+
+  return key => {
+    if (lastResult?.key === key) {
+      return Promise.resolve(lastResult.value)
+    }
+
+    const inFlight = inFlightByKey.get(key)
+    if (inFlight) return inFlight
+
+    const request = Promise.resolve()
+      .then(() => createFn(key))
+      .then(value => {
+        lastResult = { key, value }
+        return value
+      })
+      .finally(() => {
+        inFlightByKey.delete(key)
+      })
+
+    inFlightByKey.set(key, request)
+    return request
+  }
+}

--- a/packages/metascraper-media-provider/src/get-media.js
+++ b/packages/metascraper-media-provider/src/get-media.js
@@ -73,18 +73,10 @@ module.exports = ({
   ...props
 }) => {
   const inFlightByUrl = new Map()
-  let lastUrl
-  let lastValue
+  let lastResult
 
-  return targetUrl => {
-    if (targetUrl === lastUrl) {
-      return Promise.resolve(lastValue)
-    }
-
-    const inFlight = inFlightByUrl.get(targetUrl)
-    if (inFlight) return inFlight
-
-    const request = getMedia({
+  const createRequest = targetUrl =>
+    getMedia({
       targetUrl,
       getArgs,
       retry,
@@ -92,9 +84,18 @@ module.exports = ({
       props,
       run
     })
+
+  return targetUrl => {
+    if (lastResult?.url === targetUrl) {
+      return Promise.resolve(lastResult.value)
+    }
+
+    const inFlight = inFlightByUrl.get(targetUrl)
+    if (inFlight) return inFlight
+
+    const request = createRequest(targetUrl)
       .then(value => {
-        lastUrl = targetUrl
-        lastValue = value
+        lastResult = { url: targetUrl, value }
         return value
       })
       .finally(() => {

--- a/packages/metascraper-media-provider/src/index.js
+++ b/packages/metascraper-media-provider/src/index.js
@@ -165,17 +165,18 @@ const getDescription = ({ description }) => descriptionFn(description)
 
 module.exports = (opts = {}) => {
   const getMedia = createGetMedia(opts)
+  const getMediaByArgs = args => getMedia(args.url, args)
 
   const rules = {
-    audio: async ({ url }) => getAudio(await getMedia(url)),
-    author: async ({ url }) => getAuthor(await getMedia(url)),
-    date: async ({ url }) => getDate(await getMedia(url)),
-    description: async ({ url }) => getDescription(await getMedia(url)),
-    image: async ({ url }) => getImage(url, await getMedia(url)),
-    lang: async ({ url }) => getLang(await getMedia(url)),
-    publisher: async ({ url }) => getPublisher(await getMedia(url)),
-    title: async ({ url }) => getTitle(await getMedia(url)),
-    video: async ({ url }) => getVideo(await getMedia(url))
+    audio: async args => getAudio(await getMediaByArgs(args)),
+    author: async args => getAuthor(await getMediaByArgs(args)),
+    date: async args => getDate(await getMediaByArgs(args)),
+    description: async args => getDescription(await getMediaByArgs(args)),
+    image: async args => getImage(args.url, await getMediaByArgs(args)),
+    lang: async args => getLang(await getMediaByArgs(args)),
+    publisher: async args => getPublisher(await getMediaByArgs(args)),
+    title: async args => getTitle(await getMediaByArgs(args)),
+    video: async args => getVideo(await getMediaByArgs(args))
   }
 
   rules.pkgName = 'metascraper-media-provider'

--- a/packages/metascraper-media-provider/test/create-last-and-inflight-cache.js
+++ b/packages/metascraper-media-provider/test/create-last-and-inflight-cache.js
@@ -4,16 +4,17 @@ const test = require('ava')
 
 const createLastAndInFlightCache = require('../src/create-last-and-inflight-cache')
 
-test('dedupe in-flight requests for same key', async t => {
+test('dedupe in-flight requests for same key in same context', async t => {
   const calls = []
   const fn = createLastAndInFlightCache(async key => {
     const { promise, resolve } = Promise.withResolvers()
     calls.push({ key, resolve })
     return promise
   })
+  const context = {}
 
-  const first = fn('a')
-  const second = fn('a')
+  const first = fn('a', context)
+  const second = fn('a', context)
 
   t.is(first, second)
 
@@ -27,15 +28,16 @@ test('dedupe in-flight requests for same key', async t => {
   t.is(value, 'value-a')
 })
 
-test('reuse last settled value for same key', async t => {
+test('reuse settled value for same key in same context', async t => {
   let count = 0
   const fn = createLastAndInFlightCache(async () => {
     count += 1
     return `value-${count}`
   })
+  const context = {}
 
-  const first = await fn('a')
-  const second = await fn('a')
+  const first = await fn('a', context)
+  const second = await fn('a', context)
 
   t.is(first, 'value-1')
   t.is(second, 'value-1')
@@ -54,5 +56,20 @@ test('clear in-flight entry on rejection', async t => {
   const value = await fn('a')
 
   t.is(value, 'ok')
+  t.is(count, 2)
+})
+
+test('do not share settled value across contexts', async t => {
+  let count = 0
+  const fn = createLastAndInFlightCache(async () => {
+    count += 1
+    return `value-${count}`
+  })
+
+  const first = await fn('a', {})
+  const second = await fn('a', {})
+
+  t.is(first, 'value-1')
+  t.is(second, 'value-2')
   t.is(count, 2)
 })

--- a/packages/metascraper-media-provider/test/create-last-and-inflight-cache.js
+++ b/packages/metascraper-media-provider/test/create-last-and-inflight-cache.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const test = require('ava')
+
+const createLastAndInFlightCache = require('../src/create-last-and-inflight-cache')
+
+test('dedupe in-flight requests for same key', async t => {
+  const calls = []
+  const fn = createLastAndInFlightCache(async key => {
+    const { promise, resolve } = Promise.withResolvers()
+    calls.push({ key, resolve })
+    return promise
+  })
+
+  const first = fn('a')
+  const second = fn('a')
+
+  t.is(first, second)
+
+  await Promise.resolve()
+
+  t.is(calls.length, 1)
+
+  calls[0].resolve('value-a')
+  const value = await first
+
+  t.is(value, 'value-a')
+})
+
+test('reuse last settled value for same key', async t => {
+  let count = 0
+  const fn = createLastAndInFlightCache(async () => {
+    count += 1
+    return `value-${count}`
+  })
+
+  const first = await fn('a')
+  const second = await fn('a')
+
+  t.is(first, 'value-1')
+  t.is(second, 'value-1')
+  t.is(count, 1)
+})
+
+test('clear in-flight entry on rejection', async t => {
+  let count = 0
+  const fn = createLastAndInFlightCache(async () => {
+    count += 1
+    if (count === 1) throw new Error('boom')
+    return 'ok'
+  })
+
+  await t.throwsAsync(() => fn('a'), { message: 'boom' })
+  const value = await fn('a')
+
+  t.is(value, 'ok')
+  t.is(count, 2)
+})

--- a/packages/metascraper-media-provider/test/get-media.js
+++ b/packages/metascraper-media-provider/test/get-media.js
@@ -120,3 +120,24 @@ test('dedupe in-flight requests per url under interleaved calls', async t => {
   t.is(aOne.id, aTwo.id)
   t.not(aOne.id, bOne.id)
 })
+
+test('do not share cached value across different contexts', async t => {
+  let runCalls = 0
+
+  const getMediaByUrl = createGetMedia({
+    retry: 0,
+    timeout: 1000,
+    args: ({ url, flags }) => ({ url, flags }),
+    run: async () => {
+      runCalls += 1
+      return { id: runCalls }
+    }
+  })
+
+  const first = await getMediaByUrl('https://example.com/a', {})
+  const second = await getMediaByUrl('https://example.com/a', {})
+
+  t.is(first.id, 1)
+  t.is(second.id, 2)
+  t.is(runCalls, 2)
+})

--- a/packages/metascraper-media-provider/test/get-media.js
+++ b/packages/metascraper-media-provider/test/get-media.js
@@ -102,6 +102,7 @@ test('dedupe in-flight requests per url under interleaved calls', async t => {
   t.is(aOnePromise, aTwoPromise)
 
   await Promise.resolve()
+  await Promise.resolve()
 
   t.is(calls.filter(call => call.url === aUrl).length, 1)
   t.is(calls.filter(call => call.url === bUrl).length, 1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `getMedia` memoization/caching behavior and introduces context-scoped caching, which could affect concurrency and result reuse if callers relied on previous global caching semantics.
> 
> **Overview**
> Adds a new context-aware cache (`create-last-and-inflight-cache`) to **dedupe in-flight** `getMedia` calls per URL while also reusing the settled result within the same context and clearing cache entries on rejection.
> 
> Replaces `async-memoize-one` with this cache in `src/get-media.js`, adds a `run` override parameter for easier injection/testing, and updates provider rules in `src/index.js` to pass through the full args/context when calling `getMedia` (preventing cache sharing across distinct contexts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 711634fe6fd927beb8baae5106db16d9e074f874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->