### PR TITLE
perf(readability): use happy-dom window parser

### DIFF
--- a/packages/metascraper-readability/src/index.js
+++ b/packages/metascraper-readability/src/index.js
@@ -26,7 +26,7 @@ const getDocument = ({ url, html }) => {
   window.document.documentElement.innerHTML = html
   return {
     document: window.document,
-    teardown: () => window.close()
+    teardown: () => window.happyDOM.close()
   }
 }
 

--- a/packages/metascraper-readability/src/index.js
+++ b/packages/metascraper-readability/src/index.js
@@ -3,7 +3,7 @@
 const { memoizeOne, composeRule } = require('@metascraper/helpers')
 const { Readability } = require('@mozilla/readability')
 const asyncMemoizeOne = require('async-memoize-one')
-const { Browser } = require('happy-dom')
+const { Window } = require('happy-dom')
 
 const parseReader = reader => {
   let parsed = {}
@@ -13,23 +13,20 @@ const parseReader = reader => {
   return parsed
 }
 
-const getDocument = ({ url, html }) => {
-  const browser = new Browser({
-    settings: {
-      disableComputedStyleRendering: true,
-      disableCSSFileLoading: true,
-      disableIframePageLoading: true,
-      disableJavaScriptEvaluation: true,
-      disableJavaScriptFileLoading: true
-    }
-  })
+const DOCUMENT_SETTINGS = {
+  disableComputedStyleRendering: true,
+  disableCSSFileLoading: true,
+  disableIframePageLoading: true,
+  disableJavaScriptEvaluation: true,
+  disableJavaScriptFileLoading: true
+}
 
-  const page = browser.newPage()
-  page.url = url
-  page.content = html
+const getDocument = ({ url, html }) => {
+  const window = new Window({ url, settings: DOCUMENT_SETTINGS })
+  window.document.documentElement.innerHTML = html
   return {
-    document: page.mainFrame.document,
-    teardown: () => browser.close()
+    document: window.document,
+    teardown: () => window.close()
   }
 }
 

--- a/packages/metascraper-readability/test/index.js
+++ b/packages/metascraper-readability/test/index.js
@@ -80,3 +80,15 @@ test('serializes html once per invocation', async t => {
   await metascraper({ htmlDom: $, url })
   t.is(htmlCalls, 1)
 })
+
+test('extracts lang from <html lang> attribute', async t => {
+  const url = 'https://example.com'
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Test</title></head>
+<body><p>Content</p></body>
+</html>`
+
+  const metadata = await metascraper({ html, url })
+  t.is(metadata.lang, 'en')
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the HTML-to-DOM construction used by `@mozilla/readability`, which could subtly affect extraction results across sites despite being a localized refactor. Adds a test to lock in language extraction behavior.
> 
> **Overview**
> Replaces the `happy-dom` `Browser`/`Page`-based document creation with a lighter `Window`-based parser (with shared `DOCUMENT_SETTINGS`) and updates teardown to close the window.
> 
> Adds coverage to ensure `lang` is extracted from the `<html lang>` attribute when running the readability rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1528313cffb167d862ae711af6a13227238d6b4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->