### PR TITLE
perf(readability): cache html serialization per htmlDom

### DIFF
--- a/packages/metascraper-readability/src/index.js
+++ b/packages/metascraper-readability/src/index.js
@@ -44,9 +44,19 @@ const readability = asyncMemoizeOne(async (url, html, readabilityOpts) => {
   }
 }, memoizeOne.EqualityFirstArgument)
 
+const htmlCache = new WeakMap()
+
+const getHtml = htmlDom => {
+  if (!htmlCache.has(htmlDom)) {
+    htmlCache.set(htmlDom, htmlDom.html())
+  }
+
+  return htmlCache.get(htmlDom)
+}
+
 module.exports = ({ readabilityOpts } = {}) => {
   const getReadbility = composeRule(($, url) =>
-    readability(url, $.html(), readabilityOpts)
+    readability(url, getHtml($), readabilityOpts)
   )
 
   const rules = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk performance change that avoids repeated `$.html()` serialization; main risk is stale HTML if the provided `htmlDom` is mutated after first access within a process.
> 
> **Overview**
> Improves `metascraper-readability` performance by caching serialized HTML per `htmlDom` (via a module-level `WeakMap`) so multiple rules reuse the same string instead of repeatedly calling `$.html()`.
> 
> Adds a unit test that instruments a Cheerio instance to assert HTML is serialized only once per metascraper invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf18d48522b5cf4feb759ef35d9930f3c8ba300. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->