### PR TITLE
perf(media-provider): avoid URL parsing in format filters

### DIFF
--- a/packages/metascraper-media-provider/src/index.js
+++ b/packages/metascraper-media-provider/src/index.js
@@ -9,18 +9,17 @@ const {
   title: titleFn,
   url: urlFn,
   lang,
-  publisher,
-  protocol: protocolFn
+  publisher
 } = require('@metascraper/helpers')
 
 const createGetMedia = require('./get-media')
 
-const isProtocol =
-  value =>
-    ({ url }) =>
-      eq(protocolFn(url), value)
+const RE_HTTPS = /^https:\/\//i
+const RE_M3U8 = /\.m3u8(?:[?#]|$)/i
+const RE_MPD = /\.mpd(?:[?#]|$)/i
+const RE_DOWNLOAD = /[?&]download=1(?:[&#]|$)/i
 
-const isHttps = isProtocol('https')
+const isHttps = ({ url = '' }) => RE_HTTPS.test(url)
 
 const isMIME =
   extension =>
@@ -36,9 +35,9 @@ const isAac = isMIME('aac')
 const isWav = isMIME('wav')
 const isMpga = isMIME('mpga')
 
-const isM3u8 = ({ url }) => new URL(url).pathname.endsWith('.m3u8')
+const isM3u8 = ({ url = '' }) => RE_M3U8.test(url)
 
-const isMpd = ({ url }) => new URL(url).pathname.endsWith('.mpd')
+const isMpd = ({ url = '' }) => RE_MPD.test(url)
 
 const hasCodec = prop => format => format[prop] !== 'none'
 
@@ -55,8 +54,7 @@ const hasAudio = format =>
 const hasVideo = format =>
   isNil(format.format_note) || !isNil(format.height) || !isNil(format.width)
 
-const isDownloadable = ({ url }) =>
-  new URL(url).searchParams.get('download') === '1'
+const isDownloadable = ({ url = '' }) => RE_DOWNLOAD.test(url)
 
 const getOrderByRank = value => {
   if (Number.isNaN(value)) return 4

--- a/packages/metascraper-media-provider/test/get-video.js
+++ b/packages/metascraper-media-provider/test/get-video.js
@@ -31,3 +31,45 @@ test('youtube (stream)', t => {
   )
   t.snapshot(getVideo(fixture))
 })
+
+test('filter downloadable urls using query string', t => {
+  const videoUrl = getVideo({
+    formats: [
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'https://example.com/video-high.mp4?download=1',
+        tbr: 500,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      },
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'https://example.com/video-low.mp4',
+        tbr: 100,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      }
+    ]
+  })
+
+  t.is(videoUrl, 'https://example.com/video-low.mp4')
+})
+
+test('support uppercase https protocol urls', t => {
+  const videoUrl = getVideo({
+    formats: [
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'HTTPS://example.com/video.mp4',
+        tbr: 100,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      }
+    ]
+  })
+
+  t.is(videoUrl, 'HTTPS://example.com/video.mp4')
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to URL-matching heuristics in media format filtering plus added tests; main risk is subtle false positives/negatives in regex-based URL detection affecting chosen media URLs.
> 
> **Overview**
> Replaces `new URL()`-based checks in media format filters with precompiled regexes to avoid URL parsing overhead and to be more tolerant of input (case-insensitive `https`, `.m3u8`/`.mpd` detection even with query/hash, and `download=1` filtering via query parsing regex).
> 
> Adds tests ensuring downloadable URLs (via `?download=1`) are deprioritized and that uppercase `HTTPS://` URLs are accepted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c370c139d6195a3981f6747420de2508c8dd528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->