### PR TITLE
Codex/perf media provider single pass on fastpath

### DIFF
--- a/packages/metascraper-media-provider/src/index.js
+++ b/packages/metascraper-media-provider/src/index.js
@@ -9,18 +9,17 @@ const {
   title: titleFn,
   url: urlFn,
   lang,
-  publisher,
-  protocol: protocolFn
+  publisher
 } = require('@metascraper/helpers')
 
 const createGetMedia = require('./get-media')
 
-const isProtocol =
-  value =>
-    ({ url }) =>
-      eq(protocolFn(url), value)
+const RE_HTTPS = /^https:\/\//i
+const RE_M3U8 = /\.m3u8(?:[?#]|$)/i
+const RE_MPD = /\.mpd(?:[?#]|$)/i
+const RE_DOWNLOAD = /[?&]download=1(?:[&#]|$)/i
 
-const isHttps = isProtocol('https')
+const isHttps = ({ url = '' }) => RE_HTTPS.test(url)
 
 const isMIME =
   extension =>
@@ -36,9 +35,9 @@ const isAac = isMIME('aac')
 const isWav = isMIME('wav')
 const isMpga = isMIME('mpga')
 
-const isM3u8 = ({ url }) => new URL(url).pathname.endsWith('.m3u8')
+const isM3u8 = ({ url = '' }) => RE_M3U8.test(url)
 
-const isMpd = ({ url }) => new URL(url).pathname.endsWith('.mpd')
+const isMpd = ({ url = '' }) => RE_MPD.test(url)
 
 const hasCodec = prop => format => format[prop] !== 'none'
 
@@ -55,8 +54,7 @@ const hasAudio = format =>
 const hasVideo = format =>
   isNil(format.format_note) || !isNil(format.height) || !isNil(format.width)
 
-const isDownloadable = ({ url }) =>
-  new URL(url).searchParams.get('download') === '1'
+const isDownloadable = ({ url = '' }) => RE_DOWNLOAD.test(url)
 
 const getOrderByRank = value => {
   if (Number.isNaN(value)) return 4

--- a/packages/metascraper-media-provider/src/index.js
+++ b/packages/metascraper-media-provider/src/index.js
@@ -15,11 +15,18 @@ const {
 const createGetMedia = require('./get-media')
 
 const RE_HTTPS = /^https:\/\//i
-const RE_M3U8 = /\.m3u8(?:[?#]|$)/i
-const RE_MPD = /\.mpd(?:[?#]|$)/i
 const RE_DOWNLOAD = /[?&]download=1(?:[&#]|$)/i
 
 const isHttps = ({ url = '' }) => RE_HTTPS.test(url)
+
+const getPathname = (url = '') => {
+  const queryIndex = url.indexOf('?')
+  const hashIndex = url.indexOf('#')
+  let end = url.length
+  if (queryIndex !== -1 && queryIndex < end) end = queryIndex
+  if (hashIndex !== -1 && hashIndex < end) end = hashIndex
+  return end === url.length ? url : url.slice(0, end)
+}
 
 const isMIME =
   extension =>
@@ -35,9 +42,10 @@ const isAac = isMIME('aac')
 const isWav = isMIME('wav')
 const isMpga = isMIME('mpga')
 
-const isM3u8 = ({ url = '' }) => RE_M3U8.test(url)
+const isM3u8 = ({ url = '' }) =>
+  getPathname(url).toLowerCase().endsWith('.m3u8')
 
-const isMpd = ({ url = '' }) => RE_MPD.test(url)
+const isMpd = ({ url = '' }) => getPathname(url).toLowerCase().endsWith('.mpd')
 
 const hasCodec = prop => format => format[prop] !== 'none'
 

--- a/packages/metascraper-media-provider/src/index.js
+++ b/packages/metascraper-media-provider/src/index.js
@@ -19,13 +19,24 @@ const RE_DOWNLOAD = /[?&]download=1(?:[&#]|$)/i
 
 const isHttps = ({ url = '' }) => RE_HTTPS.test(url)
 
-const getPathname = (url = '') => {
+const hasPathSuffix = (url = '', suffixCodes = []) => {
   const queryIndex = url.indexOf('?')
   const hashIndex = url.indexOf('#')
   let end = url.length
   if (queryIndex !== -1 && queryIndex < end) end = queryIndex
   if (hashIndex !== -1 && hashIndex < end) end = hashIndex
-  return end === url.length ? url : url.slice(0, end)
+
+  const suffixLength = suffixCodes.length
+  if (end < suffixLength) return false
+
+  const suffixStart = end - suffixLength
+  for (let i = 0; i < suffixLength; i++) {
+    let code = url.charCodeAt(suffixStart + i)
+    if (code >= 65 && code <= 90) code += 32
+    if (code !== suffixCodes[i]) return false
+  }
+
+  return true
 }
 
 const isMIME =
@@ -42,10 +53,13 @@ const isAac = isMIME('aac')
 const isWav = isMIME('wav')
 const isMpga = isMIME('mpga')
 
-const isM3u8 = ({ url = '' }) =>
-  getPathname(url).toLowerCase().endsWith('.m3u8')
+const M3U8_SUFFIX = [46, 109, 51, 117, 56] // .m3u8
 
-const isMpd = ({ url = '' }) => getPathname(url).toLowerCase().endsWith('.mpd')
+const MPD_SUFFIX = [46, 109, 112, 100] // .mpd
+
+const isM3u8 = ({ url = '' }) => hasPathSuffix(url, M3U8_SUFFIX)
+
+const isMpd = ({ url = '' }) => hasPathSuffix(url, MPD_SUFFIX)
 
 const hasCodec = prop => format => format[prop] !== 'none'
 

--- a/packages/metascraper-media-provider/test/get-video.js
+++ b/packages/metascraper-media-provider/test/get-video.js
@@ -110,3 +110,37 @@ test('scan formats once when selecting stream fallback', t => {
   t.is(videoUrl, 'https://example.com/video-2.m3u8')
   t.is(iterationCount, formats.length)
 })
+
+test('do not treat mp4 url as m3u8 when .m3u8 appears only in query string', t => {
+  const videoUrl = getVideo({
+    formats: [
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'https://cdn.example.com/video.mp4?fallback=stream.m3u8',
+        tbr: 500,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      }
+    ]
+  })
+
+  t.is(videoUrl, 'https://cdn.example.com/video.mp4?fallback=stream.m3u8')
+})
+
+test('do not treat mp4 url as mpd when .mpd appears only in query string', t => {
+  const videoUrl = getVideo({
+    formats: [
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'https://cdn.example.com/video.mp4?manifest=playlist.mpd',
+        tbr: 500,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      }
+    ]
+  })
+
+  t.is(videoUrl, 'https://cdn.example.com/video.mp4?manifest=playlist.mpd')
+})

--- a/packages/metascraper-media-provider/test/get-video.js
+++ b/packages/metascraper-media-provider/test/get-video.js
@@ -73,3 +73,40 @@ test('support uppercase https protocol urls', t => {
 
   t.is(videoUrl, 'HTTPS://example.com/video.mp4')
 })
+
+test('scan formats once when selecting stream fallback', t => {
+  const formats = [
+    {
+      ext: 'mp4',
+      format: 'mp4',
+      url: 'https://example.com/video-1.mp4',
+      manifest_url: 'https://example.com/video-1.m3u8',
+      tbr: 100,
+      acodec: 'none',
+      vcodec: 'none'
+    },
+    {
+      ext: 'mp4',
+      format: 'mp4',
+      url: 'https://example.com/video-2.mp4',
+      manifest_url: 'https://example.com/video-2.m3u8',
+      tbr: 200,
+      acodec: 'none',
+      vcodec: 'none'
+    }
+  ]
+
+  let iterationCount = 0
+  const iterableFormats = {
+    [Symbol.iterator]: function * () {
+      for (const format of formats) {
+        iterationCount += 1
+        yield format
+      }
+    }
+  }
+
+  const videoUrl = getVideo({ formats: iterableFormats })
+  t.is(videoUrl, 'https://example.com/video-2.m3u8')
+  t.is(iterationCount, formats.length)
+})

--- a/packages/metascraper-media-provider/test/get-video.js
+++ b/packages/metascraper-media-provider/test/get-video.js
@@ -31,3 +31,45 @@ test('youtube (stream)', t => {
   )
   t.snapshot(getVideo(fixture))
 })
+
+test('filter downloadable urls using query string', t => {
+  const videoUrl = getVideo({
+    formats: [
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'https://example.com/video-high.mp4?download=1',
+        tbr: 500,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      },
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'https://example.com/video-low.mp4',
+        tbr: 100,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      }
+    ]
+  })
+
+  t.is(videoUrl, 'https://example.com/video-low.mp4')
+})
+
+test('support uppercase https protocol urls', t => {
+  const videoUrl = getVideo({
+    formats: [
+      {
+        ext: 'mp4',
+        format: 'mp4',
+        url: 'HTTPS://example.com/video.mp4',
+        tbr: 100,
+        acodec: 'aac',
+        vcodec: 'avc1'
+      }
+    ]
+  })
+
+  t.is(videoUrl, 'HTTPS://example.com/video.mp4')
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors `getVideo` selection logic and URL matching (protocol, downloadable detection, manifest suffix checks), which can change which media URL is chosen for some providers. Changes are well-covered by new targeted tests but still impact a core extraction path.
> 
> **Overview**
> Optimizes video URL selection by replacing the previous multi-pass `getFormatUrls`/filter approach with a **single-pass** `getVideo` scan that picks (in order) the best MP4 *with audio*, then best MP4 video, then a stream `manifest_url` fallback.
> 
> Replaces URL parsing via `new URL()`/`protocol` helper with faster, more tolerant checks: case-insensitive `https` matching, regex-based `download=1` filtering, and path-suffix detection for `.m3u8`/`.mpd` that ignores query/hash (avoiding false positives). Adds tests covering these edge cases and the single-iteration behavior for stream fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64242fd9c0281fcec5c46aa2f3baf7834365e6d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->