### PR TITLE
perf(metascraper): reduce getData allocations

### DIFF
--- a/packages/metascraper/src/get-data.js
+++ b/packages/metascraper/src/get-data.js
@@ -4,7 +4,9 @@ const debug = require('debug-logfmt')('metascraper:get-data')
 const { findRule, has } = require('@metascraper/helpers')
 
 const getData = async ({ rules, ...props }) => {
-  const data = await Promise.all(
+  const data = {}
+
+  await Promise.all(
     rules.map(async ([propName, innerRules]) => {
       const duration = debug.duration()
       let normalizedValue = null
@@ -26,11 +28,11 @@ const getData = async ({ rules, ...props }) => {
       duration(
         `${propName}=${normalizedValue} rules=${innerRules.length} status=${status}`
       )
-      return [propName, normalizedValue]
+      data[propName] = normalizedValue
     })
   )
 
-  return Object.fromEntries(data)
+  return data
 }
 
 module.exports = getData


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: behavior should be equivalent but the result construction strategy changed; only potential risk is subtle ordering/async side effects if callers relied on intermediary array creation or insertion order under concurrent resolution.
> 
> **Overview**
> Updates `metascraper`’s `getData` to **accumulate results directly into an object** while awaiting `Promise.all`, replacing the previous pattern of returning `[key, value]` pairs and converting via `Object.fromEntries`.
> 
> This reduces intermediate allocations while keeping the same per-rule async execution and logging/error handling flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c35201ba95b08c3a9f10d28ce9c911754c762106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->