### PR TITLE
chore: update dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 audit=false
 fund=false
 loglevel=error
-package-lock=false
+lockfile=false
 prefer-dedupe=true
 prefer-offline=false
 resolution-mode=highest

--- a/packages/metascraper-defuddle/package.json
+++ b/packages/metascraper-defuddle/package.json
@@ -27,7 +27,7 @@
     "async-memoize-one": "~1.1.9",
     "debug-logfmt": "~1.4.7",
     "defuddle": "~0.14.0",
-    "happy-dom": "~20.3.4"
+    "happy-dom": "~20.10.1"
   },
   "devDependencies": {
     "ava": "5"

--- a/packages/metascraper-readability/package.json
+++ b/packages/metascraper-readability/package.json
@@ -26,7 +26,7 @@
     "@metascraper/helpers": "workspace:*",
     "@mozilla/readability": "~0.6.0",
     "async-memoize-one": "~1.1.9",
-    "happy-dom": "~20.3.4"
+    "happy-dom": "~20.10.1"
   },
   "devDependencies": {
     "ava": "5"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency version bumps and a cosmetic npm config rename only; no logic or security-sensitive code changes.
> 
> **Overview**
> Updates **happy-dom** from `~20.3.4` to `~20.10.1` in `metascraper-defuddle` and `metascraper-readability` (both use `happy-dom`'s `Window` for in-memory HTML parsing). No application source changes.
> 
> Renames the root `.npmrc` setting from `package-lock=false` to **`lockfile=false`**, aligning with current npm/pnpm lockfile configuration naming while keeping the same “don’t write lockfiles on install” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3696096a1c5ff71ec53fa25eed437f910db167d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->