### PR TITLE
chore: update dependencies

### DIFF
--- a/packages/metascraper-logo-favicon/package.json
+++ b/packages/metascraper-logo-favicon/package.json
@@ -24,7 +24,7 @@
     "metascraper"
   ],
   "dependencies": {
-    "@keyvhq/memoize": "~2.1.11",
+    "@keyvhq/memoize": "~2.2.4",
     "@metascraper/helpers": "workspace:*",
     "lodash": "~4.18.1",
     "reachable-url": "~1.8.3"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency-only minor version bump with no source changes; low impact on favicon caching behavior.
> 
> **Overview**
> Bumps **`@keyvhq/memoize`** in `metascraper-logo-favicon` from `~2.1.11` to `~2.2.4`. No application code changes; favicon/logo extraction still uses memoize for cached URL reachability checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c344961ce07c041fb2a8915c785562d337ef83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->