### PR TITLE
chore: update dependencies

### DIFF
--- a/packages/metascraper-helpers/package.json
+++ b/packages/metascraper-helpers/package.json
@@ -35,7 +35,7 @@
     "is-uri": "~1.2.14",
     "iso-639-3": "~2.2.0",
     "isostring": "0.0.1",
-    "jsdom": "~27.4.0",
+    "jsdom": "~29.1.1",
     "jsonrepair": "~3.14.0",
     "lodash": "~4.18.1",
     "memoize-one": "~6.0.0",
@@ -53,7 +53,7 @@
     "cheerio": "latest"
   },
   "engines": {
-    "node": ">= 22"
+    "node": ">= 22.13"
   },
   "files": [
     "src"

--- a/packages/metascraper-helpers/src/load-iframe/worker.js
+++ b/packages/metascraper-helpers/src/load-iframe/worker.js
@@ -1,14 +1,30 @@
 'use strict'
 
 const { workerData, parentPort } = require('node:worker_threads')
-const { JSDOM, VirtualConsole } = require('jsdom')
+const { JSDOM, VirtualConsole, requestInterceptor } = require('jsdom')
+
+const iframeInterceptor = requestInterceptor(async (request, { element }) => {
+  if (element?.localName !== 'iframe') return
+
+  const response = await fetch(request)
+  if (!response.ok) return new Response('', { status: response.status })
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-encoding')
+  headers.delete('content-length')
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText
+  })
+})
 
 async function main ({ url, html, timeout }) {
   const dom = new JSDOM(html, {
     url,
     virtualConsole: new VirtualConsole(),
     runScripts: 'dangerously',
-    resources: 'usable'
+    resources: { interceptors: [iframeInterceptor] }
   })
 
   const iframe = dom.window.document.querySelector('iframe')

--- a/packages/metascraper-logo-favicon/package.json
+++ b/packages/metascraper-logo-favicon/package.json
@@ -24,7 +24,7 @@
     "metascraper"
   ],
   "dependencies": {
-    "@keyvhq/memoize": "~2.1.11",
+    "@keyvhq/memoize": "~2.2.4",
     "@metascraper/helpers": "workspace:*",
     "lodash": "~4.18.1",
     "reachable-url": "~1.8.3"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how iframe HTML is fetched inside a worker (network + jsdom behavior); failures are now swallowed as undefined, which could affect metadata extraction for iframe-based embeds.
> 
> **Overview**
> Upgrades **jsdom** from ~27 to ~29 in `@metascraper/helpers` and raises the package **Node** floor to **>= 22.13** to match the new jsdom requirement.
> 
> Iframe loading in the worker thread no longer uses `resources: 'usable'`. It now registers jsdom’s **`requestInterceptor`** so only **iframe** subresource requests are fetched via `fetch`, with **`content-encoding`** and **`content-length`** stripped from proxied responses (typical fix for body/header mismatches). Worker **`main`** also **`.catch`es** rejections and posts **`undefined`** to the parent instead of leaving the worker hung on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f757a2142cb64cca57fca73993eb78de8d969bb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->