### PR TITLE
chore(defuddle): use linkedom

### DIFF
--- a/packages/metascraper-defuddle/package.json
+++ b/packages/metascraper-defuddle/package.json
@@ -27,7 +27,7 @@
     "async-memoize-one": "~1.2.1",
     "debug-logfmt": "~1.4.12",
     "defuddle": "~0.18.1",
-    "happy-dom": "~20.10.2"
+    "linkedom": "~0.18.12"
   },
   "devDependencies": {
     "ava": "5"

--- a/packages/metascraper-defuddle/src/index.js
+++ b/packages/metascraper-defuddle/src/index.js
@@ -2,30 +2,18 @@
 
 const { memoizeOne, composeRule, getHtml } = require('@metascraper/helpers')
 const asyncMemoizeOne = require('async-memoize-one')
-const { Window } = require('happy-dom')
+const { parseHTML } = require('linkedom')
 
 const debug = require('debug-logfmt')('metascraper-defuddle')
 
-const DOCUMENT_SETTINGS = {
-  disableComputedStyleRendering: true,
-  disableCSSFileLoading: true,
-  disableIframePageLoading: true,
-  disableJavaScriptEvaluation: true,
-  disableJavaScriptFileLoading: true
-}
-
 const defuddleExtract = asyncMemoizeOne(async (url, html) => {
   const { Defuddle } = await import('defuddle/node')
-  const window = new Window({ url, settings: DOCUMENT_SETTINGS })
-  window.document.documentElement.innerHTML = html
   try {
-    const result = await Defuddle(window.document, url, { useAsync: false })
-    return result
+    const { document } = parseHTML(html)
+    return await Defuddle(document, url, { useAsync: false })
   } catch (err) {
     debug('Defuddle failed, fallback to next rule', { message: err.message })
     return undefined
-  } finally {
-    await window.happyDOM.close()
   }
 }, memoizeOne.EqualityFirstArgument)
 


### PR DESCRIPTION
linkedom is a pure structural parser (no CSS/JS engine), it’s all Defuddle needs — and is ~7x faster than a scripting DOM for this parse-only use.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how HTML is parsed before Defuddle runs; edge-case DOM differences could affect metadata extraction until tests confirm parity.
> 
> **Overview**
> **metascraper-defuddle** now builds the DOM for Defuddle with **linkedom**’s `parseHTML` instead of **happy-dom**’s `Window`, and drops the happy-dom window settings and `happyDOM.close()` cleanup.
> 
> The dependency swap is meant to speed up parse-only extraction (no CSS/JS engine) while keeping the same Defuddle call path and metascraper rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1edacafea17877f9c965cae2fff095883213b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->