### PR TITLE
feat(defuddle): add preprocess and defuddleOpts options

### DIFF
--- a/packages/metascraper-defuddle/README.md
+++ b/packages/metascraper-defuddle/README.md
@@ -14,6 +14,25 @@
 $ npm install metascraper-defuddle --save
 ```
 
+## Usage
+
+```js
+const metascraper = require('metascraper')([require('metascraper-defuddle')()])
+```
+
+It runs a single [Defuddle](https://github.com/kepano/defuddle) `parseInternal` pass — not the high-level `Defuddle()`, whose `parse()` re-runs on low `wordCount` to recover _content_. This connector extracts metadata, which is read from meta tags/schema regardless of content removals, so those retries add nothing here.
+
+The Defuddle result is memoized by HTML, so the same page is defuddled once even when several rules (or another consumer, such as a markdown renderer) request it; the same URL re-fetched with different HTML still re-extracts.
+
+### Options
+
+```js
+require('metascraper-defuddle')({ preprocess, defuddleOpts })
+```
+
+- **preprocess** `(document, html) => void` — mutate the parsed DOM before extraction (e.g. strip noise, normalize flattened shadow-DOM content).
+- **defuddleOpts** `object` — options forwarded to Defuddle's `parseInternal` (e.g. `{ removeLowScoring: false }` to keep link-heavy blocks).
+
 ## License
 
 **metascraper-defuddle** © [Microlink](https://microlink.io), released under the [MIT](https://github.com/microlinkhq/metascraper/blob/master/LICENSE.md) License.<br>

--- a/packages/metascraper-defuddle/src/index.d.ts
+++ b/packages/metascraper-defuddle/src/index.d.ts
@@ -1,2 +1,7 @@
-declare function rules(): import('metascraper').Rules
+type Options = {
+  preprocess?: (document: Document, html: string) => void,
+  defuddleOpts?: import('defuddle/node').DefuddleOptions
+}
+
+declare function rules(options?: Options): import('metascraper').Rules
 export = rules

--- a/packages/metascraper-defuddle/src/index.js
+++ b/packages/metascraper-defuddle/src/index.js
@@ -1,11 +1,24 @@
 'use strict'
 
-const { memoizeOne, composeRule, getHtml } = require('@metascraper/helpers')
+const { composeRule, getHtml } = require('@metascraper/helpers')
 const debug = require('debug-logfmt')('metascraper-defuddle')
 const asyncMemoizeOne = require('async-memoize-one')
 const { parseHTML } = require('linkedom')
 
-// Single Defuddle `parseInternal` pass, memoized by HTML. See README for the
+// Cache key = HTML + url + the identity of `preprocess`/`defuddleOpts`, so a
+// call with the same HTML but a different hook or options (e.g. another
+// metascraper-defuddle() instance or defuddleExtract consumer) re-extracts
+// instead of reusing a result produced with different ones.
+const isSameExtraction = (
+  [html, url, opts = {}],
+  [oldHtml, oldUrl, oldOpts = {}]
+) =>
+  html === oldHtml &&
+  url === oldUrl &&
+  opts.preprocess === oldOpts.preprocess &&
+  opts.defuddleOpts === oldOpts.defuddleOpts
+
+// Single Defuddle `parseInternal` pass, memoized. See README for the
 // `preprocess` / `defuddleOpts` options and the rationale.
 const extractMemo = asyncMemoizeOne(
   async (html, url, { preprocess, defuddleOpts } = {}) => {
@@ -19,7 +32,7 @@ const extractMemo = asyncMemoizeOne(
       return undefined
     }
   },
-  memoizeOne.EqualityFirstArgument
+  isSameExtraction
 )
 
 const defuddleExtract = (url, html, options) => extractMemo(html, url, options)

--- a/packages/metascraper-defuddle/src/index.js
+++ b/packages/metascraper-defuddle/src/index.js
@@ -1,24 +1,33 @@
 'use strict'
 
 const { memoizeOne, composeRule, getHtml } = require('@metascraper/helpers')
+const debug = require('debug-logfmt')('metascraper-defuddle')
 const asyncMemoizeOne = require('async-memoize-one')
 const { parseHTML } = require('linkedom')
 
-const debug = require('debug-logfmt')('metascraper-defuddle')
+// Single Defuddle `parseInternal` pass, memoized by HTML. See README for the
+// `preprocess` / `defuddleOpts` options and the rationale.
+const extractMemo = asyncMemoizeOne(
+  async (html, url, { preprocess, defuddleOpts } = {}) => {
+    const { DefuddleClass } = await import('defuddle/node')
+    try {
+      const { document } = parseHTML(html)
+      if (preprocess) preprocess(document, html)
+      return new DefuddleClass(document, { url }).parseInternal(defuddleOpts)
+    } catch (err) {
+      debug('Defuddle failed, fallback to next rule', { message: err.message })
+      return undefined
+    }
+  },
+  memoizeOne.EqualityFirstArgument
+)
 
-const defuddleExtract = asyncMemoizeOne(async (url, html) => {
-  const { Defuddle } = await import('defuddle/node')
-  try {
-    const { document } = parseHTML(html)
-    return await Defuddle(document, url, { useAsync: false })
-  } catch (err) {
-    debug('Defuddle failed, fallback to next rule', { message: err.message })
-    return undefined
-  }
-}, memoizeOne.EqualityFirstArgument)
+const defuddleExtract = (url, html, options) => extractMemo(html, url, options)
 
-module.exports = () => {
-  const getDefuddle = composeRule(($, url) => defuddleExtract(url, getHtml($)))
+module.exports = ({ preprocess, defuddleOpts } = {}) => {
+  const getDefuddle = composeRule(($, url) =>
+    defuddleExtract(url, getHtml($), { preprocess, defuddleOpts })
+  )
 
   const rules = {
     author: getDefuddle({ from: 'author' }),

--- a/packages/metascraper-defuddle/test/cache.js
+++ b/packages/metascraper-defuddle/test/cache.js
@@ -1,0 +1,28 @@
+'use strict'
+
+// Isolated in its own file: the extractor memoizes a single result keyed by its
+// arguments, so a colliding call from another concurrent test would mask the
+// behaviour under test. A dedicated process keeps these two calls deterministic.
+const test = require('ava')
+const path = require('path')
+const fs = require('fs')
+
+const metascraperDefuddle = require('metascraper-defuddle')
+
+test('re-extracts when options differ for the same html', async t => {
+  const url = 'https://example.com/article'
+  const html = fs.readFileSync(
+    path.resolve(__dirname, 'fixtures/article.html'),
+    'utf-8'
+  )
+
+  const calls = []
+  await metascraperDefuddle.defuddleExtract(url, html, {
+    preprocess: () => calls.push('first')
+  })
+  await metascraperDefuddle.defuddleExtract(url, html, {
+    preprocess: () => calls.push('second')
+  })
+
+  t.deepEqual(calls, ['first', 'second'])
+})


### PR DESCRIPTION
## What

Adds two configuration options to `metascraper-defuddle`:

- **`preprocess`** `(document, html) => void` — mutate the parsed DOM before extraction (e.g. strip noise, normalize flattened shadow-DOM content).
- **`defuddleOpts`** `object` — options forwarded to Defuddle's `parseInternal` (e.g. `{ removeLowScoring: false }` to keep link-heavy blocks).

## Details

- Switches from the high-level `Defuddle()` to instantiating `DefuddleClass` directly and calling `.parseInternal(defuddleOpts)` — a single pass, since this connector reads metadata from meta tags/schema and gains nothing from content-recovery retries.
- Threads both options through the HTML-memoized extractor.
- Extends `src/index.d.ts` so consumers get typed options (`defuddleOpts` reuses Defuddle's own `DefuddleOptions`).
- Documents both options in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Defuddle entry point and cache key semantics, which can alter metadata output or duplicate work for callers that depended on the old URL-only memo or high-level `Defuddle()` retries.
> 
> **Overview**
> **`metascraper-defuddle`** now accepts optional **`preprocess`** and **`defuddleOpts`** when creating rules, so callers can tweak the DOM before extraction and pass Defuddle **`parseInternal`** settings (e.g. `removeLowScoring`).
> 
> Extraction no longer uses the high-level **`Defuddle()`** helper (and its content-recovery retries); it instantiates **`DefuddleClass`** and runs a single **`parseInternal`** pass, which the README argues is enough for metadata-only rules. Memoization is keyed by **HTML, URL, and the identity of `preprocess` / `defuddleOpts`**, so the same HTML with different hooks or options triggers a fresh extract; a dedicated test asserts that behavior via **`defuddleExtract`**. Types and README usage/options sections were added for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3f9011533057009d33bdc8183648c8198331a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->