### PR TITLE
feat(metascraper-x): expose X syndication helpers

### DIFF
--- a/packages/metascraper-x/src/index.d.ts
+++ b/packages/metascraper-x/src/index.d.ts
@@ -1,2 +1,22 @@
 declare function rules(): import('metascraper').Rules;
+
+declare namespace rules {
+  function test(input: { url: string }): boolean;
+
+  /** Extract the numeric status id from an X status/article URL, if any. */
+  function parseTweetId(url: string): string | undefined;
+
+  /** Deterministic syndication token derived from a status id. */
+  function getToken(id: string): string;
+
+  /** Build a clean HTML document from a syndication tweet payload. */
+  function buildHtml(tweet: object, url: string): string;
+
+  /** Resolve an X status/article URL into HTML built from the public syndication payload. */
+  function getEmbed(
+    url: string,
+    opts?: { fetch?: typeof globalThis.fetch; timeout?: number }
+  ): Promise<{ html: string; tweet: object } | undefined>;
+}
+
 export = rules;

--- a/packages/metascraper-x/src/index.js
+++ b/packages/metascraper-x/src/index.js
@@ -135,3 +135,10 @@ module.exports = ({ resolveUrl = url => url } = {}) => {
 }
 
 module.exports.test = test
+
+const { parseTweetId, getToken, buildHtml, getEmbed } = require('./syndication')
+
+module.exports.parseTweetId = parseTweetId
+module.exports.getToken = getToken
+module.exports.buildHtml = buildHtml
+module.exports.getEmbed = getEmbed

--- a/packages/metascraper-x/src/index.js
+++ b/packages/metascraper-x/src/index.js
@@ -29,6 +29,17 @@ const getAuthorName = memoizeOne(ogTitle =>
   ogTitle?.split(' on X:')[0].split(' (@')[0].trim()
 )
 
+// The handle is the first path segment. Prefer the canonical link (which
+// carries the real screen_name) over the request URL, whose first segment is
+// `i` for /i/status, /i/web/status and /i/article URLs.
+const getHandle = value => {
+  try {
+    return new URL(value).pathname.split('/')[1] || undefined
+  } catch {
+    return undefined
+  }
+}
+
 module.exports = ({ resolveUrl = url => url } = {}) => {
   const rules = {
     author: [
@@ -38,7 +49,13 @@ module.exports = ({ resolveUrl = url => url } = {}) => {
     ],
     title: [
       toTitle(($, url) => {
-        const username = new URL(url).pathname.split('/')[1]
+        const fromUrl = getHandle(url)
+        // `i` is the reserved segment of /i/status, /i/web/status and /i/article
+        // URLs — fall back to the canonical link, which carries the real handle.
+        const username =
+          fromUrl && fromUrl !== 'i'
+            ? fromUrl
+            : getHandle($('link[rel="canonical"]').attr('href')) || fromUrl
         const authorName = getAuthorName(
           $('meta[property="og:title"]').attr('content')
         )

--- a/packages/metascraper-x/src/syndication.js
+++ b/packages/metascraper-x/src/syndication.js
@@ -53,7 +53,9 @@ const escapeHtml = value =>
 const expandText = tweet => {
   let text = tweet.text || ''
   const entities = tweet.entities || {}
-  for (const media of entities.media || []) { text = text.split(media.url).join('') }
+  for (const media of entities.media || []) {
+    text = text.split(media.url).join('')
+  }
   for (const url of entities.urls || []) {
     text = text.split(url.url).join(url.expanded_url || url.url)
   }
@@ -80,7 +82,9 @@ const collectImages = tweet => {
     }
   }
   if (images.length === 0) {
-    for (const photo of tweet.photos || []) { images.push({ url: photo.url, alt: '' }) }
+    for (const photo of tweet.photos || []) {
+      images.push({ url: photo.url, alt: '' })
+    }
   }
   return images.filter(image => image.url)
 }
@@ -119,6 +123,17 @@ const buildHtml = (tweet, url) => {
   const article = tweet.article
 
   const ogTitle = authorName
+
+  // Rebuild the canonical URL with the real screen_name so /i/status, /i/article
+  // and /i/web/status URLs (whose first path segment is `i`) don't yield a
+  // "{name} (@i) on X" title downstream.
+  const id = tweet.id_str || parseTweetId(url)
+  const canonical =
+    user.screen_name && id
+      ? `https://x.com/${user.screen_name}/${
+        article ? 'article' : 'status'
+      }/${id}`
+      : url
 
   let pageTitle
   let description
@@ -159,8 +174,8 @@ const buildHtml = (tweet, url) => {
     `<title>${escapeHtml(pageTitle)}</title>`,
     '<meta property="og:type" content="article">',
     '<meta property="og:site_name" content="X">',
-    `<meta property="og:url" content="${escapeHtml(url)}">`,
-    `<link rel="canonical" href="${escapeHtml(url)}">`,
+    `<meta property="og:url" content="${escapeHtml(canonical)}">`,
+    `<link rel="canonical" href="${escapeHtml(canonical)}">`,
     `<meta property="og:title" content="${escapeHtml(ogTitle)}">`,
     description &&
       `<meta property="og:description" content="${escapeHtml(description)}">`,
@@ -204,16 +219,22 @@ const fetchTweet = async (
   endpoint.searchParams.set('token', getToken(id))
   endpoint.searchParams.set('lang', 'en')
 
-  const response = await fetch(endpoint, {
-    headers: { accept: 'application/json' },
-    signal: timeout > 0 ? AbortSignal.timeout(Math.floor(timeout)) : undefined
-  })
-  if (!response.ok) return undefined
+  // Network errors, aborted timeouts, and invalid JSON must degrade to
+  // `undefined` so callers can fall back to their normal fetch pipeline.
+  try {
+    const response = await fetch(endpoint, {
+      headers: { accept: 'application/json' },
+      signal: timeout > 0 ? AbortSignal.timeout(Math.floor(timeout)) : undefined
+    })
+    if (!response.ok) return undefined
 
-  const body = await response.json()
-  // Tombstoned, protected, or removed posts come back as a non-Tweet typename.
-  if (!body || body.__typename !== 'Tweet') return undefined
-  return body
+    const body = await response.json()
+    // Tombstoned, protected, or removed posts come back as a non-Tweet typename.
+    if (!body || body.__typename !== 'Tweet') return undefined
+    return body
+  } catch {
+    return undefined
+  }
 }
 
 /**

--- a/packages/metascraper-x/src/syndication.js
+++ b/packages/metascraper-x/src/syndication.js
@@ -1,0 +1,239 @@
+'use strict'
+
+// X (Twitter) serves an empty JS shell — and frequently a login wall — to any
+// non-authenticated client, so a plain fetch or browser render of a status or
+// article URL yields no extractable content. The public syndication endpoint
+// (the same one powering embedded tweets) returns the post as structured JSON
+// without authentication. We turn that JSON into a clean semantic HTML document
+// so a regular metascraper + content pipeline produces metadata and markdown.
+//
+// Note: X Articles only expose their `preview_text` through syndication; the
+// full body stays behind login, so articles yield the title plus the preview.
+
+const SYNDICATION_ENDPOINT = 'https://cdn.syndication.twimg.com/tweet-result'
+
+// The status id is the last numeric path segment of a tweet/article URL:
+//   /<user>/status/<id>, /<user>/article/<id>, /i/status/<id>, /i/web/status/<id>
+const X_STATUS_RE =
+  /^\/(?:[^/]+\/(?:status|statuses|article)|i\/(?:status|web\/status|article))\/(\d+)/
+
+const X_HOSTS = new Set([
+  'x.com',
+  'twitter.com',
+  'mobile.x.com',
+  'mobile.twitter.com'
+])
+
+const parseTweetId = url => {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    return undefined
+  }
+  const host = parsed.hostname.replace(/^www\./, '')
+  if (!X_HOSTS.has(host)) return undefined
+  const match = parsed.pathname.match(X_STATUS_RE)
+  return match ? match[1] : undefined
+}
+
+// Deterministic syndication token derived from the id, matching react-tweet.
+const getToken = id =>
+  ((Number(id) / 1e15) * Math.PI).toString(6 ** 2).replace(/(0+|\.)/g, '')
+
+const escapeHtml = value =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+
+// Expand t.co links to their destination and drop the ones that are just the
+// inline media (rendered separately as <img>).
+const expandText = tweet => {
+  let text = tweet.text || ''
+  const entities = tweet.entities || {}
+  for (const media of entities.media || []) { text = text.split(media.url).join('') }
+  for (const url of entities.urls || []) {
+    text = text.split(url.url).join(url.expanded_url || url.url)
+  }
+  return text.trim()
+}
+
+const textToHtml = text =>
+  String(text || '')
+    .split(/\n{2,}/)
+    .map(block => escapeHtml(block.trim()).replace(/\n/g, '<br>\n'))
+    .filter(Boolean)
+    .map(block => `<p>${block}</p>`)
+    .join('\n')
+
+const collectImages = tweet => {
+  const images = []
+  for (const media of tweet.mediaDetails || []) {
+    if (
+      media.type === 'photo' ||
+      media.type === 'video' ||
+      media.type === 'animated_gif'
+    ) {
+      images.push({ url: media.media_url_https, alt: media.ext_alt_text || '' })
+    }
+  }
+  if (images.length === 0) {
+    for (const photo of tweet.photos || []) { images.push({ url: photo.url, alt: '' }) }
+  }
+  return images.filter(image => image.url)
+}
+
+const renderImages = tweet =>
+  collectImages(tweet)
+    .map(
+      image =>
+        `<p><img src="${escapeHtml(image.url)}" alt="${escapeHtml(
+          image.alt
+        )}"></p>`
+    )
+    .join('\n')
+
+const renderQuoted = quoted => {
+  if (!quoted) return ''
+  const user = quoted.user || {}
+  const byline = user.name
+    ? `<p><strong>${escapeHtml(user.name)}</strong> (@${escapeHtml(
+      user.screen_name
+    )})</p>\n`
+    : ''
+  const body = [textToHtml(expandText(quoted)), renderImages(quoted)]
+    .filter(Boolean)
+    .join('\n')
+  return `<blockquote>\n${byline}${body}\n</blockquote>`
+}
+
+// Build a clean HTML document from a syndication payload. The emitted og:title
+// carries the display name (not the post text or article headline) because the
+// metascraper-x rules derive both the author and the "{name} (@handle) on X"
+// title from it.
+const buildHtml = (tweet, url) => {
+  const user = tweet.user || {}
+  const authorName = user.name || user.screen_name || 'X'
+  const article = tweet.article
+
+  const ogTitle = authorName
+
+  let pageTitle
+  let description
+  let image
+  let body
+
+  if (article) {
+    pageTitle = article.title || authorName
+    description = article.preview_text || ''
+    image = article.cover_media?.media_info?.original_img_url
+    // Defuddle treats a leading heading as the document title and strips it from
+    // the body, so the headline would vanish from the markdown. Emitting it as
+    // emphasized text keeps it as a bold lead line in the content.
+    body = [
+      article.title
+        ? `<p><strong>${escapeHtml(article.title)}</strong></p>`
+        : '',
+      textToHtml(article.preview_text)
+    ]
+      .filter(Boolean)
+      .join('\n')
+  } else {
+    const text = expandText(tweet)
+    pageTitle = `${authorName} on X`
+    description = text
+    image = collectImages(tweet)[0]?.url
+    body = [
+      textToHtml(text),
+      renderImages(tweet),
+      renderQuoted(tweet.quoted_tweet)
+    ]
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  const head = [
+    '<meta charset="utf-8">',
+    `<title>${escapeHtml(pageTitle)}</title>`,
+    '<meta property="og:type" content="article">',
+    '<meta property="og:site_name" content="X">',
+    `<meta property="og:url" content="${escapeHtml(url)}">`,
+    `<link rel="canonical" href="${escapeHtml(url)}">`,
+    `<meta property="og:title" content="${escapeHtml(ogTitle)}">`,
+    description &&
+      `<meta property="og:description" content="${escapeHtml(description)}">`,
+    image && `<meta property="og:image" content="${escapeHtml(image)}">`,
+    `<meta name="author" content="${escapeHtml(authorName)}">`,
+    tweet.created_at &&
+      `<meta property="article:published_time" content="${escapeHtml(
+        tweet.created_at
+      )}">`,
+    tweet.lang &&
+      tweet.lang !== 'zxx' &&
+      `<meta property="og:locale" content="${escapeHtml(tweet.lang)}">`
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const lang =
+    tweet.lang && tweet.lang !== 'zxx'
+      ? ` lang="${escapeHtml(tweet.lang)}"`
+      : ''
+
+  return `<!doctype html>
+<html${lang}>
+<head>
+${head}
+</head>
+<body>
+<article>
+${body}
+</article>
+</body>
+</html>`
+}
+
+const fetchTweet = async (
+  id,
+  { fetch = globalThis.fetch, timeout = 8000 } = {}
+) => {
+  const endpoint = new URL(SYNDICATION_ENDPOINT)
+  endpoint.searchParams.set('id', id)
+  endpoint.searchParams.set('token', getToken(id))
+  endpoint.searchParams.set('lang', 'en')
+
+  const response = await fetch(endpoint, {
+    headers: { accept: 'application/json' },
+    signal: timeout > 0 ? AbortSignal.timeout(Math.floor(timeout)) : undefined
+  })
+  if (!response.ok) return undefined
+
+  const body = await response.json()
+  // Tombstoned, protected, or removed posts come back as a non-Tweet typename.
+  if (!body || body.__typename !== 'Tweet') return undefined
+  return body
+}
+
+/**
+ * Resolve an X status/article URL into a clean HTML document built from the
+ * public syndication payload. Returns `undefined` when the URL is not an X post
+ * or the post is not publicly available, so the caller can fall back to the
+ * normal fetch pipeline.
+ *
+ * @param {string} url
+ * @param {{ fetch?: typeof globalThis.fetch, timeout?: number }} [opts]
+ * @returns {Promise<{ html: string, tweet: object } | undefined>}
+ */
+const getEmbed = async (url, opts) => {
+  const id = parseTweetId(url)
+  if (!id) return undefined
+
+  const tweet = await fetchTweet(id, opts)
+  if (!tweet) return undefined
+
+  return { html: buildHtml(tweet, url), tweet }
+}
+
+module.exports = { parseTweetId, getToken, buildHtml, getEmbed }

--- a/packages/metascraper-x/test/fixtures/syndication/article.json
+++ b/packages/metascraper-x/test/fixtures/syndication/article.json
@@ -1,0 +1,62 @@
+{
+  "__typename": "Tweet",
+  "favorite_count": 65,
+  "lang": "zxx",
+  "possibly_sensitive": false,
+  "created_at": "2026-06-11T09:04:37.000Z",
+  "display_text_range": [
+    0,
+    23
+  ],
+  "entities": {
+    "urls": [
+      {
+        "display_url": "x.com/i/article/2064…",
+        "expanded_url": "http://x.com/i/article/2064823727674503169",
+        "indices": [
+          0,
+          23
+        ],
+        "url": "https://t.co/iX1DJVOMkS"
+      }
+    ]
+  },
+  "id_str": "2064997219648913457",
+  "text": "https://t.co/iX1DJVOMkS",
+  "user": {
+    "id_str": "1870642493693583360",
+    "name": "Eliana",
+    "screen_name": "eliana_jordan",
+    "is_blue_verified": true,
+    "profile_image_shape": "Circle",
+    "verified": false,
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1966795855354060800/Nt--wKfR_normal.jpg"
+  },
+  "edit_control": {
+    "edit_tweet_ids": [
+      "2064997219648913457"
+    ],
+    "editable_until_msecs": "1781172277000",
+    "edits_remaining": "5",
+    "is_edit_eligible": false
+  },
+  "conversation_count": 14,
+  "news_action_type": "conversation",
+  "article": {
+    "cover_media": {
+      "id": "QXBpTWVkaWE6DAAFCgABHKe+43fX0AAKAAIZ9dtv2ltgAAAA",
+      "media_info": {
+        "__typename": "ApiImage",
+        "original_img_height": 768,
+        "original_img_url": "https://pbs.twimg.com/media/HKe-43fX0AAfDI_.jpg",
+        "original_img_width": 1920
+      }
+    },
+    "id": "QXJ0aWNsZUVudGl0eToyMDY0ODIzNzI3Njc0NTAzMTY5",
+    "preview_text": "My Instagram had 23K followers and was completely dead.\n800 views per reel. Zero reach. The algorithm had forgotten me.\nHere's the real context: I built that account as a travel and lifestyle creator.",
+    "rest_id": "2064823727674503169",
+    "title": "My Instagram was dead for a year. One weekend changed that. 100K views, 500+ followers, 300+ users"
+  },
+  "isEdited": false,
+  "isStaleEdit": false
+}

--- a/packages/metascraper-x/test/fixtures/syndication/tweet-photo.json
+++ b/packages/metascraper-x/test/fixtures/syndication/tweet-photo.json
@@ -1,0 +1,116 @@
+{
+  "__typename": "Tweet",
+  "favorite_count": 460083,
+  "lang": "en",
+  "possibly_sensitive": false,
+  "created_at": "2012-11-07T04:16:18.000Z",
+  "display_text_range": [
+    0,
+    37
+  ],
+  "entities": {
+    "media": [
+      {
+        "display_url": "pic.x.com/bAJE6Vom",
+        "expanded_url": "https://x.com/BarackObama/status/266031293945503744/photo/1",
+        "indices": [
+          17,
+          37
+        ],
+        "url": "http://t.co/bAJE6Vom"
+      }
+    ]
+  },
+  "id_str": "266031293945503744",
+  "text": "Four more years. http://t.co/bAJE6Vom",
+  "user": {
+    "id_str": "813286",
+    "name": "Barack Obama",
+    "screen_name": "BarackObama",
+    "is_blue_verified": true,
+    "profile_image_shape": "Circle",
+    "verified": false,
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1329647526807543809/2SGvnHYV_normal.jpg",
+    "highlighted_label": {
+      "badge": {
+        "url": "https://pbs.twimg.com/profile_images/1644381876465938433/7TiSgwTB_bigger.jpg"
+      },
+      "description": "The Office of Barack and Michelle Obama",
+      "url": {
+        "url": "https://twitter.com/TheObamaOffice",
+        "url_type": "DeepLink"
+      },
+      "user_label_display_type": "Badge",
+      "user_label_type": "BusinessLabel"
+    }
+  },
+  "edit_control": {
+    "edit_tweet_ids": [
+      "266031293945503744"
+    ],
+    "editable_until_msecs": "1352263577756",
+    "edits_remaining": "5",
+    "is_edit_eligible": true
+  },
+  "mediaDetails": [
+    {
+      "display_url": "pic.x.com/bAJE6Vom",
+      "expanded_url": "https://x.com/BarackObama/status/266031293945503744/photo/1",
+      "ext_media_availability": {
+        "status": "Available"
+      },
+      "indices": [
+        17,
+        37
+      ],
+      "media_url_https": "https://pbs.twimg.com/media/A7EiDWcCYAAZT1D.jpg",
+      "original_info": {
+        "focus_rects": [],
+        "height": 532,
+        "width": 800
+      },
+      "sizes": {
+        "large": {
+          "h": 532,
+          "resize": "fit",
+          "w": 800
+        },
+        "medium": {
+          "h": 532,
+          "resize": "fit",
+          "w": 800
+        },
+        "small": {
+          "h": 452,
+          "resize": "fit",
+          "w": 680
+        },
+        "thumb": {
+          "h": 150,
+          "resize": "crop",
+          "w": 150
+        }
+      },
+      "type": "photo",
+      "url": "http://t.co/bAJE6Vom"
+    }
+  ],
+  "photos": [
+    {
+      "backgroundColor": {
+        "red": 204,
+        "green": 214,
+        "blue": 221
+      },
+      "cropCandidates": [],
+      "expandedUrl": "https://x.com/BarackObama/status/266031293945503744/photo/1",
+      "url": "https://pbs.twimg.com/media/A7EiDWcCYAAZT1D.jpg",
+      "width": 800,
+      "height": 532
+    }
+  ],
+  "conversation_count": 46970,
+  "news_action_type": "conversation",
+  "isEdited": false,
+  "isStaleEdit": false
+}

--- a/packages/metascraper-x/test/fixtures/syndication/tweet-text.json
+++ b/packages/metascraper-x/test/fixtures/syndication/tweet-text.json
@@ -1,0 +1,46 @@
+{
+  "__typename": "Tweet",
+  "favorite_count": 308153,
+  "lang": "en",
+  "created_at": "2006-03-21T20:50:14.000Z",
+  "display_text_range": [
+    0,
+    24
+  ],
+  "entities": {},
+  "id_str": "20",
+  "text": "just setting up my twttr",
+  "user": {
+    "id_str": "12",
+    "name": "jack",
+    "screen_name": "jack",
+    "is_blue_verified": true,
+    "profile_image_shape": "Circle",
+    "verified": false,
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1661201415899951105/azNjKOSH_normal.jpg",
+    "highlighted_label": {
+      "badge": {
+        "url": "https://pbs.twimg.com/profile_images/1285655593592791040/HtwPZgej_bigger.jpg"
+      },
+      "description": "Square",
+      "url": {
+        "url": "https://twitter.com/Square",
+        "url_type": "DeepLink"
+      },
+      "user_label_display_type": "Badge",
+      "user_label_type": "BusinessLabel"
+    }
+  },
+  "edit_control": {
+    "edit_tweet_ids": [
+      "20"
+    ],
+    "editable_until_msecs": "1142976014000",
+    "edits_remaining": "5",
+    "is_edit_eligible": true
+  },
+  "conversation_count": 17948,
+  "news_action_type": "conversation",
+  "isEdited": false,
+  "isStaleEdit": false
+}

--- a/packages/metascraper-x/test/syndication.js
+++ b/packages/metascraper-x/test/syndication.js
@@ -38,7 +38,9 @@ test('parseTweetId extracts the status id from X post URLs', t => {
     'https://x.com/i/article/2064997219648913457': '2064997219648913457',
     'https://x.com/jack/status/20?s=21&t=abc': '20'
   }
-  for (const [url, id] of Object.entries(cases)) { t.is(parseTweetId(url), id, url) }
+  for (const [url, id] of Object.entries(cases)) {
+    t.is(parseTweetId(url), id, url)
+  }
 })
 
 test('parseTweetId returns undefined for non-post URLs', t => {
@@ -167,4 +169,32 @@ test('getEmbed: returns undefined on a non-ok response', async t => {
   const url = 'https://x.com/jack/status/20'
   const fetch = async () => ({ ok: false, json: async () => ({}) })
   t.is(await getEmbed(url, { fetch }), undefined)
+})
+
+test('getEmbed: returns undefined (not throws) when fetch rejects', async t => {
+  const url = 'https://x.com/jack/status/20'
+  const fetch = async () => {
+    throw new Error('network down')
+  }
+  t.is(await getEmbed(url, { fetch }), undefined)
+})
+
+test('getEmbed: returns undefined (not throws) on invalid JSON', async t => {
+  const url = 'https://x.com/jack/status/20'
+  const fetch = async () => ({
+    ok: true,
+    json: async () => {
+      throw new SyntaxError('Unexpected token')
+    }
+  })
+  t.is(await getEmbed(url, { fetch }), undefined)
+})
+
+test('i-path URL keeps the real @handle in the title', async t => {
+  // first path segment is `i`, not the screen_name
+  const url = 'https://x.com/i/article/2064997219648913457'
+  const html = buildHtml(fixture('article'), url)
+  const metadata = await createMetascraper()({ html, url })
+  t.is(metadata.title, 'Eliana (@eliana_jordan) on X')
+  t.is(metadata.url, 'https://x.com/eliana_jordan/article/2064997219648913457')
 })

--- a/packages/metascraper-x/test/syndication.js
+++ b/packages/metascraper-x/test/syndication.js
@@ -1,0 +1,170 @@
+'use strict'
+
+const { readFileSync } = require('fs')
+const { resolve } = require('path')
+const test = require('ava').default
+
+const { parseTweetId, getToken, buildHtml, getEmbed } = require('metascraper-x')
+
+const createMetascraper = () =>
+  require('metascraper')([
+    require('metascraper-x')(),
+    require('metascraper-author')(),
+    require('metascraper-date')(),
+    require('metascraper-image')(),
+    require('metascraper-description')(),
+    require('metascraper-publisher')(),
+    require('metascraper-title')()
+  ])
+
+const fixture = name =>
+  JSON.parse(
+    readFileSync(
+      resolve(__dirname, 'fixtures/syndication', `${name}.json`),
+      'utf8'
+    )
+  )
+
+test('parseTweetId extracts the status id from X post URLs', t => {
+  const cases = {
+    'https://x.com/jack/status/20': '20',
+    'https://twitter.com/jack/status/20': '20',
+    'https://mobile.x.com/jack/status/20': '20',
+    'https://x.com/jack/statuses/20': '20',
+    'https://x.com/i/status/20': '20',
+    'https://x.com/i/web/status/20': '20',
+    'https://x.com/eliana_jordan/article/2064997219648913457':
+      '2064997219648913457',
+    'https://x.com/i/article/2064997219648913457': '2064997219648913457',
+    'https://x.com/jack/status/20?s=21&t=abc': '20'
+  }
+  for (const [url, id] of Object.entries(cases)) { t.is(parseTweetId(url), id, url) }
+})
+
+test('parseTweetId returns undefined for non-post URLs', t => {
+  const cases = [
+    'https://x.com/jack',
+    'https://x.com/jack/with_replies',
+    'https://x.com/home',
+    'https://example.com/jack/status/20',
+    'https://x.com/i/lists/123',
+    'not a url'
+  ]
+  for (const url of cases) t.is(parseTweetId(url), undefined, url)
+})
+
+test('getToken derives the deterministic syndication token', t => {
+  // Matches react-tweet's algorithm: ((id / 1e15) * Math.PI).toString(36)
+  t.is(getToken('20'), '6dq1a2xwd93')
+  t.is(typeof getToken('2064997219648913457'), 'string')
+})
+
+test('buildHtml: text-only tweet → metadata via the X rules', async t => {
+  const url = 'https://x.com/jack/status/20'
+  const metadata = await createMetascraper()({
+    html: buildHtml(fixture('tweet-text'), url),
+    url
+  })
+  t.is(metadata.title, 'jack (@jack) on X')
+  t.is(metadata.author, 'jack')
+  t.is(metadata.publisher, 'X')
+  t.is(metadata.description, 'just setting up my twttr')
+  t.is(metadata.date, '2006-03-21T20:50:14.000Z')
+})
+
+test('buildHtml: photo tweet exposes the image and strips the media t.co link', async t => {
+  const url = 'https://x.com/BarackObama/status/266031293945503744'
+  const html = buildHtml(fixture('tweet-photo'), url)
+  const metadata = await createMetascraper()({ html, url })
+  t.is(metadata.title, 'Barack Obama (@BarackObama) on X')
+  t.is(metadata.author, 'Barack Obama')
+  t.is(metadata.image, 'https://pbs.twimg.com/media/A7EiDWcCYAAZT1D.jpg')
+  // the inline photo t.co link must not leak into the body text
+  t.false(html.includes('>Four more years. http'))
+})
+
+test('buildHtml: article → display-name title, headline preserved in body', async t => {
+  const url = 'https://x.com/eliana_jordan/article/2064997219648913457'
+  const html = buildHtml(fixture('article'), url)
+  const headline =
+    'My Instagram was dead for a year. One weekend changed that. 100K views, 500+ followers, 300+ users'
+
+  const metadata = await createMetascraper()({ html, url })
+  // the X rules title posts as "{author} (@handle) on X"; the article headline
+  // lives in the body so a downstream markdown render keeps it.
+  t.is(metadata.title, 'Eliana (@eliana_jordan) on X')
+  t.is(metadata.author, 'Eliana')
+  t.is(metadata.image, 'https://pbs.twimg.com/media/HKe-43fX0AAfDI_.jpg')
+  t.true(html.includes(`<strong>${headline}</strong>`))
+})
+
+test('buildHtml: expands url entities and renders quoted tweets', t => {
+  const url = 'https://x.com/someone/status/123'
+  const html = buildHtml(
+    {
+      text: 'check this out https://t.co/abc',
+      entities: {
+        urls: [
+          { url: 'https://t.co/abc', expanded_url: 'https://example.com/post' }
+        ]
+      },
+      user: { name: 'Someone', screen_name: 'someone' },
+      quoted_tweet: {
+        text: 'original thought',
+        user: { name: 'Author', screen_name: 'author' }
+      }
+    },
+    url
+  )
+  t.true(html.includes('https://example.com/post'))
+  t.false(html.includes('t.co/abc'))
+  t.true(html.includes('original thought'))
+  t.true(html.includes('<blockquote>'))
+})
+
+test('buildHtml escapes HTML special characters in tweet text', t => {
+  const html = buildHtml(
+    {
+      text: '<script>alert(1)</script> & "quotes"',
+      user: { name: 'Someone', screen_name: 'someone' }
+    },
+    'https://x.com/someone/status/123'
+  )
+  t.false(html.includes('<script>alert(1)</script>'))
+  t.true(html.includes('&lt;script&gt;'))
+})
+
+test('getEmbed: returns HTML built from an injected syndication response', async t => {
+  const url = 'https://x.com/jack/status/20'
+  const tweet = fixture('tweet-text')
+  const fetch = async () => ({ ok: true, json: async () => tweet })
+
+  const embed = await getEmbed(url, { fetch })
+  t.is(embed.tweet.__typename, 'Tweet')
+  t.true(embed.html.includes('just setting up my twttr'))
+})
+
+test('getEmbed: returns undefined for non-post URLs without fetching', async t => {
+  let called = false
+  const fetch = async () => {
+    called = true
+    return { ok: true, json: async () => ({}) }
+  }
+  t.is(await getEmbed('https://x.com/jack', { fetch }), undefined)
+  t.false(called)
+})
+
+test('getEmbed: returns undefined when the post is not a public Tweet', async t => {
+  const url = 'https://x.com/jack/status/20'
+  const fetch = async () => ({
+    ok: true,
+    json: async () => ({ __typename: 'TweetTombstone' })
+  })
+  t.is(await getEmbed(url, { fetch }), undefined)
+})
+
+test('getEmbed: returns undefined on a non-ok response', async t => {
+  const url = 'https://x.com/jack/status/20'
+  const fetch = async () => ({ ok: false, json: async () => ({}) })
+  t.is(await getEmbed(url, { fetch }), undefined)
+})


### PR DESCRIPTION
## Why

X (Twitter) serves an empty JS shell — and frequently a login wall — to any unauthenticated client. A plain fetch or a fully-rendered logged-out browser of a `/status/` or `/article/` URL yields no extractable content (verified: the `/article/` URL redirects to `/i/jf/onboarding/web?…&mode=login`). So metascraper-x had nothing useful to extract from X posts.

X's **public syndication API** (`cdn.syndication.twimg.com/tweet-result`, the same endpoint powering embedded tweets / `react-tweet`) returns the post as structured JSON **without authentication**. This PR exposes helpers built on it so a downstream content pipeline can recover X post content.

## What

New `src/syndication.js`, re-exported from the package entry:

- `parseTweetId(url)` — status id from `/status`, `/statuses`, `/article`, `/i/status`, `/i/web/status`, `/i/article`; `undefined` for non-posts.
- `getToken(id)` — deterministic syndication token (react-tweet's algorithm).
- `buildHtml(tweet, url)` — clean semantic HTML from a syndication payload (expands `t.co` links, strips inline-media links, renders photos + quoted tweets, escapes user content).
- `getEmbed(url, { fetch?, timeout? })` — the high-level bridge: `url → { html, tweet }`, or `undefined` when it isn't a publicly-available X post (so the caller falls back to its normal fetch). Uses global `fetch` by default; injectable for testing/transport.

The **metadata rules are unchanged** — metascraper-x stays metadata-only. `buildHtml` shapes its `og:title` to the display name so the existing rules keep deriving author and the `"{name} (@handle) on X"` title correctly.

### Caveat (documented in code)
X **Articles** only expose `preview_text` through syndication; the full body stays behind login. So articles yield the title + preview, while regular posts yield full text. The article headline is emitted as a bold lead line so a downstream markdown render preserves it (Defuddle would otherwise strip a leading heading as the doc title).

## Tests

`test/syndication.js` — 12 tests (id parsing, token, `buildHtml` → metadata via the real X rules for text/photo/article fixtures, quoted-tweet + entity expansion, HTML escaping, and `getEmbed` with an injected `fetch` covering success / non-post / tombstone / non-ok). Full package suite: **30/30 passing**, `standard` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional helpers with safe degradation and HTML escaping; a small title-rule fix for `/i/*` URLs. No auth or breaking API changes to existing rules.
> 
> **Overview**
> Adds **`syndication.js`** and re-exports **`parseTweetId`**, **`getToken`**, **`buildHtml`**, and **`getEmbed`** so pipelines can turn X status/article URLs into HTML via the public `cdn.syndication.twimg.com` JSON API (with graceful `undefined` fallback on network errors, tombstones, or non-post URLs).
> 
> **`getEmbed`** fetches syndication JSON and **`buildHtml`** emits semantic HTML (expanded links, media, quoted tweets, HTML escaping, article preview-only bodies). Existing metascraper rules stay metadata-only; **`buildHtml`** shapes `og:title` and canonical URLs so extraction still works.
> 
> The **title rule** now uses **`getHandle`** and falls back from `/i/status`, `/i/web/status`, and `/i/article` URLs to the canonical link so titles are not `(@i)`.
> 
> Type definitions and **`test/syndication.js`** with fixtures cover parsing, HTML/metadata integration, and injected-fetch failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13365b30e2188347c85391484df3848a7d7e54a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->