### PR TITLE
fix(metascraper-amazon): match Amazon domains via PSL hostname, not substring regex

### DIFF
--- a/packages/metascraper-amazon/src/index.js
+++ b/packages/metascraper-amazon/src/index.js
@@ -11,10 +11,13 @@ const {
   url
 } = require('@metascraper/helpers')
 
-const REGEX_AMAZON_URL =
-  /https?:\/\/(.*amazon\..*\/.*|.*amzn\..*\/.*|.*a\.co\/.*)/i
+const isAmazonDomain = domain => {
+  if (!domain) return false
+  if (domain === 'a.co') return true
+  return /^(?:amazon|amzn)\./.test(domain)
+}
 
-const test = memoizeOne(url => REGEX_AMAZON_URL.test(url))
+const test = memoizeOne(url => isAmazonDomain(parseUrl(url).domain))
 
 const SUFFIX_LANGUAGES = {
   ca: 'en',

--- a/packages/metascraper-amazon/test/test.js
+++ b/packages/metascraper-amazon/test/test.js
@@ -33,4 +33,8 @@ test('false', t => {
   t.false(validator('https://asitea.com/x'))
   t.false(validator('https://notamazon.com/x'))
   t.false(validator('https://amazon-fake.com/x'))
+  // Subdomain spoofs where the registrable domain is the attacker's
+  t.false(validator('https://amazon.evil.com/x'))
+  t.false(validator('https://amzn.evil.com/x'))
+  t.false(validator('https://amazon.com.evil.org/x'))
 })

--- a/packages/metascraper-amazon/test/test.js
+++ b/packages/metascraper-amazon/test/test.js
@@ -26,4 +26,11 @@ test('false', t => {
   t.false(validator('https://twitter.com/username/'))
   t.false(validator('https://www.youtube.com/watch?v=123'))
   t.false(validator('https://example.com'))
+  // Hosts that merely contain "a.co" or "amazon" as a substring must not match
+  t.false(validator('https://www.rangemedia.co/some-post'))
+  t.false(validator('https://formula.co/post'))
+  t.false(validator('https://asitea.co/x'))
+  t.false(validator('https://asitea.com/x'))
+  t.false(validator('https://notamazon.com/x'))
+  t.false(validator('https://amazon-fake.com/x'))
 })


### PR DESCRIPTION
Fixes #851.

### Problem

`metascraper-amazon`'s URL test was an unanchored substring regex:

```js
const REGEX_AMAZON_URL =
  /https?:\/\/(.*amazon\..*\/.*|.*amzn\..*\/.*|.*a\.co\/.*)/i
```

The `a.co` alternative matched anywhere a letter preceded `.co/` in the URL. Hosts like `rangemedia.co`, `formula.co`, `area.co`, `asitea.co`, etc. all matched, which caused the plugin's rules — including the hardcoded `publisher: () => 'Amazon'` — to fire on completely unrelated sites. Downstream consumers (e.g. bookmark cards) ended up labelling those sites as "Amazon".

Reproducer (before this PR):

```js
> require('metascraper-amazon').test('https://www.rangemedia.co/some-post')
true  // should be false
```

### Fix

Switch the URL test to check the registrable domain via `parseUrl().domain`, which is already imported from `@metascraper/helpers` (it wraps `tldts.parse`, so the Public Suffix List handles the ccTLD edge cases for us):

```js
const isAmazonDomain = domain => {
  if (!domain) return false
  if (domain === 'a.co') return true
  return /^(?:amazon|amzn)\./.test(domain)
}

const test = memoizeOne(url => isAmazonDomain(parseUrl(url).domain))
```

This matches exactly:

- `amazon.<tld>` and any subdomain (e.g. `www.amazon.com`, `amazon.co.uk`, `kindle.amazon.com`)
- `amzn.<tld>` and any subdomain (e.g. `amzn.to`)
- `a.co` (the Amazon short link)

and rejects substring lookalikes (`rangemedia.co`, `asitea.co`, `asitea.com`, `notamazon.com`, `amazon-fake.com`, …).

### Tests

Added negative cases to `packages/metascraper-amazon/test/test.js`:

```js
t.false(validator('https://www.rangemedia.co/some-post'))
t.false(validator('https://formula.co/post'))
t.false(validator('https://asitea.co/x'))
t.false(validator('https://asitea.com/x'))
t.false(validator('https://notamazon.com/x'))
t.false(validator('https://amazon-fake.com/x'))
```

All 6 existing tests (the `true`/`false` predicate tests plus the four `amazon.<tld>` HTML fixture snapshots) still pass:

```
✔ test › true
✔ test › false
✔ index › product url for amazon.co.uk
✔ index › product url for amazon.com
✔ index › product url for amazon.es
✔ index › ansi url for amazon.com
6 tests passed
```

### Context

Reported via a Ghost customer who saw every bookmark card on their `.co` site rendering "Amazon" as the site name. Ghost is shipping a hostname-anchored gate around `metascraper-amazon` in [TryGhost/Ghost#28961](https://github.com/TryGhost/Ghost/pull/28961) as a near-term workaround, but we'd love to drop it once this lands.