### PR TITLE
ci: pin pnpm to 11.11.0 to avoid broken 11.12.0 self-installer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.11.0
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Contributors
@@ -63,7 +63,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.11.0
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
         with:
-          version: latest
+          version: 11.11.0
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Test


### PR DESCRIPTION
## Problem

Every CI job on `master` and on open PRs (including Dependabot #855) is failing at the **Setup PNPM** step, not in tests:

```
Switching pnpm from v11.7.0 to v11.12.0...
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
    at createFullPkgId (.../pnpm.mjs)
    at lockfileToDepGraph ...
##[error]Something went wrong, self-installer exits with code 1
```

`pnpm/action-setup@v6` is configured with `version: latest`, which now resolves to **pnpm 11.12.0**. That release has a regression in its self-installer (`installFromLockfile` → `createFullPkgId`) that crashes on install. The failure is unrelated to any dependency change; it blocks all PRs.

## Fix

Pin pnpm to `11.11.0` (the last release before the broken one) across all three workflow steps in `main.yml` and `pull_request.yml`. Pinning also gives reproducible CI instead of a floating `latest`.

Once merged, `@dependabot rebase` on #855 (and other open PRs) will pick up the fix and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow configuration with no application, auth, or runtime code changes.
> 
> **Overview**
> Pins **pnpm** to `11.11.0` in every **Setup PNPM** step that used `version: latest` in `main.yml` (contributors + test jobs) and `pull_request.yml` (test job).
> 
> This avoids CI failing during `pnpm/action-setup` when `latest` resolves to **11.12.0**, whose self-installer crashes with an `integrity` / lockfile parsing error before install or tests run. Pinning also keeps CI on a fixed pnpm version instead of a floating `latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933a566420972626d5b0686539f0ababb70109d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized automated testing and contributor checks on Node.js version 11.11.0.
  * Improved consistency and predictability of continuous integration results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->