### PR TITLE
feat(helpers): read the declared protocol instead of resolving it

### DIFF
--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -152,9 +152,8 @@ const protocol = url => {
   let start = 0
   while (start < length && url.charCodeAt(start) <= 0x20) start++
   const head = url.charCodeAt(start)
-  const isLower = head >= 0x61 && head <= 0x7a
-  if (!isLower && !(head >= 0x41 && head <= 0x5a)) return ''
-  let isLowerCased = isLower
+  let isLowerCased = head >= 0x61 && head <= 0x7a
+  if (!isLowerCased && !(head >= 0x41 && head <= 0x5a)) return ''
   for (let index = start + 1; index < length; index++) {
     const code = url.charCodeAt(index)
     if (code === 0x3a) {
@@ -166,8 +165,8 @@ const protocol = url => {
       isLowerCased = false
       continue
     }
-    const isDigit = code >= 0x30 && code <= 0x39
-    if (isDigit || code === 0x2b || code === 0x2d || code === 0x2e) continue
+    if (code >= 0x30 && code <= 0x39) continue
+    if (code === 0x2b || code === 0x2d || code === 0x2e) continue
     // `mai\tlto:a@b` declares `mailto`
     if (code === 0x09 || code === 0x0a || code === 0x0d) {
       return protocol(url.replace(REGEX_URL_TAB_OR_NEWLINE, ''))

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -146,32 +146,33 @@ const absoluteUrl = (baseUrl, relativePath) => {
 }
 
 // https://url.spec.whatwg.org/#scheme-state
-const isSchemeHead = code =>
-  (code >= 0x61 && code <= 0x7a) || (code >= 0x41 && code <= 0x5a)
-
-const isSchemeChar = code =>
-  isSchemeHead(code) ||
-  (code >= 0x30 && code <= 0x39) ||
-  code === 0x2b ||
-  code === 0x2d ||
-  code === 0x2e
-
 const protocol = url => {
   if (!isString(url)) return ''
-  let index = 0
-  while (index < url.length && url.charCodeAt(index) <= 0x20) index++
-  const start = index
-  for (; index < url.length; index++) {
+  const { length } = url
+  let start = 0
+  while (start < length && url.charCodeAt(start) <= 0x20) start++
+  const head = url.charCodeAt(start)
+  const isLower = head >= 0x61 && head <= 0x7a
+  if (!isLower && !(head >= 0x41 && head <= 0x5a)) return ''
+  let isLowerCased = isLower
+  for (let index = start + 1; index < length; index++) {
     const code = url.charCodeAt(index)
     if (code === 0x3a) {
-      return index === start ? '' : url.slice(start, index).toLowerCase()
+      const scheme = url.slice(start, index)
+      return isLowerCased ? scheme : scheme.toLowerCase()
     }
-    // the parser removes every ASCII tab or newline before reading the scheme,
-    // so `mai\tlto:a@b` declares `mailto`
+    if (code >= 0x61 && code <= 0x7a) continue
+    if (code >= 0x41 && code <= 0x5a) {
+      isLowerCased = false
+      continue
+    }
+    const isDigit = code >= 0x30 && code <= 0x39
+    if (isDigit || code === 0x2b || code === 0x2d || code === 0x2e) continue
+    // `mai\tlto:a@b` declares `mailto`
     if (code === 0x09 || code === 0x0a || code === 0x0d) {
       return protocol(url.replace(REGEX_URL_TAB_OR_NEWLINE, ''))
     }
-    if (!(index === start ? isSchemeHead(code) : isSchemeChar(code))) return ''
+    return ''
   }
   return ''
 }

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -123,6 +123,16 @@ const REGEX_LOCATION = /^[A-Z\s]+\s+[-—–]\s+/
 
 const REGEX_TITLE_SEPARATOR = /^[^|\-/•—]+/
 
+// https://url.spec.whatwg.org/#scheme-state
+const REGEX_SCHEME = /^[A-Za-z][A-Za-z0-9+\-.]*:/
+
+const REGEX_URL_TAB_OR_NEWLINE = /[\t\n\r]/
+
+// A leading C0 control or space, and any ASCII tab or newline, are stripped by
+// the URL parser before it reads the scheme, ruling out the fast path.
+const isUrlTrimmable = value =>
+  value.charCodeAt(0) <= 0x20 || REGEX_URL_TAB_OR_NEWLINE.test(value)
+
 const AUTHOR_MAX_LENGTH = 128
 
 const removeLocation = value => replace(value, REGEX_LOCATION, '')
@@ -205,7 +215,13 @@ const isAuthor = (str, opts = { relative: false }) =>
 const getAuthor = (str, { removeBy = true, ...opts } = {}) =>
   titleize(str, { removeBy, ...opts })
 
+const hasNoScheme = value =>
+  isString(value) && !REGEX_SCHEME.test(value) && !isUrlTrimmable(value)
+
 const protocol = url => {
+  // Such a value cannot parse without a base, and reaching '' by constructing
+  // `new URL` only to catch the throw is orders of magnitude more expensive.
+  if (hasNoScheme(url)) return ''
   const { protocol = '' } = urlObject(url)
   return protocol.replace(':', '')
 }

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -123,24 +123,7 @@ const REGEX_LOCATION = /^[A-Z\s]+\s+[-—–]\s+/
 
 const REGEX_TITLE_SEPARATOR = /^[^|\-/•—]+/
 
-// https://url.spec.whatwg.org/#scheme-state
-const REGEX_SCHEME = /^([A-Za-z][A-Za-z0-9+\-.]*):/
-
 const REGEX_URL_TAB_OR_NEWLINE = /[\t\n\r]/g
-
-const hasTabOrNewline = value =>
-  value.includes('\t') || value.includes('\n') || value.includes('\r')
-
-// The URL parser strips a leading C0 control or space, and removes every ASCII tab
-// or newline, before it reads the scheme: ' mai\tlto:a@b' declares `mailto`.
-const forScheme = value => {
-  let start = 0
-  while (start < value.length && value.charCodeAt(start) <= 0x20) start++
-  const trimmed = start === 0 ? value : value.slice(start)
-  return hasTabOrNewline(trimmed)
-    ? trimmed.replace(REGEX_URL_TAB_OR_NEWLINE, '')
-    : trimmed
-}
 
 const AUTHOR_MAX_LENGTH = 128
 
@@ -162,6 +145,37 @@ const absoluteUrl = (baseUrl, relativePath) => {
   return urlObject(relativePath, baseUrl).toString()
 }
 
+// https://url.spec.whatwg.org/#scheme-state
+const isSchemeHead = code =>
+  (code >= 0x61 && code <= 0x7a) || (code >= 0x41 && code <= 0x5a)
+
+const isSchemeChar = code =>
+  isSchemeHead(code) ||
+  (code >= 0x30 && code <= 0x39) ||
+  code === 0x2b ||
+  code === 0x2d ||
+  code === 0x2e
+
+const protocol = url => {
+  if (!isString(url)) return ''
+  let index = 0
+  while (index < url.length && url.charCodeAt(index) <= 0x20) index++
+  const start = index
+  for (; index < url.length; index++) {
+    const code = url.charCodeAt(index)
+    if (code === 0x3a) {
+      return index === start ? '' : url.slice(start, index).toLowerCase()
+    }
+    // the parser removes every ASCII tab or newline before reading the scheme,
+    // so `mai\tlto:a@b` declares `mailto`
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      return protocol(url.replace(REGEX_URL_TAB_OR_NEWLINE, ''))
+    }
+    if (!(index === start ? isSchemeHead(code) : isSchemeChar(code))) return ''
+  }
+  return ''
+}
+
 const sanetizeUrl = (url, opts) =>
   _normalizeUrl(url, {
     stripWWW: false,
@@ -175,7 +189,7 @@ const normalizeUrl = (baseUrl, relativePath, opts) => {
   try {
     const absolute = absoluteUrl(baseUrl, relativePath)
     // normalize-url v9 no longer rejects `javascript:` URLs; keep them out
-    if (urlObject(absolute).protocol === 'javascript:') return undefined
+    if (protocol(absolute) === 'javascript') return undefined
     return sanetizeUrl(absolute, opts)
   } catch (_) {}
 }
@@ -223,15 +237,6 @@ const isAuthor = (str, opts = { relative: false }) =>
 
 const getAuthor = (str, { removeBy = true, ...opts } = {}) =>
   titleize(str, { removeBy, ...opts })
-
-// Which scheme a value declares is a lexical question, so it is read rather than
-// resolved: `new URL` rejects an authority it cannot parse, and answering '' for
-// `http://` describes the whole URL, not the scheme sitting in front of it.
-const protocol = url => {
-  if (!isString(url)) return ''
-  const match = REGEX_SCHEME.exec(forScheme(url))
-  return match === null ? '' : match[1].toLowerCase()
-}
 
 const isExtension = (url, type, ext = extension(url)) =>
   type === EXTENSIONS[ext]

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -124,14 +124,23 @@ const REGEX_LOCATION = /^[A-Z\s]+\s+[-—–]\s+/
 const REGEX_TITLE_SEPARATOR = /^[^|\-/•—]+/
 
 // https://url.spec.whatwg.org/#scheme-state
-const REGEX_SCHEME = /^[A-Za-z][A-Za-z0-9+\-.]*:/
+const REGEX_SCHEME = /^([A-Za-z][A-Za-z0-9+\-.]*):/
 
-const REGEX_URL_TAB_OR_NEWLINE = /[\t\n\r]/
+const REGEX_URL_TAB_OR_NEWLINE = /[\t\n\r]/g
 
-// A leading C0 control or space, and any ASCII tab or newline, are stripped by
-// the URL parser before it reads the scheme, ruling out the fast path.
-const isUrlTrimmable = value =>
-  value.charCodeAt(0) <= 0x20 || REGEX_URL_TAB_OR_NEWLINE.test(value)
+const hasTabOrNewline = value =>
+  value.includes('\t') || value.includes('\n') || value.includes('\r')
+
+// The URL parser strips a leading C0 control or space, and removes every ASCII tab
+// or newline, before it reads the scheme: ' mai\tlto:a@b' declares `mailto`.
+const forScheme = value => {
+  let start = 0
+  while (start < value.length && value.charCodeAt(start) <= 0x20) start++
+  const trimmed = start === 0 ? value : value.slice(start)
+  return hasTabOrNewline(trimmed)
+    ? trimmed.replace(REGEX_URL_TAB_OR_NEWLINE, '')
+    : trimmed
+}
 
 const AUTHOR_MAX_LENGTH = 128
 
@@ -215,15 +224,13 @@ const isAuthor = (str, opts = { relative: false }) =>
 const getAuthor = (str, { removeBy = true, ...opts } = {}) =>
   titleize(str, { removeBy, ...opts })
 
-const hasNoScheme = value =>
-  isString(value) && !REGEX_SCHEME.test(value) && !isUrlTrimmable(value)
-
+// Which scheme a value declares is a lexical question, so it is read rather than
+// resolved: `new URL` rejects an authority it cannot parse, and answering '' for
+// `http://` describes the whole URL, not the scheme sitting in front of it.
 const protocol = url => {
-  // Such a value cannot parse without a base, and reaching '' by constructing
-  // `new URL` only to catch the throw is orders of magnitude more expensive.
-  if (hasNoScheme(url)) return ''
-  const { protocol = '' } = urlObject(url)
-  return protocol.replace(':', '')
+  if (!isString(url)) return ''
+  const match = REGEX_SCHEME.exec(forScheme(url))
+  return match === null ? '' : match[1].toLowerCase()
 }
 
 const isExtension = (url, type, ext = extension(url)) =>

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -27,6 +27,7 @@ const {
   lang,
   normalizeUrl,
   parseUrl,
+  protocol,
   url,
   video
 } = require('../src')
@@ -62,6 +63,46 @@ test('.parseUrl', t => {
   const fn = () => parseUrl('https://example.com')
   /* this assertion ensure parseUrl memoize the value */
   t.true(measure(fn) > measure(fn)) // eslint-disable-line
+})
+
+test('.protocol', t => {
+  t.is(protocol('http://example.com'), 'http')
+  t.is(protocol('HTTPS://Example.com'), 'https')
+  t.is(protocol('mailto:user@example.com'), 'mailto')
+  t.is(protocol('MAILTO:user@example.com'), 'mailto')
+  t.is(protocol('tel:+34123456789'), 'tel')
+  t.is(protocol('javascript:alert(1)'), 'javascript')
+  t.is(protocol('data:text/plain,hello'), 'data')
+  t.is(protocol('ftp://example.com/file.txt'), 'ftp')
+  t.is(protocol('file:///etc/passwd'), 'file')
+  t.is(protocol('urn:isbn:0451450523'), 'urn')
+  t.is(protocol('blob:https://example.com/uuid'), 'blob')
+
+  /* schemeless input cannot be parsed without a base */
+  t.is(protocol('/path/to/page'), '')
+  t.is(protocol('page.html'), '')
+  t.is(protocol('../up'), '')
+  t.is(protocol('//example.com/path'), '')
+  t.is(protocol('#fragment'), '')
+  t.is(protocol(''), '')
+
+  /* a scheme the URL parser rejects as a whole resolves to no protocol */
+  t.is(protocol('http://'), '')
+  t.is(protocol('http://['), '')
+
+  /* the URL parser strips these before reading the scheme */
+  t.is(protocol('  mailto:user@example.com'), 'mailto')
+  t.is(protocol('\tmailto:user@example.com'), 'mailto')
+  t.is(protocol('mai\tlto:user@example.com'), 'mailto')
+  t.is(protocol('ht\ntp://example.com'), 'http')
+
+  /* a scheme cannot start with a digit or a sign */
+  t.is(protocol('1http://example.com'), '')
+  t.is(protocol('+http://example.com'), '')
+
+  t.is(protocol(undefined), '')
+  t.is(protocol(null), '')
+  t.is(protocol(0), '')
 })
 
 test('.normalizeUrl', t => {

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -78,7 +78,6 @@ test('.protocol', t => {
   t.is(protocol('urn:isbn:0451450523'), 'urn')
   t.is(protocol('blob:https://example.com/uuid'), 'blob')
 
-  /* schemeless input cannot be parsed without a base */
   t.is(protocol('/path/to/page'), '')
   t.is(protocol('page.html'), '')
   t.is(protocol('../up'), '')
@@ -97,7 +96,6 @@ test('.protocol', t => {
   t.is(protocol('mai\tlto:user@example.com'), 'mailto')
   t.is(protocol('ht\ntp://example.com'), 'http')
 
-  /* a scheme cannot start with a digit or a sign */
   t.is(protocol('1http://example.com'), '')
   t.is(protocol('+http://example.com'), '')
 

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -86,9 +86,10 @@ test('.protocol', t => {
   t.is(protocol('#fragment'), '')
   t.is(protocol(''), '')
 
-  /* a scheme the URL parser rejects as a whole resolves to no protocol */
-  t.is(protocol('http://'), '')
-  t.is(protocol('http://['), '')
+  /* the declared scheme is read, even when the authority is unparseable */
+  t.is(protocol('http://'), 'http')
+  t.is(protocol('http://['), 'http')
+  t.is(protocol('foo://['), 'foo')
 
   /* the URL parser strips these before reading the scheme */
   t.is(protocol('  mailto:user@example.com'), 'mailto')

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -91,7 +91,7 @@ test('.protocol', t => {
   t.is(protocol('http://['), 'http')
   t.is(protocol('foo://['), 'foo')
 
-  /* the URL parser strips these before reading the scheme */
+  /* stripped before the scheme is read, as the URL parser does */
   t.is(protocol('  mailto:user@example.com'), 'mailto')
   t.is(protocol('\tmailto:user@example.com'), 'mailto')
   t.is(protocol('mai\tlto:user@example.com'), 'mailto')

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -91,7 +91,7 @@ test('.protocol', t => {
   t.is(protocol('http://['), 'http')
   t.is(protocol('foo://['), 'foo')
 
-  /* stripped before the scheme is read, as the URL parser does */
+  /* whitespace and tabs are stripped before the scheme is read */
   t.is(protocol('  mailto:user@example.com'), 'mailto')
   t.is(protocol('\tmailto:user@example.com'), 'mailto')
   t.is(protocol('mai\tlto:user@example.com'), 'mailto')

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -85,7 +85,8 @@ test('.protocol', t => {
   t.is(protocol('#fragment'), '')
   t.is(protocol(''), '')
 
-  /* the declared scheme is read, even when the authority is unparseable */
+  /* the declared scheme is read, even when the rest is not a URL */
+  t.is(protocol('example.com:8080/path'), 'example.com')
   t.is(protocol('http://'), 'http')
   t.is(protocol('http://['), 'http')
   t.is(protocol('foo://['), 'foo')


### PR DESCRIPTION
## Problem

`protocol` resolved the scheme by handing the value to `new URL` inside a try/catch:

```js
const protocol = url => {
  const { protocol = '' } = urlObject(url)
  return protocol.replace(':', '')
}
```

A value without a scheme cannot parse without a base, so it constructed a `URL`, threw, got caught, and returned `''`. Callers walking a document's links feed it mostly relative hrefs (`/path`, `page.html`, `#frag`, `//host/a`), which put a V8 exception on the hot path.

## Change

Which scheme a value declares is a lexical question, so it is read rather than
resolved: a single character scan, no `URL` construction and no allocation on
the common path.

The scheme is read after the same cleanup the URL parser applies before reading
it itself: a leading C0 control or space is skipped, and every ASCII tab or
newline is removed. So `' mai\tlto:a@b'` still declares `mailto`.

## Numbers

100k calls per set, best of 9. No input class is slower than before:

| input | before | after | |
|---|---|---|---|
| relative hrefs (schemeless) | 297.8ms | 0.7ms | **436x** |
| mixed relative + absolute | 187.5ms | 1.1ms | **177x** |
| absolute http | 14.9ms | 1.4ms | **11x** |
| non-http schemes | 13.8ms | 1.2ms | **11x** |

`normalizeUrl` asked the same question through a second `new URL`, so it now
reads the helper instead: 14x on that guard, ~6% off `normalizeUrl` end to end.

## Behavior change

Output changes for one class of input: a URL whose **authority** the parser rejects.

```js
protocol('http://')   // '' -> 'http'
protocol('http://[')  // '' -> 'http'
protocol('foo://[')   // '' -> 'foo'
```

`''` there described the whole URL rather than the scheme sitting in front of it. Whether a URL is usable is what `isUrl` answers. Marked `feat` rather than `perf` for this reason.

Everything else is untouched: `protocol('/path')`, `protocol('#frag')`, `protocol('')` and non-strings all stay `''`, and every valid URL returns the same lowercased scheme as before.

## Verification

Differential fuzz against the previous implementation over **300,079 inputs** — curated edge cases plus 300k pseudo-random strings drawn from an alphabet of scheme, delimiter, control and non-ASCII characters. Divergences are not just counted but classified, so anything outside the intended class fails the run:

```
corpus: 300079 inputs
identical:            300070
intended divergences: 9  (old '' from a rejected URL -> declared scheme)
UNEXPECTED:           0
```

Each later rewrite of the scan was then fuzzed against the one it replaced over
a further **500,044 inputs**: 0 mismatches.

All 9 are the malformed-authority case above. Covered explicitly: leading/trailing control characters and spaces, tabs and newlines inside the scheme, schemes starting with a digit or sign, bare `mailto:`, `blob:`/`view-source:`/`about:`, and non-string input (`undefined`, `null`, numbers, objects).

## Tests

Added `.protocol` to `packages/metascraper-helpers/test/index.js` pinning all of the above, including the new `http://` → `'http'` semantics and the pre-scheme cleanup cases.

- `metascraper-helpers`: 66 tests passing
- `metascraper-media-provider` (the only in-repo consumer, comparing against `'https'`): 36 passing, 4 skipped

## Motivation

Found while fixing https://github.com/Kikobeats/html-urls/pull/92, where `getLink` needs a scheme check for every URL-bearing attribute and had to carry its own matcher because `protocol()` was 75x slower than an inline regex. It now matches or beats that regex on every input class (0.70-0.98x, ~7-13ns per link) while returning the scheme rather than a boolean, so html-urls can drop the duplicate once this releases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL scheme detection for inputs with leading whitespace/control characters, including tabs and newlines.
  * Correctly recognizes schemes in a case-insensitive way.
  * Ensures only valid scheme tokens are treated as schemes, while avoiding schemeless/relative/fragment-only inputs.
  * Updates URL normalization to properly filter `javascript:` based on extracted scheme.
* **Tests**
  * Extended the test suite to cover scheme parsing across many valid/invalid and malformed URL-like inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9ddbffd2a8b6274860d5d26598eb9ce2cf0f012d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->