### PR TITLE
feat(helpers): add rule-level validate (like test)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,17 @@ Object.assign(() => 'https://example.com/logo.png', {
 
 `validate` runs after a rule produces a value. Returning a falsy value (or throwing) discards that candidate and `findRule` continues with the next rule for the property — exactly as if the rule had returned nothing. If every rule is rejected, the property is `null`.
 
-The first argument is the candidate value; the second is the same args object passed to the rule / `test`. Set `DEBUG=metascraper:find-rule` to see rejections.
+The first argument is the candidate value; the second is the same args object passed to the rule / `test`; the third is the `metascraper:find-rule` logger, so a rejection can explain itself:
+
+```js
+rules.validate = (value, { url }, debug) => {
+  if (!value.startsWith('data:')) return true
+  debug('logo:rejected', { url, reason: 'data-uri' })
+  return false
+}
+```
+
+Set `DEBUG=metascraper:find-rule` to see those lines, plus the rejections metascraper logs on its own.
 
 ### Defining `pkgName` property
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,27 @@ const rules = []
 rules.test = ({ url }) => test(url)
 ```
 
+### Defining `validate` function
+
+You can associate a `validate` function with a single rule or with the whole rules bundle (copied onto every rule, like `test`):
+
+```js
+rules.validate = async (value, { url }) =>
+  typeof value !== 'string' || !value.startsWith('data:')
+```
+
+Or per rule:
+
+```js
+Object.assign(() => 'https://example.com/logo.png', {
+  validate: async value => !(await isHostile(value))
+})
+```
+
+`validate` runs after a rule produces a value. Returning a falsy value (or throwing) discards that candidate and `findRule` continues with the next rule for the property — exactly as if the rule had returned nothing. If every rule is rejected, the property is `null`.
+
+The first argument is the candidate value; the second is the same args object passed to the rule / `test`. Set `DEBUG=metascraper:find-rule` to see rejections.
+
 ### Defining `pkgName` property
 
 Additionally you can define `pkgName` property associated with your rules:

--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ The hook receives the value plus `{ propName, rule, args }`, and it can be async
 const metadata = await metascraper({
   url,
   html,
-  validate: (value, { propName }) => !value.startsWith('data:')
+  validate: value =>
+    typeof value !== 'string' || !value.startsWith('data:')
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@
     - [pickPropNames](#pickpropnames)
     - [rules](#rules-1)
     - [url](#url)
-    - [validate](#validate)
     - [validateUrl](#validateurl)
 - [Environment Variables](#environment-variables)
     - [METASCRAPER\_RE2](#metascraper_re2)
@@ -346,38 +345,6 @@ The URL associated with the HTML markup.
 It is used for resolve relative links that can be present in the HTML markup.
 
 it can be used as fallback field for different rules as well.
-
-#### validate
-
-Type: `function|object`<br>
-Default: `undefined`
-
-A hook executed for every value a rule produces. Returning a falsy value discards that candidate and moves on to the next rule for the property, exactly as if the rule had returned nothing. If every rule is rejected, the property is `null`.
-
-The hook receives the value plus `{ propName, rule, args }`, and it can be async:
-
-```js
-const metadata = await metascraper({
-  url,
-  html,
-  validate: value =>
-    typeof value !== 'string' || !value.startsWith('data:')
-})
-```
-
-A function form runs for **every** property. To validate specific properties, pass an object keyed by property name; properties you don't list are untouched:
-
-```js
-const metadata = await metascraper({
-  url,
-  html,
-  validate: {
-    logo: async value => (await isReachable(value)) && !isSvg(value)
-  }
-})
-```
-
-A hook that throws rejects the candidate it was called with, not the whole property. Set `DEBUG=metascraper:find-rule` to see rejections.
 
 #### validateUrl
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
     - [pickPropNames](#pickpropnames)
     - [rules](#rules-1)
     - [url](#url)
+    - [validate](#validate)
     - [validateUrl](#validateurl)
 - [Environment Variables](#environment-variables)
     - [METASCRAPER\_RE2](#metascraper_re2)
@@ -345,6 +346,37 @@ The URL associated with the HTML markup.
 It is used for resolve relative links that can be present in the HTML markup.
 
 it can be used as fallback field for different rules as well.
+
+#### validate
+
+Type: `function|object`<br>
+Default: `undefined`
+
+A hook executed for every value a rule produces. Returning a falsy value discards that candidate and moves on to the next rule for the property, exactly as if the rule had returned nothing. If every rule is rejected, the property is `null`.
+
+The hook receives the value plus `{ propName, rule, args }`, and it can be async:
+
+```js
+const metadata = await metascraper({
+  url,
+  html,
+  validate: (value, { propName }) => !value.startsWith('data:')
+})
+```
+
+A function form runs for **every** property. To validate specific properties, pass an object keyed by property name; properties you don't list are untouched:
+
+```js
+const metadata = await metascraper({
+  url,
+  html,
+  validate: {
+    logo: async value => (await isReachable(value)) && !isSvg(value)
+  }
+})
+```
+
+A hook that throws rejects the candidate it was called with, not the whole property. Set `DEBUG=metascraper:find-rule` to see rejections.
 
 #### validateUrl
 

--- a/packages/metascraper-audio/src/index.js
+++ b/packages/metascraper-audio/src/index.js
@@ -6,10 +6,8 @@ const {
   audio,
   createGetIframeCached,
   defaultGetIframe,
-  findRule,
-  has,
-  normalizeUrl,
-  toRule
+  toRule,
+  withIframe
 } = require('@metascraper/helpers')
 
 const toAudio = toRule(audio)
@@ -71,41 +69,7 @@ const audioRules = [
 module.exports = ({ getIframe = defaultGetIframe } = {}) => {
   const getIframeCached = createGetIframeCached(getIframe)
   const rules = {
-    audio: audioRules.concat(
-      async ({ htmlDom: $, url, ...args }) => {
-        const srcs = $('iframe[src^="http"], iframe[src^="/"]')
-          .map((_, element) => $(element).attr('src'))
-          .get()
-        if (srcs.length === 0) return
-        const seenSrcs = new Set()
-        for (const src of srcs) {
-          try {
-            const normalizedSrc = normalizeUrl(url, src)
-            if (!normalizedSrc) continue
-            if (seenSrcs.has(normalizedSrc)) continue
-            seenSrcs.add(normalizedSrc)
-
-            const htmlDom = await getIframeCached(url, $, normalizedSrc)
-            const result = await findRule(
-              audioRules,
-              { ...args, htmlDom, url },
-              'audio'
-            )
-            if (has(result)) return result
-          } catch (_) {}
-        }
-      },
-      async ({ htmlDom: $, url, ...args }) => {
-        const src = $('meta[name="twitter:player"]').attr('content')
-        return src
-          ? findRule(
-            audioRules,
-            { ...args, htmlDom: await getIframeCached(url, $, src), url },
-            'audio'
-          )
-          : undefined
-      }
-    )
+    audio: withIframe(audioRules, getIframeCached, 'audio')
   }
 
   rules.pkgName = 'metascraper-audio'

--- a/packages/metascraper-audio/src/index.js
+++ b/packages/metascraper-audio/src/index.js
@@ -72,8 +72,7 @@ module.exports = ({ getIframe = defaultGetIframe } = {}) => {
   const getIframeCached = createGetIframeCached(getIframe)
   const rules = {
     audio: audioRules.concat(
-      async args => {
-        const { htmlDom: $, url } = args
+      async ({ htmlDom: $, url, ...args }) => {
         const srcs = $('iframe[src^="http"], iframe[src^="/"]')
           .map((_, element) => $(element).attr('src'))
           .get()
@@ -89,20 +88,19 @@ module.exports = ({ getIframe = defaultGetIframe } = {}) => {
             const htmlDom = await getIframeCached(url, $, normalizedSrc)
             const result = await findRule(
               audioRules,
-              { ...args, htmlDom },
+              { ...args, htmlDom, url },
               'audio'
             )
             if (has(result)) return result
           } catch (_) {}
         }
       },
-      async args => {
-        const { htmlDom: $, url } = args
+      async ({ htmlDom: $, url, ...args }) => {
         const src = $('meta[name="twitter:player"]').attr('content')
         return src
           ? findRule(
             audioRules,
-            { ...args, htmlDom: await getIframeCached(url, $, src) },
+            { ...args, htmlDom: await getIframeCached(url, $, src), url },
             'audio'
           )
           : undefined

--- a/packages/metascraper-audio/src/index.js
+++ b/packages/metascraper-audio/src/index.js
@@ -72,7 +72,8 @@ module.exports = ({ getIframe = defaultGetIframe } = {}) => {
   const getIframeCached = createGetIframeCached(getIframe)
   const rules = {
     audio: audioRules.concat(
-      async ({ htmlDom: $, url }) => {
+      async args => {
+        const { htmlDom: $, url } = args
         const srcs = $('iframe[src^="http"], iframe[src^="/"]')
           .map((_, element) => $(element).attr('src'))
           .get()
@@ -86,18 +87,24 @@ module.exports = ({ getIframe = defaultGetIframe } = {}) => {
             seenSrcs.add(normalizedSrc)
 
             const htmlDom = await getIframeCached(url, $, normalizedSrc)
-            const result = await findRule(audioRules, { htmlDom, url })
+            const result = await findRule(
+              audioRules,
+              { ...args, htmlDom },
+              'audio'
+            )
             if (has(result)) return result
           } catch (_) {}
         }
       },
-      async ({ htmlDom: $, url }) => {
+      async args => {
+        const { htmlDom: $, url } = args
         const src = $('meta[name="twitter:player"]').attr('content')
         return src
-          ? findRule(audioRules, {
-            htmlDom: await getIframeCached(url, $, src),
-            url
-          })
+          ? findRule(
+            audioRules,
+            { ...args, htmlDom: await getIframeCached(url, $, src) },
+            'audio'
+          )
           : undefined
       }
     )

--- a/packages/metascraper-audio/test/iframe.js
+++ b/packages/metascraper-audio/test/iframe.js
@@ -5,8 +5,8 @@ const test = require('ava').default
 
 const { runServer } = require('./helpers')
 
-const createMetascraper = (...args) =>
-  require('metascraper')([require('../src')(...args)])
+const createMetascraper = (opts, meta) =>
+  require('metascraper')([Object.assign(require('../src')(opts), meta)])
 
 test('absolute http', async t => {
   const url = await runServer(t, ({ res }) => {
@@ -69,17 +69,18 @@ test('stop iframe probing after first audio match', async t => {
 })
 
 test('validate reaches the rules nested behind an iframe', async t => {
-  const rules = require('../src')({
-    getIframe: async (url, $, { src }) =>
-      cheerio.load(
-        `<meta property="og:audio" content="https://cdn.microlink.io${src.replace(
-          'https://example.com',
-          ''
-        )}.mp3">`
-      )
-  })
-  rules.validate = value => !value.endsWith('/hostile.mp3')
-  const metascraper = require('metascraper')([rules])
+  const metascraper = createMetascraper(
+    {
+      getIframe: async (url, $, { src }) =>
+        cheerio.load(
+          `<meta property="og:audio" content="https://cdn.microlink.io${src.replace(
+            'https://example.com',
+            ''
+          )}.mp3">`
+        )
+    },
+    { validate: value => !value.endsWith('/hostile.mp3') }
+  )
 
   const metadata = await metascraper({
     url: 'https://example.com',
@@ -90,15 +91,16 @@ test('validate reaches the rules nested behind an iframe', async t => {
 })
 
 test('validate reaches the rules nested behind twitter:player', async t => {
-  const rules = require('../src')({
-    getIframe: async () =>
-      cheerio.load(`
+  const metascraper = createMetascraper(
+    {
+      getIframe: async () =>
+        cheerio.load(`
         <meta property="og:audio" content="https://cdn.microlink.io/hostile.mp3">
         <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp3">
       `)
-  })
-  rules.validate = value => !value.endsWith('/hostile.mp3')
-  const metascraper = require('metascraper')([rules])
+    },
+    { validate: value => !value.endsWith('/hostile.mp3') }
+  )
 
   const metadata = await metascraper({
     url: 'https://example.com',

--- a/packages/metascraper-audio/test/iframe.js
+++ b/packages/metascraper-audio/test/iframe.js
@@ -68,6 +68,26 @@ test('stop iframe probing after first audio match', async t => {
   t.deepEqual(calls, ['https://example.com/ok'])
 })
 
+test('validate reaches the rules nested behind an iframe', async t => {
+  const metascraper = createMetascraper({
+    getIframe: async (url, $, { src }) =>
+      cheerio.load(
+        `<meta property="og:audio" content="https://cdn.microlink.io${src.replace(
+          'https://example.com',
+          ''
+        )}.mp3">`
+      )
+  })
+
+  const metadata = await metascraper({
+    url: 'https://example.com',
+    html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
+    validate: value => !value.endsWith('/hostile.mp3')
+  })
+
+  t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')
+})
+
 test('dedupe normalized iframe urls while probing', async t => {
   let calls = 0
   const metascraper = createMetascraper({

--- a/packages/metascraper-audio/test/iframe.js
+++ b/packages/metascraper-audio/test/iframe.js
@@ -69,7 +69,7 @@ test('stop iframe probing after first audio match', async t => {
 })
 
 test('validate reaches the rules nested behind an iframe', async t => {
-  const metascraper = createMetascraper({
+  const rules = require('../src')({
     getIframe: async (url, $, { src }) =>
       cheerio.load(
         `<meta property="og:audio" content="https://cdn.microlink.io${src.replace(
@@ -78,29 +78,31 @@ test('validate reaches the rules nested behind an iframe', async t => {
         )}.mp3">`
       )
   })
+  rules.validate = value => !value.endsWith('/hostile.mp3')
+  const metascraper = require('metascraper')([rules])
 
   const metadata = await metascraper({
     url: 'https://example.com',
-    html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
-    validate: { audio: value => !value.endsWith('/hostile.mp3') }
+    html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>'
   })
 
   t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')
 })
 
 test('validate reaches the rules nested behind twitter:player', async t => {
-  const metascraper = createMetascraper({
+  const rules = require('../src')({
     getIframe: async () =>
       cheerio.load(`
         <meta property="og:audio" content="https://cdn.microlink.io/hostile.mp3">
         <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp3">
       `)
   })
+  rules.validate = value => !value.endsWith('/hostile.mp3')
+  const metascraper = require('metascraper')([rules])
 
   const metadata = await metascraper({
     url: 'https://example.com',
-    html: '<meta name="twitter:player" content="https://example.com/player">',
-    validate: { audio: value => !value.endsWith('/hostile.mp3') }
+    html: '<meta name="twitter:player" content="https://example.com/player">'
   })
 
   t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')

--- a/packages/metascraper-audio/test/iframe.js
+++ b/packages/metascraper-audio/test/iframe.js
@@ -90,26 +90,6 @@ test('validate reaches the rules nested behind an iframe', async t => {
   t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')
 })
 
-test('validate reaches the rules nested behind twitter:player', async t => {
-  const metascraper = createMetascraper(
-    {
-      getIframe: async () =>
-        cheerio.load(`
-        <meta property="og:audio" content="https://cdn.microlink.io/hostile.mp3">
-        <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp3">
-      `)
-    },
-    { validate: value => !value.endsWith('/hostile.mp3') }
-  )
-
-  const metadata = await metascraper({
-    url: 'https://example.com',
-    html: '<meta name="twitter:player" content="https://example.com/player">'
-  })
-
-  t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')
-})
-
 test('dedupe normalized iframe urls while probing', async t => {
   let calls = 0
   const metascraper = createMetascraper({

--- a/packages/metascraper-audio/test/iframe.js
+++ b/packages/metascraper-audio/test/iframe.js
@@ -82,7 +82,25 @@ test('validate reaches the rules nested behind an iframe', async t => {
   const metadata = await metascraper({
     url: 'https://example.com',
     html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
-    validate: value => !value.endsWith('/hostile.mp3')
+    validate: { audio: value => !value.endsWith('/hostile.mp3') }
+  })
+
+  t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')
+})
+
+test('validate reaches the rules nested behind twitter:player', async t => {
+  const metascraper = createMetascraper({
+    getIframe: async () =>
+      cheerio.load(`
+        <meta property="og:audio" content="https://cdn.microlink.io/hostile.mp3">
+        <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp3">
+      `)
+  })
+
+  const metadata = await metascraper({
+    url: 'https://example.com',
+    html: '<meta name="twitter:player" content="https://example.com/player">',
+    validate: { audio: value => !value.endsWith('/hostile.mp3') }
   })
 
   t.is(metadata.audio, 'https://cdn.microlink.io/safe.mp3')

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -548,9 +548,6 @@ const validator = {
 
 const truthyTest = () => true
 
-const toValidate = (validate, propName) =>
-  typeof validate === 'function' ? validate : validate?.[propName]
-
 const isValidValue = async (validate, value, context) => {
   try {
     return await validate(value, context)
@@ -568,7 +565,10 @@ const isValidValue = async (validate, value, context) => {
 const findRule = async (rules, args = {}, propName) => {
   let index = 0
   let value
-  const validate = toValidate(args.validate, propName)
+  const validate =
+    typeof args.validate === 'function'
+      ? args.validate
+      : args.validate?.[propName]
 
   do {
     const rule = rules[index++]
@@ -655,6 +655,36 @@ const createGetIframeCached = getIframe => {
   }
 }
 
+const withIframe = (rules, getIframe, propName) => {
+  const probe = async (src, args) => {
+    try {
+      return await findRule(
+        rules,
+        { ...args, htmlDom: await getIframe(args.url, args.htmlDom, src) },
+        propName
+      )
+    } catch (_) {}
+  }
+
+  return rules.concat(async args => {
+    const { htmlDom: $, url } = args
+    const seen = new Set()
+
+    for (const src of $('iframe[src^="http"], iframe[src^="/"]')
+      .map((_, el) => $(el).attr('src'))
+      .get()) {
+      const normalized = normalizeUrl(url, src)
+      if (!normalized || seen.has(normalized)) continue
+      seen.add(normalized)
+      const value = await probe(normalized, args)
+      if (has(value)) return value
+    }
+
+    const twitter = $('meta[name="twitter:player"]').attr('content')
+    return twitter ? probe(twitter, args) : undefined
+  })
+}
+
 module.exports = {
   $filter,
   $jsonld,
@@ -707,5 +737,6 @@ module.exports = {
   url,
   validator,
   video,
-  videoExtensions
+  videoExtensions,
+  withIframe
 }

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -550,7 +550,7 @@ const truthyTest = () => true
 
 const isValidValue = async (validate, value, args, rule) => {
   try {
-    return await validate(value, args)
+    return await validate(value, args, debug)
   } catch (error) {
     debug('validate:error', {
       pkgName: rule.pkgName,

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -548,13 +548,12 @@ const validator = {
 
 const truthyTest = () => true
 
-const isValidValue = async (validate, value, context) => {
+const isValidValue = async (validate, value, args, rule) => {
   try {
-    return await validate(value, context)
+    return await validate(value, args)
   } catch (error) {
     debug('validate:error', {
-      propName: context.propName,
-      pkgName: context.rule.pkgName,
+      pkgName: rule.pkgName,
       errorName: error?.name,
       errorMessage: error?.message
     })
@@ -565,10 +564,6 @@ const isValidValue = async (validate, value, context) => {
 const findRule = async (rules, args = {}, propName) => {
   let index = 0
   let value
-  const validate =
-    typeof args.validate === 'function'
-      ? args.validate
-      : args.validate?.[propName]
 
   do {
     const rule = rules[index++]
@@ -577,12 +572,8 @@ const findRule = async (rules, args = {}, propName) => {
       const duration = debug.duration()
       value = await rule(args)
       let isRejected = false
-      if (has(value) && validate) {
-        isRejected = !(await isValidValue(validate, value, {
-          propName,
-          rule,
-          args
-        }))
+      if (has(value) && rule.validate) {
+        isRejected = !(await isValidValue(rule.validate, value, args, rule))
         if (isRejected) value = undefined
       }
       duration(

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -548,10 +548,27 @@ const validator = {
 
 const truthyTest = () => true
 
-const findRule = async (rules, args, propName) => {
+const toValidate = (validate, propName) =>
+  typeof validate === 'function' ? validate : validate?.[propName]
+
+const isValidValue = async (validate, value, context) => {
+  try {
+    return await validate(value, context)
+  } catch (error) {
+    debug('validate:error', {
+      propName: context.propName,
+      pkgName: context.rule.pkgName,
+      errorName: error?.name,
+      errorMessage: error?.message
+    })
+    return false
+  }
+}
+
+const findRule = async (rules, args = {}, propName) => {
   let index = 0
   let value
-  const { validate } = args
+  const validate = toValidate(args.validate, propName)
 
   do {
     const rule = rules[index++]
@@ -559,11 +576,20 @@ const findRule = async (rules, args, propName) => {
     if (test(args)) {
       const duration = debug.duration()
       value = await rule(args)
+      let isRejected = false
       if (has(value) && validate) {
-        const isValid = await validate(value, { propName, rule, args })
-        if (!isValid) value = undefined
+        isRejected = !(await isValidValue(validate, value, {
+          propName,
+          rule,
+          args
+        }))
+        if (isRejected) value = undefined
       }
-      duration(`${rule.pkgName}:${propName}:${index - 1}:${has(value)}`)
+      duration(
+        `${rule.pkgName}:${propName}:${index - 1}:${has(value)}${
+          isRejected ? ':rejected' : ''
+        }`
+      )
     }
   } while (!has(value) && index < rules.length)
 

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -551,6 +551,7 @@ const truthyTest = () => true
 const findRule = async (rules, args, propName) => {
   let index = 0
   let value
+  const { validate } = args
 
   do {
     const rule = rules[index++]
@@ -558,6 +559,10 @@ const findRule = async (rules, args, propName) => {
     if (test(args)) {
       const duration = debug.duration()
       value = await rule(args)
+      if (has(value) && validate) {
+        const isValid = await validate(value, { propName, rule, args })
+        if (!isValid) value = undefined
+      }
       duration(`${rule.pkgName}:${propName}:${index - 1}:${has(value)}`)
     }
   } while (!has(value) && index < rules.length)

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -548,9 +548,9 @@ const validator = {
 
 const truthyTest = () => true
 
-const isValidValue = async (validate, value, args, rule) => {
+const isValidValue = async (rule, value, args) => {
   try {
-    return await validate(value, args, debug)
+    return await rule.validate(value, args, debug)
   } catch (error) {
     debug('validate:error', {
       pkgName: rule.pkgName,
@@ -564,6 +564,7 @@ const isValidValue = async (validate, value, args, rule) => {
 const findRule = async (rules, args = {}, propName) => {
   let index = 0
   let value
+  let hasValue = false
 
   do {
     const rule = rules[index++]
@@ -571,18 +572,20 @@ const findRule = async (rules, args = {}, propName) => {
     if (test(args)) {
       const duration = debug.duration()
       value = await rule(args)
-      let isRejected = false
-      if (has(value) && rule.validate) {
-        isRejected = !(await isValidValue(rule.validate, value, args, rule))
-        if (isRejected) value = undefined
+      hasValue = has(value)
+      const isRejected =
+        hasValue && rule.validate && !(await isValidValue(rule, value, args))
+      if (isRejected) {
+        value = undefined
+        hasValue = false
       }
       duration(
-        `${rule.pkgName}:${propName}:${index - 1}:${has(value)}${
+        `${rule.pkgName}:${propName}:${index - 1}:${hasValue}${
           isRejected ? ':rejected' : ''
         }`
       )
     }
-  } while (!has(value) && index < rules.length)
+  } while (!hasValue && index < rules.length)
 
   return value
 }
@@ -659,20 +662,23 @@ const withIframe = (rules, getIframe, propName) => {
 
   return rules.concat(async args => {
     const { htmlDom: $, url } = args
-    const seen = new Set()
-
-    for (const src of $('iframe[src^="http"], iframe[src^="/"]')
+    const srcs = $('iframe[src^="http"], iframe[src^="/"]')
       .map((_, el) => $(el).attr('src'))
-      .get()) {
-      const normalized = normalizeUrl(url, src)
-      if (!normalized || seen.has(normalized)) continue
-      seen.add(normalized)
-      const value = await probe(normalized, args)
-      if (has(value)) return value
+      .get()
+
+    if (srcs.length > 0) {
+      const seen = new Set()
+      for (const src of srcs) {
+        const normalized = normalizeUrl(url, src)
+        if (!normalized || seen.has(normalized)) continue
+        seen.add(normalized)
+        const value = await probe(normalized, args)
+        if (has(value)) return value
+      }
     }
 
     const twitter = $('meta[name="twitter:player"]').attr('content')
-    return twitter ? probe(twitter, args) : undefined
+    if (twitter) return probe(twitter, args)
   })
 }
 

--- a/packages/metascraper-helpers/test/find-rule.js
+++ b/packages/metascraper-helpers/test/find-rule.js
@@ -2,7 +2,7 @@
 
 const test = require('ava').default
 
-const { findRule } = require('../src')
+const { findRule } = require('..')
 
 const withValidate = (fn, validate) => Object.assign(fn, { validate })
 

--- a/packages/metascraper-helpers/test/find-rule.js
+++ b/packages/metascraper-helpers/test/find-rule.js
@@ -94,7 +94,3 @@ test('validate receives the find-rule debug logger', async t => {
   t.falsy(debug.enabled)
   t.notThrows(() => debug('validate:custom', { reason: 'test' }))
 })
-
-test('rules without validate are unchanged', async t => {
-  t.is(await findRule([() => 'value']), 'value')
-})

--- a/packages/metascraper-helpers/test/find-rule.js
+++ b/packages/metascraper-helpers/test/find-rule.js
@@ -4,6 +4,8 @@ const test = require('ava').default
 
 const { findRule } = require('../src')
 
+const withValidate = (fn, validate) => Object.assign(fn, { validate })
+
 test('args are optional', async t => {
   t.is(await findRule([() => 'value']), 'value')
 })
@@ -29,35 +31,53 @@ test('a rule test skips the rule entirely', async t => {
 
 test('validate rejects a candidate and resumes at the next rule', async t => {
   t.is(
-    await findRule([() => 'bad', () => 'good'], {
-      validate: v => v === 'good'
-    }),
+    await findRule([
+      withValidate(
+        () => 'bad',
+        v => v === 'good'
+      ),
+      withValidate(
+        () => 'good',
+        v => v === 'good'
+      )
+    ]),
     'good'
   )
 })
 
 test('validate rejecting every rule returns undefined', async t => {
   t.is(
-    await findRule([() => 'a', () => 'b'], { validate: () => false }),
+    await findRule([
+      withValidate(
+        () => 'a',
+        () => false
+      ),
+      withValidate(
+        () => 'b',
+        () => false
+      )
+    ]),
     undefined
   )
 })
 
 test('a throwing validate rejects only that candidate', async t => {
-  const value = await findRule([() => 'a', () => 'b'], {
-    validate: v => {
-      if (v === 'a') throw new Error('boom')
-      return true
-    }
-  })
+  const value = await findRule([
+    withValidate(
+      () => 'a',
+      v => {
+        if (v === 'a') throw new Error('boom')
+      }
+    ),
+    withValidate(
+      () => 'b',
+      () => true
+    )
+  ])
 
   t.is(value, 'b')
 })
 
-test('an object validate only applies to the matching propName', async t => {
-  const rules = [() => 'value']
-  const validate = { logo: () => false }
-
-  t.is(await findRule(rules, { validate }, 'logo'), undefined)
-  t.is(await findRule(rules, { validate }, 'title'), 'value')
+test('rules without validate are unchanged', async t => {
+  t.is(await findRule([() => 'value']), 'value')
 })

--- a/packages/metascraper-helpers/test/find-rule.js
+++ b/packages/metascraper-helpers/test/find-rule.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const test = require('ava').default
+
+const { findRule } = require('../src')
+
+test('args are optional', async t => {
+  t.is(await findRule([() => 'value']), 'value')
+})
+
+test('rules are evaluated until one produces a value', async t => {
+  const calls = []
+  const rule = (name, value) => () => {
+    calls.push(name)
+    return value
+  }
+
+  t.is(
+    await findRule([rule('first'), rule('second', 'value'), rule('third')]),
+    'value'
+  )
+  t.deepEqual(calls, ['first', 'second'])
+})
+
+test('a rule test skips the rule entirely', async t => {
+  const skipped = Object.assign(() => 'skipped', { test: () => false })
+  t.is(await findRule([skipped, () => 'value']), 'value')
+})
+
+test('validate rejects a candidate and resumes at the next rule', async t => {
+  t.is(
+    await findRule([() => 'bad', () => 'good'], {
+      validate: v => v === 'good'
+    }),
+    'good'
+  )
+})
+
+test('validate rejecting every rule returns undefined', async t => {
+  t.is(
+    await findRule([() => 'a', () => 'b'], { validate: () => false }),
+    undefined
+  )
+})
+
+test('a throwing validate rejects only that candidate', async t => {
+  const value = await findRule([() => 'a', () => 'b'], {
+    validate: v => {
+      if (v === 'a') throw new Error('boom')
+      return true
+    }
+  })
+
+  t.is(value, 'b')
+})
+
+test('an object validate only applies to the matching propName', async t => {
+  const rules = [() => 'value']
+  const validate = { logo: () => false }
+
+  t.is(await findRule(rules, { validate }, 'logo'), undefined)
+  t.is(await findRule(rules, { validate }, 'title'), 'value')
+})

--- a/packages/metascraper-helpers/test/find-rule.js
+++ b/packages/metascraper-helpers/test/find-rule.js
@@ -78,6 +78,23 @@ test('a throwing validate rejects only that candidate', async t => {
   t.is(value, 'b')
 })
 
+test('validate receives the find-rule debug logger', async t => {
+  let debug
+  await findRule([
+    withValidate(
+      () => 'value',
+      (value, args, logger) => {
+        debug = logger
+        return true
+      }
+    )
+  ])
+
+  t.is(typeof debug, 'function')
+  t.falsy(debug.enabled)
+  t.notThrows(() => debug('validate:custom', { reason: 'test' }))
+})
+
 test('rules without validate are unchanged', async t => {
   t.is(await findRule([() => 'value']), 'value')
 })

--- a/packages/metascraper-helpers/test/with-iframe.js
+++ b/packages/metascraper-helpers/test/with-iframe.js
@@ -127,8 +127,9 @@ test('no iframe and no twitter:player yields nothing', async t => {
 })
 
 test('validate on a nested rule rejects the candidate behind the iframe', async t => {
-  const validate = value => !value.endsWith('/hostile.mp4')
-  const rule = Object.assign(contentRule, { validate })
+  const rule = Object.assign(args => contentRule(args), {
+    validate: value => !value.endsWith('/hostile.mp4')
+  })
 
   const rules = withIframe(
     [rule],

--- a/packages/metascraper-helpers/test/with-iframe.js
+++ b/packages/metascraper-helpers/test/with-iframe.js
@@ -1,0 +1,151 @@
+'use strict'
+
+const cheerio = require('cheerio')
+const test = require('ava').default
+
+const { findRule, withIframe } = require('..')
+
+const url = 'https://example.com'
+
+const scrape = (html, rules) =>
+  findRule(rules, { htmlDom: cheerio.load(html), url }, 'video')
+
+const contentRule = ({ htmlDom: $ }) =>
+  $('meta[property="og:video"]').attr('content')
+
+test('page rules win before any iframe is fetched', async t => {
+  const rules = withIframe(
+    [contentRule],
+    () => t.fail('getIframe should not be called'),
+    'video'
+  )
+
+  t.is(
+    await scrape('<meta property="og:video" content="/page.mp4">', rules),
+    '/page.mp4'
+  )
+})
+
+test('probes every iframe until one yields a value', async t => {
+  const probed = []
+  const rules = withIframe(
+    [contentRule],
+    async (_url, _$, src) => {
+      probed.push(src)
+      return cheerio.load(
+        src.endsWith('/second')
+          ? '<meta property="og:video" content="/found.mp4">'
+          : ''
+      )
+    },
+    'video'
+  )
+
+  t.is(
+    await scrape(
+      '<iframe src="/first"></iframe><iframe src="/second"></iframe>',
+      rules
+    ),
+    '/found.mp4'
+  )
+  t.deepEqual(probed, [`${url}/first`, `${url}/second`])
+})
+
+test('a duplicated iframe src is probed once', async t => {
+  const probed = []
+  const rules = withIframe(
+    [contentRule],
+    async (_url, _$, src) => {
+      probed.push(src)
+      return cheerio.load('')
+    },
+    'video'
+  )
+
+  t.is(
+    await scrape(
+      `<iframe src="/dup"></iframe><iframe src="${url}/dup"></iframe>`,
+      rules
+    ),
+    undefined
+  )
+  t.deepEqual(probed, [`${url}/dup`])
+})
+
+test('a throwing getIframe skips that src', async t => {
+  const rules = withIframe(
+    [contentRule],
+    async (_url, _$, src) => {
+      if (src.endsWith('/boom')) throw new Error('boom')
+      return cheerio.load('<meta property="og:video" content="/found.mp4">')
+    },
+    'video'
+  )
+
+  t.is(
+    await scrape(
+      '<iframe src="/boom"></iframe><iframe src="/ok"></iframe>',
+      rules
+    ),
+    '/found.mp4'
+  )
+})
+
+test('falls back to twitter:player when no iframe yields a value', async t => {
+  const probed = []
+  const rules = withIframe(
+    [contentRule],
+    async (_url, _$, src) => {
+      probed.push(src)
+      return cheerio.load(
+        src.endsWith('/player')
+          ? '<meta property="og:video" content="/found.mp4">'
+          : ''
+      )
+    },
+    'video'
+  )
+
+  t.is(
+    await scrape(
+      '<iframe src="/empty"></iframe><meta name="twitter:player" content="/player">',
+      rules
+    ),
+    '/found.mp4'
+  )
+  t.deepEqual(probed, [`${url}/empty`, '/player'])
+})
+
+test('no iframe and no twitter:player yields nothing', async t => {
+  const rules = withIframe(
+    [contentRule],
+    () => t.fail('getIframe should not be called'),
+    'video'
+  )
+
+  t.is(await scrape('<p>nothing here</p>', rules), undefined)
+})
+
+test('validate on a nested rule rejects the candidate behind the iframe', async t => {
+  const validate = value => !value.endsWith('/hostile.mp4')
+  const rule = Object.assign(contentRule, { validate })
+
+  const rules = withIframe(
+    [rule],
+    async (_url, _$, src) =>
+      cheerio.load(
+        `<meta property="og:video" content="${
+          src.endsWith('/hostile') ? '/hostile.mp4' : '/safe.mp4'
+        }">`
+      ),
+    'video'
+  )
+
+  t.is(
+    await scrape(
+      '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
+      rules
+    ),
+    '/safe.mp4'
+  )
+})

--- a/packages/metascraper-video/src/index.js
+++ b/packages/metascraper-video/src/index.js
@@ -4,12 +4,10 @@ const {
   $jsonld,
   createGetIframeCached,
   defaultGetIframe,
-  findRule,
-  has,
-  normalizeUrl,
   toRule,
   url: urlFn,
-  video
+  video,
+  withIframe
 } = require('@metascraper/helpers')
 
 const toUrl = toRule(urlFn)
@@ -67,43 +65,6 @@ const videoRules = [
 ]
 
 const imageRules = [toUrl($ => $('video').attr('poster'))]
-
-const withIframe = (rules, getIframe, propName) =>
-  rules.concat(
-    async ({ htmlDom: $, url, ...args }) => {
-      const srcs = $('iframe[src^="http"], iframe[src^="/"]')
-        .map((_, element) => $(element).attr('src'))
-        .get()
-      if (srcs.length === 0) return
-      const seenSrcs = new Set()
-      for (const src of srcs) {
-        try {
-          const normalizedSrc = normalizeUrl(url, src)
-          if (!normalizedSrc) continue
-          if (seenSrcs.has(normalizedSrc)) continue
-          seenSrcs.add(normalizedSrc)
-
-          const htmlDom = await getIframe(url, $, normalizedSrc)
-          const result = await findRule(
-            rules,
-            { ...args, htmlDom, url },
-            propName
-          )
-          if (has(result)) return result
-        } catch (_) {}
-      }
-    },
-    async ({ htmlDom: $, url, ...args }) => {
-      const src = $('meta[name="twitter:player"]').attr('content')
-      return src
-        ? findRule(
-          rules,
-          { ...args, htmlDom: await getIframe(url, $, src), url },
-          propName
-        )
-        : undefined
-    }
-  )
 
 module.exports = ({ getIframe = defaultGetIframe } = {}) => {
   const getIframeCached = createGetIframeCached(getIframe)

--- a/packages/metascraper-video/src/index.js
+++ b/packages/metascraper-video/src/index.js
@@ -68,9 +68,10 @@ const videoRules = [
 
 const imageRules = [toUrl($ => $('video').attr('poster'))]
 
-const withIframe = (rules, getIframe) =>
+const withIframe = (rules, getIframe, propName) =>
   rules.concat(
-    async ({ htmlDom: $, url }) => {
+    async args => {
+      const { htmlDom: $, url } = args
       const srcs = $('iframe[src^="http"], iframe[src^="/"]')
         .map((_, element) => $(element).attr('src'))
         .get()
@@ -84,18 +85,20 @@ const withIframe = (rules, getIframe) =>
           seenSrcs.add(normalizedSrc)
 
           const htmlDom = await getIframe(url, $, normalizedSrc)
-          const result = await findRule(rules, { htmlDom, url })
+          const result = await findRule(rules, { ...args, htmlDom }, propName)
           if (has(result)) return result
         } catch (_) {}
       }
     },
-    async ({ htmlDom: $, url }) => {
+    async args => {
+      const { htmlDom: $, url } = args
       const src = $('meta[name="twitter:player"]').attr('content')
       return src
-        ? findRule(rules, {
-          htmlDom: await getIframe(url, $, src),
-          url
-        })
+        ? findRule(
+          rules,
+          { ...args, htmlDom: await getIframe(url, $, src) },
+          propName
+        )
         : undefined
     }
   )
@@ -103,8 +106,8 @@ const withIframe = (rules, getIframe) =>
 module.exports = ({ getIframe = defaultGetIframe } = {}) => {
   const getIframeCached = createGetIframeCached(getIframe)
   const rules = {
-    image: withIframe(imageRules, getIframeCached),
-    video: withIframe(videoRules, getIframeCached)
+    image: withIframe(imageRules, getIframeCached, 'image'),
+    video: withIframe(videoRules, getIframeCached, 'video')
   }
 
   rules.pkgName = 'metascraper-video'

--- a/packages/metascraper-video/src/index.js
+++ b/packages/metascraper-video/src/index.js
@@ -70,8 +70,7 @@ const imageRules = [toUrl($ => $('video').attr('poster'))]
 
 const withIframe = (rules, getIframe, propName) =>
   rules.concat(
-    async args => {
-      const { htmlDom: $, url } = args
+    async ({ htmlDom: $, url, ...args }) => {
       const srcs = $('iframe[src^="http"], iframe[src^="/"]')
         .map((_, element) => $(element).attr('src'))
         .get()
@@ -85,18 +84,21 @@ const withIframe = (rules, getIframe, propName) =>
           seenSrcs.add(normalizedSrc)
 
           const htmlDom = await getIframe(url, $, normalizedSrc)
-          const result = await findRule(rules, { ...args, htmlDom }, propName)
+          const result = await findRule(
+            rules,
+            { ...args, htmlDom, url },
+            propName
+          )
           if (has(result)) return result
         } catch (_) {}
       }
     },
-    async args => {
-      const { htmlDom: $, url } = args
+    async ({ htmlDom: $, url, ...args }) => {
       const src = $('meta[name="twitter:player"]').attr('content')
       return src
         ? findRule(
           rules,
-          { ...args, htmlDom: await getIframe(url, $, src) },
+          { ...args, htmlDom: await getIframe(url, $, src), url },
           propName
         )
         : undefined

--- a/packages/metascraper-video/test/iframe.js
+++ b/packages/metascraper-video/test/iframe.js
@@ -70,7 +70,7 @@ test('stop iframe probing after first video match', async t => {
 })
 
 test('validate reaches the rules nested behind an iframe', async t => {
-  const metascraper = createMetascraper({
+  const rules = require('../src')({
     getIframe: async (url, $, { src }) =>
       cheerio.load(
         `<meta property="og:video" content="https://cdn.microlink.io${src.replace(
@@ -79,31 +79,33 @@ test('validate reaches the rules nested behind an iframe', async t => {
         )}.mp4">`
       )
   })
+  rules.validate = value => !value.endsWith('/hostile.mp4')
+  const metascraper = require('metascraper')([rules])
 
   const metadata = await metascraper({
     url: 'https://example.com',
     html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
-    pickPropNames: new Set(['video']),
-    validate: { video: value => !value.endsWith('/hostile.mp4') }
+    pickPropNames: new Set(['video'])
   })
 
   t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')
 })
 
 test('validate reaches the rules nested behind twitter:player', async t => {
-  const metascraper = createMetascraper({
+  const rules = require('../src')({
     getIframe: async () =>
       cheerio.load(`
         <meta property="og:video" content="https://cdn.microlink.io/hostile.mp4">
         <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp4">
       `)
   })
+  rules.validate = value => !value.endsWith('/hostile.mp4')
+  const metascraper = require('metascraper')([rules])
 
   const metadata = await metascraper({
     url: 'https://example.com',
     html: '<meta name="twitter:player" content="https://example.com/player">',
-    pickPropNames: new Set(['video']),
-    validate: { video: value => !value.endsWith('/hostile.mp4') }
+    pickPropNames: new Set(['video'])
   })
 
   t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')

--- a/packages/metascraper-video/test/iframe.js
+++ b/packages/metascraper-video/test/iframe.js
@@ -92,27 +92,6 @@ test('validate reaches the rules nested behind an iframe', async t => {
   t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')
 })
 
-test('validate reaches the rules nested behind twitter:player', async t => {
-  const metascraper = createMetascraper(
-    {
-      getIframe: async () =>
-        cheerio.load(`
-        <meta property="og:video" content="https://cdn.microlink.io/hostile.mp4">
-        <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp4">
-      `)
-    },
-    { validate: value => !value.endsWith('/hostile.mp4') }
-  )
-
-  const metadata = await metascraper({
-    url: 'https://example.com',
-    html: '<meta name="twitter:player" content="https://example.com/player">',
-    pickPropNames: new Set(['video'])
-  })
-
-  t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')
-})
-
 test('reuse iframe fetch across image and video extraction', async t => {
   let calls = 0
   const metascraper = createMetascraper({

--- a/packages/metascraper-video/test/iframe.js
+++ b/packages/metascraper-video/test/iframe.js
@@ -69,6 +69,27 @@ test('stop iframe probing after first video match', async t => {
   t.deepEqual(calls, ['https://example.com/ok'])
 })
 
+test('validate reaches the rules nested behind an iframe', async t => {
+  const metascraper = createMetascraper({
+    getIframe: async (url, $, { src }) =>
+      cheerio.load(
+        `<meta property="og:video" content="https://cdn.microlink.io${src.replace(
+          'https://example.com',
+          ''
+        )}.mp4">`
+      )
+  })
+
+  const metadata = await metascraper({
+    url: 'https://example.com',
+    html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
+    pickPropNames: new Set(['video']),
+    validate: value => !value.endsWith('/hostile.mp4')
+  })
+
+  t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')
+})
+
 test('reuse iframe fetch across image and video extraction', async t => {
   let calls = 0
   const metascraper = createMetascraper({

--- a/packages/metascraper-video/test/iframe.js
+++ b/packages/metascraper-video/test/iframe.js
@@ -84,7 +84,26 @@ test('validate reaches the rules nested behind an iframe', async t => {
     url: 'https://example.com',
     html: '<iframe src="/hostile"></iframe><iframe src="/safe"></iframe>',
     pickPropNames: new Set(['video']),
-    validate: value => !value.endsWith('/hostile.mp4')
+    validate: { video: value => !value.endsWith('/hostile.mp4') }
+  })
+
+  t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')
+})
+
+test('validate reaches the rules nested behind twitter:player', async t => {
+  const metascraper = createMetascraper({
+    getIframe: async () =>
+      cheerio.load(`
+        <meta property="og:video" content="https://cdn.microlink.io/hostile.mp4">
+        <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp4">
+      `)
+  })
+
+  const metadata = await metascraper({
+    url: 'https://example.com',
+    html: '<meta name="twitter:player" content="https://example.com/player">',
+    pickPropNames: new Set(['video']),
+    validate: { video: value => !value.endsWith('/hostile.mp4') }
   })
 
   t.is(metadata.video, 'https://cdn.microlink.io/safe.mp4')

--- a/packages/metascraper-video/test/iframe.js
+++ b/packages/metascraper-video/test/iframe.js
@@ -5,8 +5,8 @@ const test = require('ava').default
 
 const { runServer } = require('./helpers')
 
-const createMetascraper = (...args) =>
-  require('metascraper')([require('../src')(...args)])
+const createMetascraper = (opts, meta) =>
+  require('metascraper')([Object.assign(require('../src')(opts), meta)])
 
 test('absolute http', async t => {
   const url = await runServer(t, ({ res }) => {
@@ -70,17 +70,18 @@ test('stop iframe probing after first video match', async t => {
 })
 
 test('validate reaches the rules nested behind an iframe', async t => {
-  const rules = require('../src')({
-    getIframe: async (url, $, { src }) =>
-      cheerio.load(
-        `<meta property="og:video" content="https://cdn.microlink.io${src.replace(
-          'https://example.com',
-          ''
-        )}.mp4">`
-      )
-  })
-  rules.validate = value => !value.endsWith('/hostile.mp4')
-  const metascraper = require('metascraper')([rules])
+  const metascraper = createMetascraper(
+    {
+      getIframe: async (url, $, { src }) =>
+        cheerio.load(
+          `<meta property="og:video" content="https://cdn.microlink.io${src.replace(
+            'https://example.com',
+            ''
+          )}.mp4">`
+        )
+    },
+    { validate: value => !value.endsWith('/hostile.mp4') }
+  )
 
   const metadata = await metascraper({
     url: 'https://example.com',
@@ -92,15 +93,16 @@ test('validate reaches the rules nested behind an iframe', async t => {
 })
 
 test('validate reaches the rules nested behind twitter:player', async t => {
-  const rules = require('../src')({
-    getIframe: async () =>
-      cheerio.load(`
+  const metascraper = createMetascraper(
+    {
+      getIframe: async () =>
+        cheerio.load(`
         <meta property="og:video" content="https://cdn.microlink.io/hostile.mp4">
         <meta name="twitter:player:stream" content="https://cdn.microlink.io/safe.mp4">
       `)
-  })
-  rules.validate = value => !value.endsWith('/hostile.mp4')
-  const metascraper = require('metascraper')([rules])
+    },
+    { validate: value => !value.endsWith('/hostile.mp4') }
+  )
 
   const metadata = await metascraper({
     url: 'https://example.com',

--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -59,7 +59,7 @@ declare namespace createMetascraper {
   export interface ValidateContext {
     propName: string;
     rule: RulesOptions;
-    args: RulesTestOptions;
+    args: MetascraperOptions & RulesTestOptions;
   }
 
   export type Validate = (

--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -111,6 +111,11 @@ declare namespace createMetascraper {
   };
 
   /**
+   * Pre-run gate for a rule. A falsy result skips the rule entirely.
+   */
+  export type Test = (options: RulesTestOptions) => boolean;
+
+  /**
    * Post-accept check for a rule candidate. Falsy or throw rejects the
    * candidate and findRule continues with the next rule.
    */
@@ -136,7 +141,7 @@ declare namespace createMetascraper {
     /**
      * The test function to be executed for skipping rules that doesn't return `true`.
      */
-    test?: (options: RulesTestOptions) => boolean;
+    test?: Test;
     /**
      * Copied onto each rule in the bundle. Runs after a rule produces a value;
      * falsy or throw rejects that candidate and continues.
@@ -154,7 +159,7 @@ declare namespace createMetascraper {
     [key: string]:
       | Array<RulesOptions>
       | RulesOptions
-      | ((options: RulesTestOptions) => boolean)
+      | Test
       | Validate
       | string
       | undefined;
@@ -166,7 +171,7 @@ declare namespace createMetascraper {
       | null
       | undefined
       | Promise<string | null | undefined>;
-    test?: (options: RulesTestOptions) => boolean;
+    test?: Test;
     validate?: Validate;
     pkgName?: string;
   }

--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -45,7 +45,27 @@ declare namespace createMetascraper {
      * Takes precedence over omitPropNames when both are specified.
      */
     pickPropNames?: Set<string>;
+    /**
+     * A validation hook executed for every value produced by a rule.
+     * Returning a falsy value (or throwing) discards the candidate and
+     * moves on to the next rule for that property.
+     *
+     * Pass a function to validate every property, or an object keyed by
+     * property name to validate only the properties you list.
+     */
+    validate?: Validate | { [propName: string]: Validate };
   }
+
+  export interface ValidateContext {
+    propName: string;
+    rule: RulesOptions;
+    args: RulesTestOptions;
+  }
+
+  export type Validate = (
+    value: string,
+    context: ValidateContext
+  ) => boolean | Promise<boolean>;
 
   export interface Metadata {
     /**

--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -45,27 +45,7 @@ declare namespace createMetascraper {
      * Takes precedence over omitPropNames when both are specified.
      */
     pickPropNames?: Set<string>;
-    /**
-     * A validation hook executed for every value produced by a rule.
-     * Returning a falsy value (or throwing) discards the candidate and
-     * moves on to the next rule for that property.
-     *
-     * Pass a function to validate every property, or an object keyed by
-     * property name to validate only the properties you list.
-     */
-    validate?: Validate | { [propName: string]: Validate };
   }
-
-  export interface ValidateContext {
-    propName: string;
-    rule: RulesOptions;
-    args: MetascraperOptions & RulesTestOptions;
-  }
-
-  export type Validate = (
-    value: string,
-    context: ValidateContext
-  ) => boolean | Promise<boolean>;
 
   export interface Metadata {
     /**
@@ -109,7 +89,7 @@ declare namespace createMetascraper {
      */
     publisher?: string;
     /**
-     * Get title property from HTML markup
+     * Get title property from HTML markup.
      * The package [metascraper-title](https://example.com/metascraper-title) needs to be loaded.
      */
     title?: string;
@@ -130,11 +110,25 @@ declare namespace createMetascraper {
     [C in keyof Metadata as string extends C ? never : C]?: Array<RulesOptions> | RulesOptions;
   };
 
+  /**
+   * Post-accept check for a rule candidate. Falsy or throw rejects the
+   * candidate and findRule continues with the next rule.
+   */
+  export type Validate = (
+    value: string,
+    options: RulesTestOptions
+  ) => boolean | Promise<boolean>;
+
   export interface Rules extends NamedRules {
     /**
      * The test function to be executed for skipping rules that doesn't return `true`.
      */
     test?: (options: RulesTestOptions) => boolean;
+    /**
+     * Copied onto each rule in the bundle. Runs after a rule produces a value;
+     * falsy or throw rejects that candidate and continues.
+     */
+    validate?: Validate;
     /**
      * The package name associated with the rule, used for debugging purposes.
      */
@@ -142,19 +136,27 @@ declare namespace createMetascraper {
     /**
      * allow any other string key to be
      * a rule-function (for ad-hoc metadata),
-     * or the two special keys above.
+     * or the special keys above.
      **/
     [key: string]:
       | Array<RulesOptions>
       | RulesOptions
       | ((options: RulesTestOptions) => boolean)
+      | Validate
       | string
       | undefined;
   }
 
-  export type RulesOptions = (
-    options: RulesTestOptions
-  ) => string | null | undefined;
+  export interface RulesOptions {
+    (options: RulesTestOptions):
+      | string
+      | null
+      | undefined
+      | Promise<string | null | undefined>;
+    test?: (options: RulesTestOptions) => boolean;
+    validate?: Validate;
+    pkgName?: string;
+  }
 
   export interface RulesTestOptions {
     htmlDom: import("cheerio").CheerioAPI;

--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -116,8 +116,21 @@ declare namespace createMetascraper {
    */
   export type Validate = (
     value: string,
-    options: RulesTestOptions
+    options: RulesTestOptions,
+    debug: Debug
   ) => boolean | Promise<boolean>;
+
+  /**
+   * The `metascraper:find-rule` logger, so a validate can explain a rejection.
+   * Only writes when `DEBUG=metascraper:find-rule` is enabled.
+   */
+  export interface Debug {
+    (...args: Array<string | object>): void;
+    readonly enabled: boolean | undefined;
+    info(...args: Array<string | object>): void;
+    warn(...args: Array<string | object>): void;
+    error(...args: Array<string | object>): void;
+  }
 
   export interface Rules extends NamedRules {
     /**

--- a/packages/metascraper/src/rules.js
+++ b/packages/metascraper/src/rules.js
@@ -62,12 +62,12 @@ const mergeRules = (
     return Object.entries(result)
   }
 
-  for (const { test, validate, ...ruleSet } of rules) {
+  for (const { test, validate, pkgName, ...ruleSet } of rules) {
     for (const [propName, innerRules] of Object.entries(ruleSet)) {
       if (!shouldIncludeProp(propName)) continue
 
       const processedRules = castArray(innerRules)
-      attachRuleMeta(processedRules, { test, validate })
+      attachRuleMeta(processedRules, { test, validate, pkgName })
 
       if (result[propName]) {
         result[propName] = processedRules.concat(result[propName])

--- a/packages/metascraper/src/rules.js
+++ b/packages/metascraper/src/rules.js
@@ -14,10 +14,9 @@ const loadRules = rulesBundle => {
   const acc = {}
 
   for (const { test, validate, pkgName, ...rules } of rulesBundle) {
-    const hasMeta = Boolean(test || validate || pkgName)
     for (const [propName, innerRules] of Object.entries(rules)) {
       const processedRules = castArray(innerRules)
-      if (hasMeta) attachRuleMeta(processedRules, test, validate, pkgName)
+      attachRuleMeta(processedRules, test, validate, pkgName)
 
       if (acc[propName]) {
         acc[propName].push(...processedRules)
@@ -63,12 +62,11 @@ const mergeRules = (
   }
 
   for (const { test, validate, pkgName, ...ruleSet } of rules) {
-    const hasMeta = Boolean(test || validate || pkgName)
     for (const [propName, innerRules] of Object.entries(ruleSet)) {
       if (!shouldIncludeProp(propName)) continue
 
       const processedRules = castArray(innerRules)
-      if (hasMeta) attachRuleMeta(processedRules, test, validate, pkgName)
+      attachRuleMeta(processedRules, test, validate, pkgName)
 
       if (result[propName]) {
         result[propName] = processedRules.concat(result[propName])

--- a/packages/metascraper/src/rules.js
+++ b/packages/metascraper/src/rules.js
@@ -2,18 +2,22 @@
 
 const castArray = value => (Array.isArray(value) ? value : [value])
 
+const attachRuleMeta = (rules, { test, validate, pkgName }) => {
+  if (!test && !validate && !pkgName) return
+  for (const rule of rules) {
+    if (test) rule.test = test
+    if (validate) rule.validate = validate
+    if (pkgName) rule.pkgName = pkgName ?? 'unknown'
+  }
+}
+
 const loadRules = rulesBundle => {
   const acc = {}
 
-  for (const { test, pkgName, ...rules } of rulesBundle) {
+  for (const { test, validate, pkgName, ...rules } of rulesBundle) {
     for (const [propName, innerRules] of Object.entries(rules)) {
       const processedRules = castArray(innerRules)
-      if (test || pkgName) {
-        for (const rule of processedRules) {
-          if (test) rule.test = test
-          if (pkgName) rule.pkgName = pkgName ?? 'unknown'
-        }
-      }
+      attachRuleMeta(processedRules, { test, validate, pkgName })
 
       if (acc[propName]) {
         acc[propName].push(...processedRules)
@@ -58,16 +62,12 @@ const mergeRules = (
     return Object.entries(result)
   }
 
-  for (const { test, ...ruleSet } of rules) {
+  for (const { test, validate, ...ruleSet } of rules) {
     for (const [propName, innerRules] of Object.entries(ruleSet)) {
       if (!shouldIncludeProp(propName)) continue
 
       const processedRules = castArray(innerRules)
-      if (test) {
-        for (const rule of processedRules) {
-          rule.test = test
-        }
-      }
+      attachRuleMeta(processedRules, { test, validate })
 
       if (result[propName]) {
         result[propName] = processedRules.concat(result[propName])

--- a/packages/metascraper/src/rules.js
+++ b/packages/metascraper/src/rules.js
@@ -2,12 +2,11 @@
 
 const castArray = value => (Array.isArray(value) ? value : [value])
 
-const attachRuleMeta = (rules, { test, validate, pkgName }) => {
-  if (!test && !validate && !pkgName) return
+const attachRuleMeta = (rules, test, validate, pkgName) => {
   for (const rule of rules) {
     if (test) rule.test = test
     if (validate) rule.validate = validate
-    if (pkgName) rule.pkgName = pkgName ?? 'unknown'
+    if (pkgName) rule.pkgName = pkgName
   }
 }
 
@@ -15,9 +14,10 @@ const loadRules = rulesBundle => {
   const acc = {}
 
   for (const { test, validate, pkgName, ...rules } of rulesBundle) {
+    const hasMeta = Boolean(test || validate || pkgName)
     for (const [propName, innerRules] of Object.entries(rules)) {
       const processedRules = castArray(innerRules)
-      attachRuleMeta(processedRules, { test, validate, pkgName })
+      if (hasMeta) attachRuleMeta(processedRules, test, validate, pkgName)
 
       if (acc[propName]) {
         acc[propName].push(...processedRules)
@@ -63,11 +63,12 @@ const mergeRules = (
   }
 
   for (const { test, validate, pkgName, ...ruleSet } of rules) {
+    const hasMeta = Boolean(test || validate || pkgName)
     for (const [propName, innerRules] of Object.entries(ruleSet)) {
       if (!shouldIncludeProp(propName)) continue
 
       const processedRules = castArray(innerRules)
-      attachRuleMeta(processedRules, { test, validate, pkgName })
+      if (hasMeta) attachRuleMeta(processedRules, test, validate, pkgName)
 
       if (result[propName]) {
         result[propName] = processedRules.concat(result[propName])

--- a/packages/metascraper/test/types/index.test-d.ts
+++ b/packages/metascraper/test/types/index.test-d.ts
@@ -43,3 +43,14 @@ createMetascraper([
     ]
   }
 ])
+
+createMetascraper([
+  {
+    logo: [() => 'https://example.com/a.png'],
+    validate: (value, { url }, debug) => {
+      if (value !== url) return true
+      if (debug.enabled) debug('logo:rejected', { url, reason: 'same-as-url' })
+      return false
+    }
+  }
+])

--- a/packages/metascraper/test/types/index.test-d.ts
+++ b/packages/metascraper/test/types/index.test-d.ts
@@ -23,3 +23,27 @@ const payload = await metascraper({
 })
 
 console.log(payload.author)
+
+/* validate */
+
+await metascraper({
+  url: 'https://example.com',
+  html: '',
+  validate: value => value.startsWith('https://')
+})
+
+await metascraper({
+  url: 'https://example.com',
+  html: '',
+  validate: async (value, { propName, rule, args }) =>
+    propName !== 'url' || value !== args.url
+})
+
+await metascraper({
+  url: 'https://example.com',
+  html: '',
+  validate: {
+    author: value => value.length > 1,
+    url: async value => value.startsWith('https://')
+  }
+})

--- a/packages/metascraper/test/types/index.test-d.ts
+++ b/packages/metascraper/test/types/index.test-d.ts
@@ -24,26 +24,22 @@ const payload = await metascraper({
 
 console.log(payload.author)
 
-/* validate */
+/* validate on rules bundle */
 
-await metascraper({
-  url: 'https://example.com',
-  html: '',
-  validate: value => value.startsWith('https://')
-})
-
-await metascraper({
-  url: 'https://example.com',
-  html: '',
-  validate: async (value, { propName, rule, args }) =>
-    propName !== 'url' || value !== args.url
-})
-
-await metascraper({
-  url: 'https://example.com',
-  html: '',
-  validate: {
-    author: value => value.length > 1,
-    url: async value => value.startsWith('https://')
+createMetascraper([
+  {
+    logo: [() => 'https://example.com/a.png'],
+    validate: value => value.startsWith('https://')
   }
-})
+])
+
+createMetascraper([
+  {
+    logo: [
+      Object.assign(() => 'https://example.com/a.png', {
+        validate: async (value: string, { url }: { url: string }) =>
+          value !== url
+      })
+    ]
+  }
+])

--- a/packages/metascraper/test/unit/merge-rules.js
+++ b/packages/metascraper/test/unit/merge-rules.js
@@ -125,79 +125,41 @@ test('accept non-array inline rule values', t => {
   ])
 })
 
-test('propagate inline test function only to inline rules', t => {
-  const baseRule = { id: 'base-title-1' }
-  const inlineOne = { id: 'inline-title-1' }
-  const inlineTwo = { id: 'inline-title-2' }
-  const inlineDescription = { id: 'inline-description-1' }
-  const testFn = () => true
+for (const [metaName, metaValue] of [
+  ['test', () => true],
+  ['validate', () => true],
+  ['pkgName', 'inline-bundle']
+]) {
+  test(`propagate inline ${metaName} only to inline rules`, t => {
+    const baseRule = { id: 'base-title-1' }
+    const inlineOne = { id: 'inline-title-1' }
+    const inlineTwo = { id: 'inline-title-2' }
+    const inlineDescription = { id: 'inline-description-1' }
 
-  const baseRules = [
-    ['title', [baseRule]],
-    ['description', []]
-  ]
+    const baseRules = [
+      ['title', [baseRule]],
+      ['description', []]
+    ]
 
-  const inlineRules = [
-    {
-      test: testFn,
-      title: [inlineOne, inlineTwo],
-      description: inlineDescription
-    }
-  ]
+    const inlineRules = [
+      {
+        [metaName]: metaValue,
+        title: [inlineOne, inlineTwo],
+        description: inlineDescription
+      }
+    ]
 
-  const merged = mergeRules(inlineRules, baseRules)
-  const titleRules = findRules(merged, 'title')
-  const descriptionRules = findRules(merged, 'description')
+    const merged = mergeRules(inlineRules, baseRules)
+    const titleRules = findRules(merged, 'title')
+    const descriptionRules = findRules(merged, 'description')
 
-  t.is(titleRules[0].test, testFn)
-  t.is(titleRules[1].test, testFn)
-  t.is(descriptionRules[0].test, testFn)
-  t.is(baseRule.test, undefined)
-})
-
-test('propagate inline validate function only to inline rules', t => {
-  const baseRule = { id: 'base-title-1' }
-  const inlineOne = { id: 'inline-title-1' }
-  const inlineTwo = { id: 'inline-title-2' }
-  const validateFn = () => true
-
-  const baseRules = [['title', [baseRule]]]
-  const inlineRules = [
-    {
-      validate: validateFn,
-      title: [inlineOne, inlineTwo]
-    }
-  ]
-
-  const merged = mergeRules(inlineRules, baseRules)
-  const titleRules = findRules(merged, 'title')
-
-  t.is(titleRules[0].validate, validateFn)
-  t.is(titleRules[1].validate, validateFn)
-  t.is(baseRule.validate, undefined)
-})
-
-test('propagate inline pkgName only to inline rules', t => {
-  const baseRule = { id: 'base-title-1' }
-  const inlineOne = { id: 'inline-title-1' }
-  const inlineTwo = { id: 'inline-title-2' }
-
-  const baseRules = [['title', [baseRule]]]
-  const inlineRules = [
-    {
-      pkgName: 'inline-bundle',
-      title: [inlineOne, inlineTwo]
-    }
-  ]
-
-  const merged = mergeRules(inlineRules, baseRules)
-  const titleRules = findRules(merged, 'title')
-
-  t.is(titleRules[0].pkgName, 'inline-bundle')
-  t.is(titleRules[1].pkgName, 'inline-bundle')
-  t.is(baseRule.pkgName, undefined)
-  t.false(merged.some(([propName]) => propName === 'pkgName'))
-})
+    t.is(titleRules[0][metaName], metaValue)
+    t.is(titleRules[1][metaName], metaValue)
+    t.is(descriptionRules[0][metaName], metaValue)
+    t.is(baseRule[metaName], undefined)
+    t.false(merged.some(([propName]) => propName === metaName))
+  })
+}
 
 test('does not mutate original rule objects', t => {
   const originalRule1 = { fn: () => 'value1', originalProp: 'unchanged' }

--- a/packages/metascraper/test/unit/merge-rules.js
+++ b/packages/metascraper/test/unit/merge-rules.js
@@ -155,6 +155,28 @@ test('propagate inline test function only to inline rules', t => {
   t.is(baseRule.test, undefined)
 })
 
+test('propagate inline validate function only to inline rules', t => {
+  const baseRule = { id: 'base-title-1' }
+  const inlineOne = { id: 'inline-title-1' }
+  const inlineTwo = { id: 'inline-title-2' }
+  const validateFn = () => true
+
+  const baseRules = [['title', [baseRule]]]
+  const inlineRules = [
+    {
+      validate: validateFn,
+      title: [inlineOne, inlineTwo]
+    }
+  ]
+
+  const merged = mergeRules(inlineRules, baseRules)
+  const titleRules = findRules(merged, 'title')
+
+  t.is(titleRules[0].validate, validateFn)
+  t.is(titleRules[1].validate, validateFn)
+  t.is(baseRule.validate, undefined)
+})
+
 test('does not mutate original rule objects', t => {
   const originalRule1 = { fn: () => 'value1', originalProp: 'unchanged' }
   const originalRule2 = { fn: () => 'value2', originalProp: 'unchanged' }

--- a/packages/metascraper/test/unit/merge-rules.js
+++ b/packages/metascraper/test/unit/merge-rules.js
@@ -177,6 +177,28 @@ test('propagate inline validate function only to inline rules', t => {
   t.is(baseRule.validate, undefined)
 })
 
+test('propagate inline pkgName only to inline rules', t => {
+  const baseRule = { id: 'base-title-1' }
+  const inlineOne = { id: 'inline-title-1' }
+  const inlineTwo = { id: 'inline-title-2' }
+
+  const baseRules = [['title', [baseRule]]]
+  const inlineRules = [
+    {
+      pkgName: 'inline-bundle',
+      title: [inlineOne, inlineTwo]
+    }
+  ]
+
+  const merged = mergeRules(inlineRules, baseRules)
+  const titleRules = findRules(merged, 'title')
+
+  t.is(titleRules[0].pkgName, 'inline-bundle')
+  t.is(titleRules[1].pkgName, 'inline-bundle')
+  t.is(baseRule.pkgName, undefined)
+  t.false(merged.some(([propName]) => propName === 'pkgName'))
+})
+
 test('does not mutate original rule objects', t => {
   const originalRule1 = { fn: () => 'value1', originalProp: 'unchanged' }
   const originalRule2 = { fn: () => 'value2', originalProp: 'unchanged' }

--- a/packages/metascraper/test/unit/validate.js
+++ b/packages/metascraper/test/unit/validate.js
@@ -4,10 +4,11 @@ const test = require('ava').default
 
 const metascraper = require('../..')
 
+const url = 'https://example.com'
+const html = '<html></html>'
+
 test('validate false skips to the next rule', async t => {
   let third = 0
-  const html = '<html></html>'
-  const url = 'https://example.com'
   const scraper = metascraper([
     {
       logo: [
@@ -31,7 +32,7 @@ test('validate false skips to the next rule', async t => {
   t.is(third, 0)
 })
 
-test('validate throw nulls the property', async t => {
+test('validate is sync friendly', async t => {
   const scraper = metascraper([
     {
       logo: [
@@ -42,32 +43,131 @@ test('validate throw nulls the property', async t => {
   ])
 
   const data = await scraper({
-    url: 'https://example.com',
-    html: '<html></html>',
-    validate: async () => {
-      throw new Error('validator boom')
+    url,
+    html,
+    validate: value => value.endsWith('b.png')
+  })
+
+  t.is(data.logo, 'https://example.com/b.png')
+})
+
+test('validate throw rejects the candidate, not the property', async t => {
+  const scraper = metascraper([
+    {
+      logo: [
+        () => 'https://example.com/a.png',
+        () => 'https://example.com/b.png'
+      ]
+    }
+  ])
+
+  const data = await scraper({
+    url,
+    html,
+    validate: async value => {
+      if (value.endsWith('a.png')) throw new Error('validator boom')
+      return true
     }
   })
+
+  t.is(data.logo, 'https://example.com/b.png')
+})
+
+test('validate rejecting every rule nulls the property', async t => {
+  const scraper = metascraper([
+    {
+      logo: [
+        () => 'https://example.com/a.png',
+        () => 'https://example.com/b.png'
+      ]
+    }
+  ])
+
+  const data = await scraper({ url, html, validate: () => false })
 
   t.is(data.logo, null)
 })
 
-test('no validate is byte-identical to accepting every value', async t => {
+test('a function validate runs for every property', async t => {
+  const propNames = []
   const scraper = metascraper([
-    {
-      title: [() => 'hello']
-    }
+    { logo: [() => 'https://example.com/a.png'], title: [() => 'hello'] }
   ])
 
+  const data = await scraper({
+    url,
+    html,
+    validate: (value, { propName }) => {
+      propNames.push(propName)
+      return true
+    }
+  })
+
+  t.deepEqual(propNames.sort(), ['logo', 'title'])
+  t.deepEqual(data, { logo: 'https://example.com/a.png', title: 'hello' })
+})
+
+test('an object validate runs only for the listed properties', async t => {
+  const propNames = []
+  const scraper = metascraper([
+    { logo: [() => 'https://example.com/a.png'], title: [() => 'hello'] }
+  ])
+
+  const data = await scraper({
+    url,
+    html,
+    validate: {
+      logo: (value, { propName }) => {
+        propNames.push(propName)
+        return false
+      }
+    }
+  })
+
+  t.deepEqual(propNames, ['logo'])
+  t.deepEqual(data, { logo: null, title: 'hello' })
+})
+
+test('validate receives the rule and the scraping args', async t => {
+  const logoRule = () => 'https://example.com/a.png'
+  let context
+  const scraper = metascraper([
+    { pkgName: 'metascraper-test', logo: [logoRule] }
+  ])
+
+  await scraper({
+    url,
+    html,
+    validate: (value, ctx) => {
+      context = { value, ...ctx }
+      return true
+    }
+  })
+
+  t.is(context.value, 'https://example.com/a.png')
+  t.is(context.propName, 'logo')
+  t.is(context.rule, logoRule)
+  t.is(context.args.url, url)
+})
+
+test('no validate is byte-identical to accepting every value', async t => {
+  const scraper = metascraper([{ title: [() => 'hello'] }])
+
+  const withValidate = await scraper({ url, html, validate: async () => true })
+  const without = await scraper({ url, html })
+
+  t.deepEqual(withValidate, without)
+})
+
+test('no validate is byte-identical to an object validate for other properties', async t => {
+  const scraper = metascraper([{ title: [() => 'hello'] }])
+
   const withValidate = await scraper({
-    url: 'https://example.com',
-    html: '<html></html>',
-    validate: async () => true
+    url,
+    html,
+    validate: { logo: () => false }
   })
-  const without = await scraper({
-    url: 'https://example.com',
-    html: '<html></html>'
-  })
+  const without = await scraper({ url, html })
 
   t.deepEqual(withValidate, without)
 })

--- a/packages/metascraper/test/unit/validate.js
+++ b/packages/metascraper/test/unit/validate.js
@@ -133,8 +133,8 @@ test('validate receives the scraping args', async t => {
       pkgName: 'metascraper-test',
       logo: [
         Object.assign(() => 'https://example.com/a.png', {
-          validate: (value, args) => {
-            received = { value, args }
+          validate: (value, args, debug) => {
+            received = { value, args, debug }
             return true
           }
         })
@@ -146,6 +146,7 @@ test('validate receives the scraping args', async t => {
 
   t.is(received.value, 'https://example.com/a.png')
   t.is(received.args.url, url)
+  t.is(typeof received.debug, 'function')
 })
 
 test('no validate is byte-identical to accepting every value', async t => {

--- a/packages/metascraper/test/unit/validate.js
+++ b/packages/metascraper/test/unit/validate.js
@@ -12,29 +12,35 @@ test('validate false skips to the next rule', async t => {
   const scraper = metascraper([
     {
       logo: [
-        () => 'https://example.com/bad.svg',
-        () => 'https://example.com/good.png',
-        () => {
-          third += 1
-          return 'https://example.com/never.png'
-        }
+        Object.assign(() => 'https://example.com/bad.svg', {
+          validate: async value => value !== 'https://example.com/bad.svg'
+        }),
+        Object.assign(() => 'https://example.com/good.png', {
+          validate: async value => value !== 'https://example.com/bad.svg'
+        }),
+        Object.assign(
+          () => {
+            third += 1
+            return 'https://example.com/never.png'
+          },
+          {
+            validate: async value => value !== 'https://example.com/bad.svg'
+          }
+        )
       ]
     }
   ])
 
-  const data = await scraper({
-    url,
-    html,
-    validate: async value => value !== 'https://example.com/bad.svg'
-  })
+  const data = await scraper({ url, html })
 
   t.is(data.logo, 'https://example.com/good.png')
   t.is(third, 0)
 })
 
-test('validate is sync friendly', async t => {
+test('bundle validate is copied onto every rule', async t => {
   const scraper = metascraper([
     {
+      validate: value => value.endsWith('b.png'),
       logo: [
         () => 'https://example.com/a.png',
         () => 'https://example.com/b.png'
@@ -42,11 +48,26 @@ test('validate is sync friendly', async t => {
     }
   ])
 
-  const data = await scraper({
-    url,
-    html,
-    validate: value => value.endsWith('b.png')
-  })
+  const data = await scraper({ url, html })
+
+  t.is(data.logo, 'https://example.com/b.png')
+})
+
+test('validate is sync friendly', async t => {
+  const scraper = metascraper([
+    {
+      logo: [
+        Object.assign(() => 'https://example.com/a.png', {
+          validate: value => value.endsWith('b.png')
+        }),
+        Object.assign(() => 'https://example.com/b.png', {
+          validate: value => value.endsWith('b.png')
+        })
+      ]
+    }
+  ])
+
+  const data = await scraper({ url, html })
 
   t.is(data.logo, 'https://example.com/b.png')
 })
@@ -55,20 +76,20 @@ test('validate throw rejects the candidate, not the property', async t => {
   const scraper = metascraper([
     {
       logo: [
-        () => 'https://example.com/a.png',
-        () => 'https://example.com/b.png'
+        Object.assign(() => 'https://example.com/a.png', {
+          validate: async value => {
+            if (value.endsWith('a.png')) throw new Error('validator boom')
+            return true
+          }
+        }),
+        Object.assign(() => 'https://example.com/b.png', {
+          validate: async () => true
+        })
       ]
     }
   ])
 
-  const data = await scraper({
-    url,
-    html,
-    validate: async value => {
-      if (value.endsWith('a.png')) throw new Error('validator boom')
-      return true
-    }
-  })
+  const data = await scraper({ url, html })
 
   t.is(data.logo, 'https://example.com/b.png')
 })
@@ -76,6 +97,7 @@ test('validate throw rejects the candidate, not the property', async t => {
 test('validate rejecting every rule nulls the property', async t => {
   const scraper = metascraper([
     {
+      validate: () => false,
       logo: [
         () => 'https://example.com/a.png',
         () => 'https://example.com/b.png'
@@ -83,91 +105,54 @@ test('validate rejecting every rule nulls the property', async t => {
     }
   ])
 
-  const data = await scraper({ url, html, validate: () => false })
+  const data = await scraper({ url, html })
 
   t.is(data.logo, null)
 })
 
-test('a function validate runs for every property', async t => {
-  const propNames = []
+test('bundle validate only applies to rules from that bundle', async t => {
   const scraper = metascraper([
-    { logo: [() => 'https://example.com/a.png'], title: [() => 'hello'] }
+    {
+      validate: () => false,
+      logo: [() => 'https://example.com/a.png']
+    },
+    {
+      title: [() => 'hello']
+    }
   ])
 
-  const data = await scraper({
-    url,
-    html,
-    validate: (value, { propName }) => {
-      propNames.push(propName)
-      return true
-    }
-  })
+  const data = await scraper({ url, html })
 
-  t.deepEqual(propNames.sort(), ['logo', 'title'])
-  t.deepEqual(data, { logo: 'https://example.com/a.png', title: 'hello' })
-})
-
-test('an object validate runs only for the listed properties', async t => {
-  const propNames = []
-  const scraper = metascraper([
-    { logo: [() => 'https://example.com/a.png'], title: [() => 'hello'] }
-  ])
-
-  const data = await scraper({
-    url,
-    html,
-    validate: {
-      logo: (value, { propName }) => {
-        propNames.push(propName)
-        return false
-      }
-    }
-  })
-
-  t.deepEqual(propNames, ['logo'])
   t.deepEqual(data, { logo: null, title: 'hello' })
 })
 
-test('validate receives the rule and the scraping args', async t => {
-  const logoRule = () => 'https://example.com/a.png'
-  let context
+test('validate receives the scraping args', async t => {
+  let received
   const scraper = metascraper([
-    { pkgName: 'metascraper-test', logo: [logoRule] }
+    {
+      pkgName: 'metascraper-test',
+      logo: [
+        Object.assign(() => 'https://example.com/a.png', {
+          validate: (value, args) => {
+            received = { value, args }
+            return true
+          }
+        })
+      ]
+    }
   ])
 
-  await scraper({
-    url,
-    html,
-    validate: (value, ctx) => {
-      context = { value, ...ctx }
-      return true
-    }
-  })
+  await scraper({ url, html })
 
-  t.is(context.value, 'https://example.com/a.png')
-  t.is(context.propName, 'logo')
-  t.is(context.rule, logoRule)
-  t.is(context.args.url, url)
+  t.is(received.value, 'https://example.com/a.png')
+  t.is(received.args.url, url)
 })
 
 test('no validate is byte-identical to accepting every value', async t => {
   const scraper = metascraper([{ title: [() => 'hello'] }])
+  const withValidate = metascraper([
+    { validate: async () => true, title: [() => 'hello'] }
+  ])
 
-  const withValidate = await scraper({ url, html, validate: async () => true })
-  const without = await scraper({ url, html })
-
-  t.deepEqual(withValidate, without)
-})
-
-test('no validate is byte-identical to an object validate for other properties', async t => {
-  const scraper = metascraper([{ title: [() => 'hello'] }])
-
-  const withValidate = await scraper({
-    url,
-    html,
-    validate: { logo: () => false }
-  })
-  const without = await scraper({ url, html })
-
-  t.deepEqual(withValidate, without)
+  t.deepEqual(await withValidate({ url, html }), await scraper({ url, html }))
 })

--- a/packages/metascraper/test/unit/validate.js
+++ b/packages/metascraper/test/unit/validate.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const test = require('ava').default
+
+const metascraper = require('../..')
+
+test('validate false skips to the next rule', async t => {
+  let third = 0
+  const html = '<html></html>'
+  const url = 'https://example.com'
+  const scraper = metascraper([
+    {
+      logo: [
+        () => 'https://example.com/bad.svg',
+        () => 'https://example.com/good.png',
+        () => {
+          third += 1
+          return 'https://example.com/never.png'
+        }
+      ]
+    }
+  ])
+
+  const data = await scraper({
+    url,
+    html,
+    validate: async value => value !== 'https://example.com/bad.svg'
+  })
+
+  t.is(data.logo, 'https://example.com/good.png')
+  t.is(third, 0)
+})
+
+test('validate throw nulls the property', async t => {
+  const scraper = metascraper([
+    {
+      logo: [
+        () => 'https://example.com/a.png',
+        () => 'https://example.com/b.png'
+      ]
+    }
+  ])
+
+  const data = await scraper({
+    url: 'https://example.com',
+    html: '<html></html>',
+    validate: async () => {
+      throw new Error('validator boom')
+    }
+  })
+
+  t.is(data.logo, null)
+})
+
+test('no validate is byte-identical to accepting every value', async t => {
+  const scraper = metascraper([
+    {
+      title: [() => 'hello']
+    }
+  ])
+
+  const withValidate = await scraper({
+    url: 'https://example.com',
+    html: '<html></html>',
+    validate: async () => true
+  })
+  const without = await scraper({
+    url: 'https://example.com',
+    html: '<html></html>'
+  })
+
+  t.deepEqual(withValidate, without)
+})


### PR DESCRIPTION
## Summary
- Add optional `validate` on a rule or rules bundle (same shape as `test`): after a rule returns a value, `validate(value, args)` may return falsy or throw to reject that candidate and continue to the next rule.
- `loadRules` / `mergeRules` copy bundle `validate` onto each rule; `findRule` reads `rule.validate`.
- Extract shared `withIframe` into `@metascraper/helpers` so audio/video nested iframe probing (and validate) share one path.
- Docs in CONTRIBUTING; TypeScript types updated. No scrape-time `metascraper({ validate })` option.

```js
rules.validate = async (value, args) => !(await isHostile(value))
// or
Object.assign(ruleFn, { validate: async value => … })
```

Unblocks Microlink API logo XSS fallthrough (hostile candidate → next rule) by setting `validate` on logo rule bundles.

## Test plan
- [x] `ava` on helpers `find-rule`, metascraper `validate` / `merge-rules`, audio/video `iframe`
- [ ] CI green on `next`
- [ ] After merge/release, bump api `@metascraper/helpers` and set `rules.validate` on logo / logo-favicon / logo-bimi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `findRule` resolution used on every scrape property, but behavior is backward-compatible when `validate` is omitted and is covered by new unit/integration tests.
> 
> **Overview**
> Introduces optional **`validate`** on individual rules or whole rule bundles (mirroring **`test`**): after a rule returns a value, `validate(value, args, debug)` can reject it so **`findRule`** tries the next rule; if all fail, the property is **`null`**. Bundle-level **`validate`** is copied onto each rule via **`loadRules`** / **`mergeRules`**, with TypeScript types and CONTRIBUTING docs.
> 
> Moves duplicated iframe / **`twitter:player`** probing from **metascraper-audio** and **metascraper-video** into shared **`withIframe`** in **`@metascraper/helpers`**, including **`propName`** for debug timing and coverage that **`validate`** applies to values found inside iframes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27f1adc4738c7c05d63e798d2acc3f7dd26a8b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->