### PR TITLE
feat(helpers): pass propName to validate

### DIFF
--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -564,10 +564,6 @@ const findRule = async (rules, args = {}, propName) => {
   let index = 0
   let value
   let hasValue = false
-
-  // A validate needs to know which property it is judging: a `logo` candidate
-  // and the `url` property want opposite answers for the same bytes. Built once
-  // per property rather than per candidate, and only when there is a validate.
   const validateArgs = args.validate ? { ...args, propName } : args
 
   do {

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -565,6 +565,11 @@ const findRule = async (rules, args = {}, propName) => {
   let value
   let hasValue = false
 
+  // A validate needs to know which property it is judging: a `logo` candidate
+  // and the `url` property want opposite answers for the same bytes. Built once
+  // per property rather than per candidate, and only when there is a validate.
+  const validateArgs = args.validate ? { ...args, propName } : args
+
   do {
     const rule = rules[index++]
     const test = rule.test || truthyTest
@@ -573,7 +578,7 @@ const findRule = async (rules, args = {}, propName) => {
       value = await rule(args)
       hasValue = has(value)
       const isRejected =
-        hasValue && args.validate && !(await isValidValue(value, args))
+        hasValue && args.validate && !(await isValidValue(value, validateArgs))
       if (isRejected) {
         value = undefined
         hasValue = false

--- a/packages/metascraper/src/index.d.ts
+++ b/packages/metascraper/src/index.d.ts
@@ -123,10 +123,14 @@ declare namespace createMetascraper {
   /**
    * Scrape-level check inside `findRule`. Falsy or throw rejects the candidate
    * and continues with the next rule.
+   *
+   * `options.propName` is the property being resolved, so a validate can scope
+   * itself: the same value is a hostile asset under `logo` and the expected
+   * result under `url`.
    */
   export type Validate = (
     value: string,
-    options: RulesTestOptions,
+    options: RulesTestOptions & { propName: string },
     debug: Debug
   ) => boolean | Promise<boolean>;
 

--- a/packages/metascraper/test/types/index.test-d.ts
+++ b/packages/metascraper/test/types/index.test-d.ts
@@ -47,3 +47,9 @@ await metascraper({
     return false
   }
 })
+
+await metascraper({
+  url: 'https://example.com',
+  html: '',
+  validate: (value, { propName, url }) => propName !== 'logo' || value !== url
+})

--- a/packages/metascraper/test/unit/validate.js
+++ b/packages/metascraper/test/unit/validate.js
@@ -106,6 +106,29 @@ test('validate rejecting every rule nulls the property', async t => {
   t.is(data.logo, null)
 })
 
+test('validate receives the property name it is judging', async t => {
+  const seen = []
+  const scraper = metascraper([
+    {
+      logo: [() => 'https://example.com/a.png'],
+      title: [() => 'hello']
+    }
+  ])
+
+  const data = await scraper({
+    url,
+    html,
+    validate: (value, { propName }) => {
+      seen.push(propName)
+      return propName !== 'logo'
+    }
+  })
+
+  t.deepEqual(seen.sort(), ['logo', 'title'])
+  t.is(data.logo, null)
+  t.is(data.title, 'hello')
+})
+
 test('validate receives the scraping args', async t => {
   let received
   const scraper = metascraper([


### PR DESCRIPTION
## Why

`findRule` already receives the property it is resolving and uses it only for a debug label. `validate` never sees it, so a consumer cannot scope itself by property — and the same bytes want opposite answers depending on which one it is: a script-bearing HTML document is a hostile `logo` candidate and the expected `url` result.

Without `propName`, callers reach for proxies, and both of the obvious ones are wrong:

- **Comparing the value to the page URL**, standing in for "this is the `url` property". Mismatches both ways: a `logo` that happens to equal the page URL goes ungated, and a `url` rule returning a canonicalised variant (trailing slash) gets rejected.
- **Exempting a content type**, standing in for "this might be a page". It then applies to every property and every caller, which turns a page-shaped allowance into a global hole.

We hit exactly this downstream: an executable-markup gate for `logo` could not be scoped, so a `text/html` exemption had to live in the byte-level predicate, where any origin serving that content type passes.

## What

`propName` rides on the options object:

```js
validate: (value, { propName, url }) => propName !== 'logo' || value !== url
```

The documented `(value, options, debug)` signature is unchanged, so existing validates keep working — this is additive.

The options object is built once per property inside `findRule`, not per candidate, and only when a validate is present, so a scrape without one allocates nothing new.

## Test plan

- [x] `validate receives the property name it is judging` — asserts both properties are seen and that rejecting only `logo` nulls it while `title` survives. Verified to fail without the change.
- [x] Existing validate suite unchanged: 8 passing.
- [x] `tsd` passes with a new case exercising `propName`.
- [x] `metascraper` unit 29 passing; `metascraper-helpers` 80 passing under `TZ=UTC`.

Note: `.date` fails on a non-UTC machine on master as well (`Jun 20` with no year) — pre-existing and unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and a small options copy only when validate is set; no change to default validation behavior.
> 
> **Overview**
> Scrape-level **`validate`** callbacks now receive **`propName`** on the options object (alongside existing fields like `url`), so consumers can accept or reject the same candidate value differently per metadata field—for example blocking a `text/html` URL for `logo` while allowing it for `url`.
> 
> In **`findRule`**, when a validate is configured, options are shallow-copied once per property with `propName` set before **`isValidValue`** runs; scrapes without validate avoid the extra object. Type definitions and **`tsd`** cover the new field; a unit test confirms each property is validated independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b488d443f09269b185f128989fe6444c9f50208f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata validation so candidates can be evaluated according to the property they populate.
  * Prevented unsuitable values from being accepted for specific fields while preserving valid results for others.
  * Added property-specific validation context to improve consistency when resolving multiple metadata fields.

* **Documentation**
  * Updated validation type information to clarify that validators receive the property name and page URL as context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->