### PR TITLE
ci: automate release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  SKIP_INSTALL_SIMPLE_GIT_HOOKS: true
+
 jobs:
   contributors:
     if: "${{ github.event.head_commit.message != 'build: contributors' }}"
@@ -21,7 +28,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
         with:
-          version: 11.11.0
+          version: latest
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Contributors
@@ -32,6 +39,7 @@ jobs:
       - name: Push changes
         run: |
           git push origin ${{ github.head_ref }}
+
   matrix:
     runs-on: ubuntu-latest
     steps:
@@ -42,6 +50,25 @@ jobs:
       - run: echo ${{ steps.matrix.outputs.matrix }}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+      - name: Install
+        run: pnpm install --dangerously-allow-all-builds
+      - name: Lint
+        run: pnpm lint
+
   test:
     name: Test ${{ matrix.package.name }}
     if: |
@@ -63,7 +90,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
         with:
-          version: 11.11.0
+          version: latest
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Test
@@ -87,3 +114,36 @@ jobs:
         uses: coverallsapp/github-action@main
         with:
           parallel-finished: true
+
+  release:
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+      - name: Install
+        run: pnpm install --dangerously-allow-all-builds
+      - name: Sync master
+        run: |
+          git config --global user.email ${{ secrets.GIT_EMAIL }}
+          git config --global user.name ${{ secrets.GIT_USERNAME }}
+          git pull origin master
+      - name: Release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pnpm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          pnpm run release

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v6
         with:
-          version: 11.11.0
+          version: latest
       - name: Install
         run: pnpm install --dangerously-allow-all-builds
       - name: Test


### PR DESCRIPTION
Mirrors the release pipeline from `microlinkhq/keyvhq`.

## What

- **`release` job** — gated on `test` + `lint`. Runs on every green master push: checks out `master` with full history, installs, syncs, then `pnpm run release` (lerna publish, conventional commits, GitHub release).
- **`lint` job** — runs `pnpm lint` at root. The matrix `test` job runs per-package, so root lint had no coverage.
- **`concurrency: release-${{ github.ref }}`** with `cancel-in-progress: false` — serializes runs so two pushes can't publish concurrently, and never kills a publish mid-flight.
- **`SKIP_INSTALL_SIMPLE_GIT_HOOKS: true`** — no point installing git hooks in CI.

Auth goes through `pnpm config set` rather than the committed `.npmrc`: pnpm now refuses to expand env vars in project-level registry credentials.

## Skip semantics

`test` already skips `chore(release):`, `docs:`, and `ci:` commits. Since `release` needs `test`, the release commit lerna itself pushes won't trigger a second release.

## Blocker

`NPM_TOKEN` is not set on this repo (keyvhq has it, metascraper doesn't). The release job will fail to publish until it's added:

```
gh secret set NPM_TOKEN -R microlinkhq/metascraper
```

`GH_TOKEN`, `GIT_EMAIL`, `GIT_USERNAME` are already present.

## Difference from keyvhq

keyvhq re-runs the full test suite inside the release job because its per-package matrix jobs each boot different services. metascraper has no such split, and its integration tests hit live network, so a re-run only adds flake. The `needs: [test, lint]` gate is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpJ853BGG6R6biZvpkZSpi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated npm/GitHub releases depend on `NPM_TOKEN` (not yet on this repo) and secret handling; behavior is otherwise limited to workflow config.
> 
> **Overview**
> Adds **automated publishing** on green `master` pushes: a new `release` job runs after `test` and `lint`, checks out `master` with full history, syncs git, configures npm auth via `pnpm config set`, then runs `pnpm run release` (Lerna conventional publish + GitHub release).
> 
> Introduces a dedicated **`lint` job** at the repo root (`pnpm lint`), since matrix tests only cover per-package runs. **`concurrency`** (`release-${{ github.ref }}`, no cancel-in-progress) serializes workflow runs so concurrent publishes cannot overlap. **`SKIP_INSTALL_SIMPLE_GIT_HOOKS: true`** skips hook install in CI.
> 
> **pnpm** is bumped from pinned `11.11.0` to `latest` in `main.yml` and `pull_request.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7accd33669198e59bdbfb500fc30885beef3bf05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release workflow coordination and publishing.
  * Added automated lint checks to the release pipeline.
  * Updated CI workflows to use the latest PNPM version.
  * Improved release concurrency and dependency installation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->