### PR TITLE
fix(helpers): keep CGI + in query strings

### DIFF
--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -223,17 +223,18 @@ const restoreCgiPlus = (original, normalized) => {
   return `${normalized.slice(0, normMark + 1)}${restored.join('&')}${hash}`
 }
 
-const sanetizeUrl = (url, opts) =>
-  restoreCgiPlus(
-    url,
-    _normalizeUrl(url, {
-      stripWWW: false,
-      sortQueryParameters: false,
-      removeSingleSlash: false,
-      removeTrailingSlash: false,
-      ...opts
-    })
-  )
+const sanetizeUrl = (url, opts) => {
+  const normalized = _normalizeUrl(url, {
+    stripWWW: false,
+    sortQueryParameters: false,
+    removeSingleSlash: false,
+    removeTrailingSlash: false,
+    ...opts
+  })
+  const queryStart = url.indexOf('?')
+  if (queryStart === -1 || url.indexOf('+', queryStart) === -1) { return normalized }
+  return restoreCgiPlus(url, normalized)
+}
 
 const normalizeUrl = (baseUrl, relativePath, opts) => {
   try {

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -232,8 +232,9 @@ const sanetizeUrl = (url, opts) => {
     ...opts
   })
   const queryStart = url.indexOf('?')
-  if (queryStart === -1 || url.indexOf('+', queryStart) === -1) { return normalized }
-  return restoreCgiPlus(url, normalized)
+  return queryStart === -1 || url.indexOf('+', queryStart) === -1
+    ? normalized
+    : restoreCgiPlus(url, normalized)
 }
 
 const normalizeUrl = (baseUrl, relativePath, opts) => {

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -232,9 +232,9 @@ const sanetizeUrl = (url, opts) => {
     ...opts
   })
   const queryStart = url.indexOf('?')
-  return queryStart === -1 || url.indexOf('+', queryStart) === -1
-    ? normalized
-    : restoreCgiPlus(url, normalized)
+  return queryStart !== -1 && url.indexOf('+', queryStart) !== -1
+    ? restoreCgiPlus(url, normalized)
+    : normalized
 }
 
 const normalizeUrl = (baseUrl, relativePath, opts) => {

--- a/packages/metascraper-helpers/src/index.js
+++ b/packages/metascraper-helpers/src/index.js
@@ -176,14 +176,64 @@ const protocol = url => {
   return ''
 }
 
-const sanetizeUrl = (url, opts) =>
-  _normalizeUrl(url, {
-    stripWWW: false,
-    sortQueryParameters: false,
-    removeSingleSlash: false,
-    removeTrailingSlash: false,
-    ...opts
+/**
+ * `normalize-url` treats `+` as a space in query keys that have no `=`
+ * (CGI-style `?241+ful+HB1288+pdf`) and emits `%20`. Restore those pluses —
+ * they are delimiters, not encoded spaces.
+ *
+ * @param {string} original
+ * @param {string} normalized
+ * @returns {string}
+ */
+const restoreCgiPlus = (original, normalized) => {
+  const origMark = original.indexOf('?')
+  const normMark = normalized.indexOf('?')
+  if (origMark === -1 || normMark === -1) return normalized
+
+  const origHash = original.indexOf('#', origMark)
+  const origSearch = original.slice(
+    origMark + 1,
+    origHash === -1 ? undefined : origHash
+  )
+  if (!origSearch.includes('+')) return normalized
+
+  const origByEncoded = new Map()
+  for (const orig of origSearch.split('&')) {
+    if (!orig.includes('=') && orig.includes('+')) {
+      origByEncoded.set(orig.replaceAll('+', '%20'), orig)
+    }
+  }
+  if (origByEncoded.size === 0) return normalized
+
+  const normHash = normalized.indexOf('#', normMark)
+  const normSearch = normalized.slice(
+    normMark + 1,
+    normHash === -1 ? undefined : normHash
+  )
+  let changed = false
+  const restored = normSearch.split('&').map(norm => {
+    const orig = origByEncoded.get(norm)
+    if (!orig) return norm
+    changed = true
+    return orig
   })
+  if (!changed) return normalized
+
+  const hash = normHash === -1 ? '' : normalized.slice(normHash)
+  return `${normalized.slice(0, normMark + 1)}${restored.join('&')}${hash}`
+}
+
+const sanetizeUrl = (url, opts) =>
+  restoreCgiPlus(
+    url,
+    _normalizeUrl(url, {
+      stripWWW: false,
+      sortQueryParameters: false,
+      removeSingleSlash: false,
+      removeTrailingSlash: false,
+      ...opts
+    })
+  )
 
 const normalizeUrl = (baseUrl, relativePath, opts) => {
   try {

--- a/packages/metascraper-helpers/test/index.js
+++ b/packages/metascraper-helpers/test/index.js
@@ -149,6 +149,27 @@ test('.normalizeUrl', t => {
     undefined
   )
   t.is(normalizeUrl('https://www.example.com', 'javascript:void(0)'), undefined)
+  t.is(
+    normalizeUrl(
+      'https://legacylis.virginia.gov/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
+    ),
+    'https://legacylis.virginia.gov/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
+  )
+  t.is(
+    normalizeUrl(
+      'https://legacylis.virginia.gov/',
+      '/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
+    ),
+    'https://legacylis.virginia.gov/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
+  )
+  t.is(
+    normalizeUrl('https://example.com/?q=hello+world'),
+    'https://example.com/?q=hello+world'
+  )
+  t.is(
+    normalizeUrl('https://example.com/?q=hello%20world'),
+    'https://example.com/?q=hello%20world'
+  )
 })
 
 test('.author', t => {
@@ -214,6 +235,18 @@ test('.url', t => {
       }
     ),
     'http://cdn2.cloudpro.co.uk/sites/cloudprod7/files/4/29/handshake_0.jpg'
+  )
+  t.is(
+    url(
+      'https://legacylis.virginia.gov/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
+    ),
+    'https://legacylis.virginia.gov/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
+  )
+  t.is(
+    url('/cgi-bin/legp604.exe?241+ful+HB1288+pdf', {
+      url: 'https://legacylis.virginia.gov/'
+    }),
+    'https://legacylis.virginia.gov/cgi-bin/legp604.exe?241+ful+HB1288+pdf'
   )
 })
 


### PR DESCRIPTION
## Summary
- `normalize-url` treats `+` as a space in query keys with no `=` and emits `%20`. That breaks CGI-style URLs such as `?241+ful+HB1288+pdf` (Virginia LIS and similar).
- Restore those pluses after sanitizing. `key=value` queries (`?q=hello+world`) are unchanged.

## Test plan
- [x] `pnpm test` in `packages/metascraper-helpers`
- [ ] Confirm `url()` / `normalizeUrl()` keep `+` on a CGI query and still pass `?q=hello+world` / `%20` cases


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL normalization to preserve literal plus signs in query-string parameters.
  * Improved handling of CGI-style query keys, including PDF links and root-relative URLs.
  * Preserved URL fragments, percent-encoded spaces, and other query-string values during normalization.

* **Tests**
  * Added coverage for absolute, root-relative, and query-string URLs containing plus signs.
  * Added regression checks for encoded spaces and fragment preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->